### PR TITLE
Use $MY_POD_NAME instead of hostname

### DIFF
--- a/controllers/scripts/common-env.sh
+++ b/controllers/scripts/common-env.sh
@@ -104,7 +104,7 @@ export MAPPED_TLSPORT="$POD_TLSPORT"
 {{- end}}
 
 # Parse out cluster name, formatted as: stsname-rackid-index
-IFS='-' read -ra ADDR <<< "$(hostname)"
+IFS='-' read -ra ADDR <<< "$MY_POD_NAME"
 
 POD_ORDINAL="${ADDR[-1]}"
 


### PR DESCRIPTION
The hostname is not guaranteed to be the pod name.
Since the operator already creates the pod with an env with
the pod name we can use that instead