### PR TITLE
Fix rackConfig in cluster helm chart README.md

### DIFF
--- a/helm-charts/aerospike-cluster/README.md
+++ b/helm-charts/aerospike-cluster/README.md
@@ -232,21 +232,21 @@ resources:
           aerospikeConfig:
             service:
               proto-fd-max: 18000
-            storage:
-              filesystemVolumePolicy:
-                initMethod: deleteFiles
-                cascadeDelete: true
-              blockVolumePolicy:
-                cascadeDelete: true
-              volumes:
-                - storageClass: ssd
-                  path: /opt/aerospike
-                  volumeMode: filesystem
-                  sizeInGB: 1
-                - path: /opt/aerospike/data
-                  storageClass: ssd
-                  volumeMode: filesystem
-                  sizeInGB: 3
+          storage:
+            filesystemVolumePolicy:
+              initMethod: deleteFiles
+              cascadeDelete: true
+            blockVolumePolicy:
+              cascadeDelete: true
+            volumes:
+              - storageClass: ssd
+                path: /opt/aerospike
+                volumeMode: filesystem
+                sizeInGB: 1
+              - path: /opt/aerospike/data
+                storageClass: ssd
+                volumeMode: filesystem
+                sizeInGB: 3
         - id: 2
           zone: us-west1-b
           aerospikeConfig:


### PR DESCRIPTION
  Indentation for the storage stanza in the rack config example is fixed

Signed-off-by: Jean-Francois Weber-Marx <jf.webermarx@criteo.com>
Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>