### PR TITLE
Make it possible to set custom docker registry for init container

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -60,6 +60,8 @@ const (
 const (
 	AerospikeServerContainerName     string = "aerospike-server"
 	AerospikeServerInitContainerName string = "aerospike-init"
+	AerospikeServerInitContainerImageEnvVar string = "AEROSPIKE_KUBERNETES_INIT_IMAGE"
+	AerospikeServerInitContainerDefaultImage string = "aerospike/aerospike-kubernetes-init:0.0.12"
 )
 
 // ClusterNamespacedName return namespaced name


### PR DESCRIPTION
 - This is done through an env var AEROSPIKE_KUBERNETES_INIT_IMAGE
 - If this env var is not set the default image is used; the default image name is moved to utils.utils.go
 - The env var definition is also set at the same location in utils.go

Signed-off-by: Jean-Francois Weber-Marx <jf.webermarx@criteo.com>
Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>