### PR TITLE
1.0.0 fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                         dir("${env.GO_REPO}") {
                             sh "rsync -aK ${env.WORKSPACE}/../../aerospike-kubernetes-operator-resources/secrets/ deploy/secrets"
                             // Changing directory again otherwise operator generates binary with the symlink name.
-                            sh "cd ${GO_REPO} && operator-sdk build --image-build-args "--build-arg OPERATOR_VERSION=${OPERATOR_VERSION}" ${OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME}"
+                            sh "cd ${GO_REPO} && operator-sdk build --image-build-args \"--build-arg OPERATOR_VERSION=${OPERATOR_VERSION}\" ${OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME}"
                             sh "docker push ${OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME}"
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ pipeline {
         GO_REPO="${env.GO_REPO_ROOT}/aerospike-kubernetes-operator"
         DOCKER_REGISTRY=""
         OPERATOR_NAME = "aerospike-kubernetes-operator"
-        OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME = "${env.DOCKER_REGISTRY}aerospike/${env.OPERATOR_NAME}:candidate-${env.BRANCH_NAME}"
+        OPERATOR_VERSION = "candidate-${env.BRANCH_NAME}"
+        OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME = "${env.DOCKER_REGISTRY}aerospike/${env.OPERATOR_NAME}:${env.OPERATOR_VERSION}"
     }
 
     stages {
@@ -39,7 +40,7 @@ pipeline {
                         dir("${env.GO_REPO}") {
                             sh "rsync -aK ${env.WORKSPACE}/../../aerospike-kubernetes-operator-resources/secrets/ deploy/secrets"
                             // Changing directory again otherwise operator generates binary with the symlink name.
-                            sh "cd ${GO_REPO} && operator-sdk build ${OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME}"
+                            sh "cd ${GO_REPO} && operator-sdk build --image-build-args "--build-arg OPERATOR_VERSION=${OPERATOR_VERSION}" ${OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME}"
                             sh "docker push ${OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME}"
                         }
                     }

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,6 +4,10 @@ ENV OPERATOR=/usr/local/bin/aerospike-kubernetes-operator \
     USER_UID=1001 \
     USER_NAME=aerospike-kubernetes-operator
 
+ARG OPERATOR_VERSION
+RUN if [ -z "$OPERATOR_VERSION" ]; then echo "OPERATOR_VERSION NOT SET - ERROR"; exit 1; else : ; fi
+ENV OPERATOR_VERSION=$OPERATOR_VERSION
+
 # install operator binary
 COPY build/_output/bin/aerospike-kubernetes-operator ${OPERATOR}
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: aerospike-kubernetes-operator
       containers:
         - name: aerospike-kubernetes-operator
-          image: aerospike/aerospike-kubernetes-operator:1.0.0
+          image: aerospike/aerospike-kubernetes-operator:v0.0.14-beta
           command:
           - aerospike-kubernetes-operator
           imagePullPolicy: Always

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,26 +29,39 @@ spec:
     metadata:
       labels:
         name: aerospike-kubernetes-operator
+
     spec:
       serviceAccountName: aerospike-kubernetes-operator
       containers:
         - name: aerospike-kubernetes-operator
           image: aerospike/aerospike-kubernetes-operator:v0.0.14-beta
           command:
-          - aerospike-kubernetes-operator
+            - aerospike-kubernetes-operator
           imagePullPolicy: Always
+
           ports:
-          - containerPort: 8443
+            - containerPort: 8443
+
           env:
-          - name: WATCH_NAMESPACE
-            value: aerospike
-            # Use below value for watching multiple namespaces by operator
-            # value: aerospike,aerospike1,aerospike2
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: OPERATOR_NAME
-            value: "aerospike-kubernetes-operator"
-          - name: LOG_LEVEL
-            value: debug
+            - name: WATCH_NAMESPACE
+              value: aerospike
+              # Use below value for watching multiple namespaces by operator
+              # value: aerospike,aerospike1,aerospike2
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "aerospike-kubernetes-operator"
+            - name: LOG_LEVEL
+              value: debug
+
+          readinessProbe:
+            exec:
+              command:
+              - stat
+              - "/tmp/cert"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,7 @@ kind: Deployment
 metadata:
   name: aerospike-kubernetes-operator
   namespace: aerospike
+
 spec:
   replicas: 1
   selector:

--- a/pkg/controller/admission/mutate_cluster.go
+++ b/pkg/controller/admission/mutate_cluster.go
@@ -136,9 +136,7 @@ func (s *ClusterMutatingAdmissionWebhook) setDefaults() error {
 // setDefaultRackConf create the default rack if the spec has no racks configured.
 func (s *ClusterMutatingAdmissionWebhook) setDefaultRackConf() error {
 	if len(s.obj.Spec.RackConfig.Racks) == 0 {
-		s.obj.Spec.RackConfig = aerospikev1alpha1.RackConfig{
-			Racks: []aerospikev1alpha1.Rack{{ID: utils.DefaultRackID}},
-		}
+		s.obj.Spec.RackConfig.Racks = append(s.obj.Spec.RackConfig.Racks, aerospikev1alpha1.Rack{ID: utils.DefaultRackID})
 		s.logger.Info("No rack given. Added default rack-id for all nodes", log.Ctx{"racks": s.obj.Spec.RackConfig, "DefaultRackID": utils.DefaultRackID})
 	} else {
 		for _, rack := range s.obj.Spec.RackConfig.Racks {

--- a/pkg/controller/aerospikecluster/aero_helper.go
+++ b/pkg/controller/aerospikecluster/aero_helper.go
@@ -55,7 +55,7 @@ func (r *ReconcileAerospikeCluster) getAerospikeServerVersionFromPod(aeroCluster
 	return version, nil
 }
 
-func (r *ReconcileAerospikeCluster) waitForClusterToBeReady(aeroCluster *aerospikev1alpha1.AerospikeCluster) error {
+func (r *ReconcileAerospikeCluster) waitForClusterStaefulSetsToBeReady(aeroCluster *aerospikev1alpha1.AerospikeCluster) error {
 	// User aeroCluster.Status to get all existing sts.
 	// Can status be empty here
 	logger := pkglog.New(log.Ctx{"AerospikeCluster": utils.ClusterNamespacedName(aeroCluster)})
@@ -78,20 +78,21 @@ func (r *ReconcileAerospikeCluster) waitForClusterToBeReady(aeroCluster *aerospi
 	return nil
 }
 
-func (r *ReconcileAerospikeCluster) waitForNodeSafeStopReady(aeroCluster *aerospikev1alpha1.AerospikeCluster, pod *v1.Pod) reconcileResult {
+// waitForNodeSafeStopReady waits util the input pod is safe to stop, skipping pods that are not running and present in ignorablePods for stability check. The ignorablePods list should be a list of failed or pending pods that are going to be deleted eventually and are safe to ignore in stability checks.
+func (r *ReconcileAerospikeCluster) waitForNodeSafeStopReady(aeroCluster *aerospikev1alpha1.AerospikeCluster, pod *v1.Pod, ignorablePods []v1.Pod) reconcileResult {
 	// TODO: Check post quiesce recluster conditions first.
 	// If they pass the node is safe to remove and cluster is stable ignoring migration this node is safe to shut down.
 
 	logger := pkglog.New(log.Ctx{"AerospikeCluster": utils.ClusterNamespacedName(aeroCluster)})
 
 	// Remove a node only if cluster is stable
-	err := r.waitForClusterToBeReady(aeroCluster)
+	err := r.waitForClusterStaefulSetsToBeReady(aeroCluster)
 	if err != nil {
 		return reconcileError(fmt.Errorf("Failed to wait for cluster to be ready: %v", err))
 	}
 
 	// This doesn't make actual connection, only objects having connection info are created
-	allHostConns, err := r.newAllHostConn(aeroCluster)
+	allHostConns, err := r.newAllHostConnWithOption(aeroCluster, ignorablePods)
 	if err != nil {
 		return reconcileError(fmt.Errorf("Failed to get hostConn for aerospike cluster nodes: %v", err))
 	}
@@ -153,21 +154,6 @@ func (r *ReconcileAerospikeCluster) alumniReset(aeroCluster *aerospikev1alpha1.A
 		return err
 	}
 	return deployment.AlumniReset(r.getClientPolicy(aeroCluster), asConn)
-}
-
-func getRackIDFromPodName(podName string) (*int, error) {
-	parts := strings.Split(podName, "-")
-	if len(parts) < 3 {
-		return nil, fmt.Errorf("Failed to get rackID from podName %s", podName)
-	}
-	// Podname format stsname-ordinal
-	// stsname ==> clustername-rackid
-	rackStr := parts[len(parts)-2]
-	rackID, err := strconv.Atoi(rackStr)
-	if err != nil {
-		return nil, err
-	}
-	return &rackID, nil
 }
 
 // getIPs returns the pod IP, host internal IP and the host external IP unless there is an error.
@@ -234,10 +220,18 @@ func (r *ReconcileAerospikeCluster) getServicePortForPod(aeroCluster *aerospikev
 }
 
 func (r *ReconcileAerospikeCluster) newAllHostConn(aeroCluster *aerospikev1alpha1.AerospikeCluster) ([]*deployment.HostConn, error) {
+	return r.newAllHostConnWithOption(aeroCluster, nil)
+}
+
+// newAllHostConnWithOption returns connections to all pods in the cluster skipping pods that are not running and present in ignorablePods.
+func (r *ReconcileAerospikeCluster) newAllHostConnWithOption(aeroCluster *aerospikev1alpha1.AerospikeCluster, ignorablePods []v1.Pod) ([]*deployment.HostConn, error) {
+	logger := pkglog.New(log.Ctx{"AerospikeCluster": utils.ClusterNamespacedName(aeroCluster)})
+
 	podList, err := r.getClusterPodList(aeroCluster)
 	if err != nil {
 		return nil, err
 	}
+
 	if len(podList.Items) == 0 {
 		return nil, fmt.Errorf("Pod list empty")
 	}
@@ -247,10 +241,18 @@ func (r *ReconcileAerospikeCluster) newAllHostConn(aeroCluster *aerospikev1alpha
 		if utils.IsTerminating(&pod) {
 			continue
 		}
+
 		// Checking if all the container in the pod are ready or not
-		if !utils.IsPodReady(&pod) {
+		if !utils.IsPodRunningAndReady(&pod) {
+			ignorablePod := utils.GetPod(pod.Name, ignorablePods)
+			if ignorablePod != nil {
+				// This pod is not running and ignorable.
+				logger.Info("Ignoring info call on non-running pod ", log.Ctx{"pod": pod.Name})
+				continue
+			}
 			return nil, fmt.Errorf("Pod: %v is not ready", pod.Name)
 		}
+
 		hostConn, err := r.newHostConn(aeroCluster, &pod)
 		if err != nil {
 			return nil, err

--- a/pkg/controller/aerospikecluster/aero_helper.go
+++ b/pkg/controller/aerospikecluster/aero_helper.go
@@ -132,12 +132,12 @@ func (r *ReconcileAerospikeCluster) waitForNodeSafeStopReady(aeroCluster *aerosp
 	return reconcileSuccess()
 }
 
-func (r *ReconcileAerospikeCluster) tipClearHostname(aeroCluster *aerospikev1alpha1.AerospikeCluster, pod *v1.Pod, clearPod *v1.Pod) error {
+func (r *ReconcileAerospikeCluster) tipClearHostname(aeroCluster *aerospikev1alpha1.AerospikeCluster, pod *v1.Pod, clearPodName string) error {
 	asConn, err := r.newAsConn(aeroCluster, pod)
 	if err != nil {
 		return err
 	}
-	return deployment.TipClearHostname(r.getClientPolicy(aeroCluster), asConn, getFQDNForPod(aeroCluster, clearPod.Name), utils.HeartbeatPort)
+	return deployment.TipClearHostname(r.getClientPolicy(aeroCluster), asConn, getFQDNForPod(aeroCluster, clearPodName), utils.HeartbeatPort)
 }
 
 func (r *ReconcileAerospikeCluster) tipHostname(aeroCluster *aerospikev1alpha1.AerospikeCluster, pod *v1.Pod, clearPod *v1.Pod) error {

--- a/pkg/controller/aerospikecluster/controller_helper.go
+++ b/pkg/controller/aerospikecluster/controller_helper.go
@@ -12,12 +12,6 @@ import (
 	"strings"
 	"time"
 
-	as "github.com/ashishshinde/aerospike-client-go"
-
-	aerospikev1alpha1 "github.com/aerospike/aerospike-kubernetes-operator/pkg/apis/aerospike/v1alpha1"
-	accessControl "github.com/aerospike/aerospike-kubernetes-operator/pkg/controller/asconfig"
-	"github.com/aerospike/aerospike-kubernetes-operator/pkg/controller/configmap"
-	"github.com/aerospike/aerospike-kubernetes-operator/pkg/controller/utils"
 	log "github.com/inconshreveable/log15"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	aerospikev1alpha1 "github.com/aerospike/aerospike-kubernetes-operator/pkg/apis/aerospike/v1alpha1"
+	accessControl "github.com/aerospike/aerospike-kubernetes-operator/pkg/controller/asconfig"
+	"github.com/aerospike/aerospike-kubernetes-operator/pkg/controller/configmap"
+	"github.com/aerospike/aerospike-kubernetes-operator/pkg/controller/utils"
+	lib "github.com/aerospike/aerospike-management-lib"
+	as "github.com/ashishshinde/aerospike-client-go"
 )
 
 const (
@@ -620,6 +621,26 @@ func (r *ReconcileAerospikeCluster) getClusterStatefulSets(aeroCluster *aerospik
 	return statefulSetList, nil
 }
 
+func (r *ReconcileAerospikeCluster) getOldRackList(aeroCluster *aerospikev1alpha1.AerospikeCluster) ([]int, error) {
+	rackIDs := []int{}
+	// Create dummy rack structures for dangling racks that have stateful sets but were deleted later because rack before status was updated.
+	statefulSetList, err := r.getClusterStatefulSets(aeroCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sts := range statefulSetList.Items {
+		rackID, err := utils.GetRackIDFromStatefulSetName(sts.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		rackIDs = append(rackIDs, *rackID)
+	}
+
+	return rackIDs, nil
+}
+
 func (r *ReconcileAerospikeCluster) getClusterServerPool(aeroCluster *aerospikev1alpha1.AerospikeCluster) *x509.CertPool {
 	logger := pkglog.New(log.Ctx{"AerospikeCluster": utils.ClusterNamespacedName(aeroCluster)})
 
@@ -994,10 +1015,15 @@ func updateStatefulSetPodSpec(aeroCluster *aerospikev1alpha1.AerospikeCluster, s
 	// Add new sidecars.
 	for _, newSidecar := range aeroCluster.Spec.PodSpec.Sidecars {
 		found := false
+
+		// Create a copy because updating stateful sets sets defaults
+		// on the sidecar container object which mutates original aeroCluster object.
+		sideCarCopy := corev1.Container{}
+		lib.DeepCopy(&sideCarCopy, &newSidecar)
 		for i, container := range st.Spec.Template.Spec.Containers {
 			if newSidecar.Name == container.Name {
 				// Update the sidecar in case something has changed.
-				st.Spec.Template.Spec.Containers[i] = newSidecar
+				st.Spec.Template.Spec.Containers[i] = sideCarCopy
 				found = true
 				break
 			}
@@ -1005,7 +1031,7 @@ func updateStatefulSetPodSpec(aeroCluster *aerospikev1alpha1.AerospikeCluster, s
 
 		if !found {
 			// Add to stateful set containers.
-			st.Spec.Template.Spec.Containers = append(st.Spec.Template.Spec.Containers, newSidecar)
+			st.Spec.Template.Spec.Containers = append(st.Spec.Template.Spec.Containers, sideCarCopy)
 		}
 	}
 
@@ -1357,12 +1383,4 @@ func getNewRackStateList(aeroCluster *aerospikev1alpha1.AerospikeCluster) []Rack
 		})
 	}
 	return rackStateList
-}
-
-func getOldRackList(aeroCluster *aerospikev1alpha1.AerospikeCluster) []aerospikev1alpha1.Rack {
-	var rackList []aerospikev1alpha1.Rack
-	for _, rack := range aeroCluster.Status.RackConfig.Racks {
-		rackList = append(rackList, rack)
-	}
-	return rackList
 }

--- a/test/e2e/setup_operator_test.yaml
+++ b/test/e2e/setup_operator_test.yaml
@@ -26,7 +26,7 @@ metadata:
   name: aerospike-kubernetes-operator-test
   namespace: test
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       name: aerospike-kubernetes-operator-test
@@ -41,21 +41,31 @@ spec:
           # Replace this with the built image name
           image: aerospike/aerospike-kubernetes-operator:1.0.0
           command:
-          - aerospike-kubernetes-operator
+            - aerospike-kubernetes-operator
           imagePullPolicy: Always
           ports:
-          - containerPort: 8443
+            - containerPort: 8443
           env:
-          - name: WATCH_NAMESPACE
-            value: test,test1,test2
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: OPERATOR_NAME
-            value: "aerospike-kubernetes-operator-test"
-          - name: LOG_LEVEL
-            value: debug
+            - name: WATCH_NAMESPACE
+              value: test,test1,test2
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "aerospike-kubernetes-operator-test"
+            - name: LOG_LEVEL
+              value: debug
+          readinessProbe:
+            exec:
+              command:
+              - stat
+              - "/tmp/cert"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 1
+
 
 ---
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,17 @@
 package version
 
-var (
-	Version = "0.0.1"
+import (
+	"os"
 )
+
+var (
+	// Version is the current operator version.
+	Version string
+)
+
+func init() {
+	Version = os.Getenv("OPERATOR_VERSION")
+	if Version == "" {
+		Version = "N/A"
+	}
+}


### PR DESCRIPTION
 * Podspec triggered rolling restart without an update on the second run. Fixed.
 * Pending pods caused rack deletes to get stuck. Fixed by ignoring pending pods during scaledown, rack delete, rolling restart, and version upgrade.
 * Removed hardcoded version from versions. Passed to build using build args.
 * Dangling rack stateful sets that failed for some reason and then deleted by users even before being added to status, cleaned up now.
 * Operator deployment has a readiness probe to ensure operator webhook service redirects correctly to the operator leader instance.
 * Dangling pods where cleanup fails are retried and cleaned up.