### PR TITLE
Fix helm chart indent issue with resources in deployment.yaml

### DIFF
--- a/helm-charts/aerospike-kubernetes-operator/templates/deployment.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           {{- with .Values.resources }}
-          resources: {{- toYaml . | indent 12 }}
+          resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
changes indent to nindent so that YAML is properly formed when actually specifying resource requests and limits with the helm chart values.