### PR TITLE
Add the possibility for alternate rack ids

### DIFF
--- a/pkg/controller/aerospikecluster/controller_helper.go
+++ b/pkg/controller/aerospikecluster/controller_helper.go
@@ -85,6 +85,7 @@ func (r *ReconcileAerospikeCluster) createStatefulSet(aeroCluster *aerospikev1al
 		newEnvVar("MY_POD_NAMESPACE", "metadata.namespace"),
 		newEnvVar("MY_POD_IP", "status.podIP"),
 		newEnvVar("MY_HOST_IP", "status.hostIP"),
+		newEnvVar("MY_NODE_NAME", "spec.nodeName"),
 		newEnvVarStatic("MY_POD_TLS_NAME", getServiceTLSName(aeroCluster)),
 		newEnvVarStatic("MY_POD_CLUSTER_NAME", aeroCluster.Name),
 	}

--- a/pkg/controller/configmap/configdata.go
+++ b/pkg/controller/configmap/configdata.go
@@ -64,16 +64,14 @@ IFS='-' read -ra ADDR <<< "$(hostname)"
 POD_ORDINAL="${ADDR[-1]}"
 
 # Find rack-id
+export RACK_ID="${ADDR[-2]}"
 ALTERNATE_RACK_ID="$(curl -f --cacert $CA_CERT -H "Authorization: Bearer $TOKEN" "$KUBE_API_SERVER/api/v1/nodes/$NODE" | awk '/aerospike.com\/alternate-rack-id/ {gsub(/"|,/,"",$2); print ($2) + 0}')"
 if [ "$ALTERNATE_RACK_ID" == "0" ] || [ "$ALTERNATE_RACK_ID" == "" ]; then
-  RACK_ID="${ADDR[-2]}"
+  sed -i "s/rack-id.\+[0-9]$/rack-id    ${RACK_ID}/" ${CFG}
 else
-  RACK_ID="$ALTERNATE_RACK_ID"
+  sed -i "s/rack-id.\+[0-9]$/rack-id    ${ALTERNATE_RACK_ID}/" ${CFG}
 fi
-export RACK_ID
-sed -i "s/rack-id.\+[0-9]$/rack-id    ${RACK_ID}/" ${CFG}
 export NODE_ID="${RACK_ID}a${POD_ORDINAL}"
-
 sed -i "s/ENV_NODE_ID/${NODE_ID}/" ${CFG}
 
 # ------------------------------------------------------------------------------
@@ -501,15 +499,14 @@ POD_ORDINAL="${ADDR[-1]}"
 CFG=/etc/aerospike/aerospike.template.conf
 
 # Find rack-id
+RACK_ID="${ADDR[-2]}"
 ALTERNATE_RACK_ID="$(curl -f --cacert $CA_CERT -H "Authorization: Bearer $TOKEN" "$KUBE_API_SERVER/api/v1/nodes/$NODE" | awk '/aerospike.com\/alternate-rack-id/ {gsub(/"|,/,"",$2); print ($2) + 0}')"
 if [ "$ALTERNATE_RACK_ID" == "0" ] || [ "$ALTERNATE_RACK_ID" == "" ]; then
-  RACK_ID="${ADDR[-2]}"
+  sed -i "s/rack-id.\+[0-9]$/rack-id    ${RACK_ID}/" ${CFG}
 else
-  RACK_ID="$ALTERNATE_RACK_ID"
+  sed -i "s/rack-id.\+[0-9]$/rack-id    ${ALTERNATE_RACK_ID}/" ${CFG}
 fi
-sed -i "s/rack-id.\+[0-9]$/rack-id    ${RACK_ID}/" ${CFG}
 NODE_ID="${RACK_ID}a${POD_ORDINAL}"
-
 sed -i "s/ENV_NODE_ID/${NODE_ID}/" ${CFG}
 
 # Parse lines to insert peer-list


### PR DESCRIPTION
  When the label "aerospike.com/alternate-rack-id" is set at the node level, it used in the Aerospike configuration (/etc/aerospike/aerospike.conf) as rack-id.
The Aerospike node id is not updated with alternate rack id, we stick to the pattern {rack-id}a{pod-ordinal} already in use. 
To add the alternate rack id to the aerospike server configuration, a new env var containing the node name was added. By using the kubernetes api in the init scripts (running on the init container) the "aerospike.com/alternate-rack-id" label is retrieved. If such label does not exist (or is not an integer) the behaviour does not change.