### PR TITLE
Add releaseName in the RBAC definition

### DIFF
--- a/helm-charts/aerospike-cluster/templates/aerospike-cluster-rbac.yaml
+++ b/helm-charts/aerospike-cluster/templates/aerospike-cluster-rbac.yaml
@@ -21,7 +21,7 @@ imagePullSecrets:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-cluster
+  name: aerospike-cluster-{{ .Release.Name }}
   labels:
     app: {{ template "aerospike-cluster.commonName" . }}
     chart: {{ .Chart.Name }}
@@ -48,14 +48,14 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aerospike-cluster
+  name: aerospike-cluster-{{ .Release.Name }}
   labels:
     app: {{ template "aerospike-cluster.commonName" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
 roleRef:
   kind: ClusterRole
-  name: aerospike-cluster
+  name: aerospike-cluster-{{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Without it, it will create collision when deploying multiple Aerospike cluster
in the same kubernetes cluster.
The ClusterRole and ClusterRoleBinding don't belong to a namespace
and helm doesn't know to which cluster it belongs to