### PR TITLE
Support list for tls-authenticate-client.

### DIFF
--- a/api/v1alpha1/aerospikecluster_mutating_webhook.go
+++ b/api/v1alpha1/aerospikecluster_mutating_webhook.go
@@ -444,9 +444,12 @@ func toInterfaceList(list []string) []interface{} {
 }
 
 func isValueUpdated(m1, m2 map[string]interface{}, key string) bool {
-	val1 := m1[key]
-	val2 := m2[key]
-	return val1 != val2
+	val1, ok1 := m1[key]
+	val2, ok2 := m2[key]
+	if ok1 != ok2 {
+		return true
+	}
+	return !reflect.DeepEqual(val1, val2)
 }
 
 func isNameExist(names []string, name string) bool {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.76.0 // indirect
 	github.com/Azure/go-autorest/autorest v0.11.17 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.11 // indirect
-	github.com/aerospike/aerospike-management-lib v0.0.0-20210414182131-82c9c425ad34
+	github.com/aerospike/aerospike-management-lib v0.0.0-20210624173435-e6a2307b9445
 	github.com/ashishshinde/aerospike-client-go v3.0.4-0.20200924015406-d85b25081637+incompatible
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/go-logr/logr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/aerospike/aerospike-management-lib v0.0.0-20210414182131-82c9c425ad34 h1:o6dZ/hlGaq0LFJcBR+vR+0JBagiKHezRhEIXJ3+7vqg=
 github.com/aerospike/aerospike-management-lib v0.0.0-20210414182131-82c9c425ad34/go.mod h1:dD3418ie4w+paWRSoLbFrBh9wWHwcRujeCS36jh1QHg=
+github.com/aerospike/aerospike-management-lib v0.0.0-20210624173435-e6a2307b9445 h1:hncjgSgP/qlXXmMTR5cGTpsot5SwN7CSs5j0nGf22Yo=
+github.com/aerospike/aerospike-management-lib v0.0.0-20210624173435-e6a2307b9445/go.mod h1:dD3418ie4w+paWRSoLbFrBh9wWHwcRujeCS36jh1QHg=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/pkg/configschema/4_0_0.go
+++ b/pkg/configschema/4_0_0.go
@@ -955,10 +955,14 @@ const conf4_0_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_1_0.go
+++ b/pkg/configschema/4_1_0.go
@@ -955,10 +955,14 @@ const conf4_1_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_2_0.go
+++ b/pkg/configschema/4_2_0.go
@@ -963,10 +963,14 @@ const conf4_2_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_3_0.go
+++ b/pkg/configschema/4_3_0.go
@@ -963,10 +963,14 @@ const conf4_3_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_3_1.go
+++ b/pkg/configschema/4_3_1.go
@@ -981,10 +981,14 @@ const conf4_3_1 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_4_0.go
+++ b/pkg/configschema/4_4_0.go
@@ -971,10 +971,14 @@ const conf4_4_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_5_0.go
+++ b/pkg/configschema/4_5_0.go
@@ -977,10 +977,14 @@ const conf4_5_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_5_1.go
+++ b/pkg/configschema/4_5_1.go
@@ -945,10 +945,14 @@ const conf4_5_1 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_5_2.go
+++ b/pkg/configschema/4_5_2.go
@@ -945,10 +945,14 @@ const conf4_5_2 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_5_3.go
+++ b/pkg/configschema/4_5_3.go
@@ -951,10 +951,14 @@ const conf4_5_3 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_6_0.go
+++ b/pkg/configschema/4_6_0.go
@@ -957,10 +957,14 @@ const conf4_6_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_7_0.go
+++ b/pkg/configschema/4_7_0.go
@@ -925,10 +925,14 @@ const conf4_7_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_8_0.go
+++ b/pkg/configschema/4_8_0.go
@@ -925,10 +925,14 @@ const conf4_8_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/4_9_0.go
+++ b/pkg/configschema/4_9_0.go
@@ -925,10 +925,14 @@ const conf4_9_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/5_0_0.go
+++ b/pkg/configschema/5_0_0.go
@@ -919,10 +919,14 @@ const conf5_0_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/5_1_0.go
+++ b/pkg/configschema/5_1_0.go
@@ -939,10 +939,14 @@ const conf5_1_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/5_2_0.go
+++ b/pkg/configschema/5_2_0.go
@@ -945,10 +945,14 @@ const conf5_2_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/5_3_0.go
+++ b/pkg/configschema/5_3_0.go
@@ -945,10 +945,14 @@ const conf5_3_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/5_4_0.go
+++ b/pkg/configschema/5_4_0.go
@@ -945,10 +945,14 @@ const conf5_4_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",

--- a/pkg/configschema/5_5_0.go
+++ b/pkg/configschema/5_5_0.go
@@ -959,10 +959,14 @@ const conf5_5_0 = `
               "dynamic": false
             },
             "tls-authenticate-client": {
-              "type": "string",
-              "default": "",
-              "description": "",
-              "dynamic": false
+		      "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "default": "",
+                "description": "",
+                "dynamic": false
+              }
             },
             "tls-name": {
               "type": "string",


### PR DESCRIPTION
This PR is continue of https://github.com/aerospike/aerospike-management-lib/pull/7
This will change all schemas to support lists for tls-authenticate-client.
Also added validation to prevent mixing "false" or "any" values with other values in a list.
Also added some extra validation on tls configuration preventing set tls params without providing a valid tls-name.