### PR TITLE
Unhardcode port values.

### DIFF
--- a/api/v1alpha1/aerospikecluster_mutating_webhook.go
+++ b/api/v1alpha1/aerospikecluster_mutating_webhook.go
@@ -310,16 +310,24 @@ func setDefaultNetworkConf(aslog logr.Logger, configSpec *AerospikeConfigSpec, c
 	// TODO: These values lines will be replaces with runtime info by script in init-container
 	// See if we can get better way to make template
 	serviceDefaults := map[string]interface{}{}
-	serviceDefaults["port"] = ServicePort
-	serviceDefaults["access-port"] = ServicePort // must be greater that or equal to 1024
+	srvPort := GetServicePort(configSpec)
+	serviceDefaults["port"] = srvPort
+	// Here all access ports are explicitly set to hardcoded constant 65535. These values will
+	// be replaced by aerospike-init container with an appropriate port in accordance to
+	// MultiPodPerHost flag (NodePort of Service or Host Port of Pod).
+	// Alternatively, we can set all access ports to srvPort, but in this case if user changes srvPort in CR
+	// we will get a confusing error for the rack scope config. Rack scope config will have merged global network config
+	// (thus have all access ports set to service.port value) and got confusing error message that "non-default values
+	// can't be set". In order to avoid this confusing message we are going to use hardcoded constant 65535 as a placeholder.
+	serviceDefaults["access-port"] = 65535 // must be greater that or equal to 1024,
 	serviceDefaults["access-addresses"] = []string{"<access-address>"}
-	serviceDefaults["alternate-access-port"] = ServicePort // must be greater that or equal to 1024,
+	serviceDefaults["alternate-access-port"] = 65535 // must be greater that or equal to 1024,
 	serviceDefaults["alternate-access-addresses"] = []string{"<alternate-access-address>"}
-	if _, ok := serviceConf["tls-name"]; ok {
-		serviceDefaults["tls-port"] = ServiceTLSPort
-		serviceDefaults["tls-access-port"] = ServiceTLSPort
+	if tlsName, tlsPort := GetServiceTLSNameAndPort(configSpec); tlsName != "" {
+		serviceDefaults["tls-port"] = tlsPort
+		serviceDefaults["tls-access-port"] = 65535 // must be greater that or equal to 1024,
 		serviceDefaults["tls-access-addresses"] = []string{"<tls-access-address>"}
-		serviceDefaults["tls-alternate-access-port"] = ServiceTLSPort // must be greater that or equal to 1024,
+		serviceDefaults["tls-alternate-access-port"] = 65535 // must be greater that or equal to 1024,
 		serviceDefaults["tls-alternate-access-addresses"] = []string{"<tls-alternate-access-address>"}
 	}
 
@@ -340,9 +348,9 @@ func setDefaultNetworkConf(aslog logr.Logger, configSpec *AerospikeConfigSpec, c
 
 	hbDefaults := map[string]interface{}{}
 	hbDefaults["mode"] = "mesh"
-	hbDefaults["port"] = HeartbeatPort
+	hbDefaults["port"] = GetHeartbeatPort(configSpec)
 	if _, ok := heartbeatConf["tls-name"]; ok {
-		hbDefaults["tls-port"] = HeartbeatTLSPort
+		hbDefaults["tls-port"] = GetHeartbeatTLSPort(configSpec)
 	}
 
 	if err := setDefaultsInConfigMap(aslog, heartbeatConf, hbDefaults); err != nil {
@@ -361,9 +369,9 @@ func setDefaultNetworkConf(aslog logr.Logger, configSpec *AerospikeConfigSpec, c
 	}
 
 	fabricDefaults := map[string]interface{}{}
-	fabricDefaults["port"] = FabricPort
+	fabricDefaults["port"] = GetFabricPort(configSpec)
 	if _, ok := fabricConf["tls-name"]; ok {
-		fabricDefaults["tls-port"] = FabricTLSPort
+		fabricDefaults["tls-port"] = GetFabricTLSPort(configSpec)
 	}
 
 	if err := setDefaultsInConfigMap(aslog, fabricConf, fabricDefaults); err != nil {

--- a/api/v1alpha1/aerospikecluster_validating_webhook.go
+++ b/api/v1alpha1/aerospikecluster_validating_webhook.go
@@ -35,6 +35,7 @@ import (
 )
 
 var networkConnectionTypes = []string{"service", "heartbeat", "fabric"}
+var immutableNetworkParams = []string{"tls-name", "tls-authenticate-client", "port", "access-port", "alternate-access-port", "tls-port", "tls-access-port", "tls-alternate-access-port"}
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // +kubebuilder:webhook:path=/validate-asdb-aerospike-com-v1alpha1-aerospikecluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=asdb.aerospike.com,resources=aerospikeclusters,verbs=create;update,versions=v1alpha1,name=vaerospikecluster.kb.io,admissionReviewVersions={v1,v1beta1}
@@ -219,7 +220,7 @@ func validateClientCertSpec(clientCertSpec *AerospikeOperatorClientCertSpec, con
 	if !networkConfExist {
 		return nil
 	}
-	serviceConf, serviceConfExists := networkConf.(map[string]interface{})["service"]
+	serviceConf, serviceConfExists := networkConf.(map[string]interface{})[confKeyNetworkService]
 	if !serviceConfExists {
 		return nil
 	}
@@ -360,6 +361,18 @@ func (r *AerospikeCluster) validateRackConfig(aslog logr.Logger) error {
 		// Allow DefaultRackID
 		if rack.ID > MaxRackID {
 			return fmt.Errorf("invalid rackID. RackID range (%d, %d)", MinRackID, MaxRackID)
+		}
+
+		if rack.InputAerospikeConfig != nil {
+			if _, ok := rack.InputAerospikeConfig.Value["network"]; ok {
+				// Aerospike K8s Operator doesn't support different network configurations for different racks.
+				// I.e.
+				//    - the same heartbeat port (taken from current node) is used for all peers regardless to racks.
+				//    - a single target port is used in headless service and LB.
+				//    - we need to refactor how connection is created to AS to take into account rack's network config.
+				// So, just reject rack specific network connections for now.
+				return fmt.Errorf("you can't specify network configuration for rack %d (network should be the same for all racks)", rack.ID)
+			}
 		}
 
 		config := rack.AerospikeConfig
@@ -751,28 +764,27 @@ func validateAerospikeConfigUpdate(aslog logr.Logger, newConfSpec, oldConfSpec *
 		return fmt.Errorf("cannot update cluster network.tls config")
 	}
 
-	// network.service
-	if isValueUpdated(oldConf["network"].(map[string]interface{})["service"].(map[string]interface{}), newConf["network"].(map[string]interface{})["service"].(map[string]interface{}), "tls-name") {
-		return fmt.Errorf("cannot update tls-name for network.service")
-	}
-	if isValueUpdated(oldConf["network"].(map[string]interface{})["service"].(map[string]interface{}), newConf["network"].(map[string]interface{})["service"].(map[string]interface{}), "tls-authenticate-client") {
-		return fmt.Errorf("cannot update tls-authenticate-client for network.service")
-	}
-
-	// network.heartbeat
-	if isValueUpdated(oldConf["network"].(map[string]interface{})["heartbeat"].(map[string]interface{}), newConf["network"].(map[string]interface{})["heartbeat"].(map[string]interface{}), "tls-name") {
-		return fmt.Errorf("cannot update tls-name for network.heartbeat")
-	}
-
-	// network.fabric
-	if isValueUpdated(oldConf["network"].(map[string]interface{})["fabric"].(map[string]interface{}), newConf["network"].(map[string]interface{})["fabric"].(map[string]interface{}), "tls-name") {
-		return fmt.Errorf("cannot update tls-name for network.fabric")
+	for _, connectionType := range networkConnectionTypes {
+		if err := validateNetworkConnectionUpdate(newConf, oldConf, connectionType); err != nil {
+			return err
+		}
 	}
 
 	if err := validateNsConfUpdate(aslog, newConfSpec, oldConfSpec); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func validateNetworkConnectionUpdate(newConf, oldConf map[string]interface{}, connectionType string) error {
+	oldConnectionConfig := oldConf["network"].(map[string]interface{})[connectionType].(map[string]interface{})
+	newConnectionConfig := newConf["network"].(map[string]interface{})[connectionType].(map[string]interface{})
+	for _, param := range immutableNetworkParams {
+		if isValueUpdated(oldConnectionConfig, newConnectionConfig, param) {
+			return fmt.Errorf("cannot update %s for network.%s", param, connectionType)
+		}
+	}
 	return nil
 }
 

--- a/api/v1alpha1/utils.go
+++ b/api/v1alpha1/utils.go
@@ -77,9 +77,14 @@ const (
 	confKeyFilesize      = "filesize"
 	confKeyDevice        = "devices"
 	confKeyFile          = "files"
-	confKeyNetwork       = "network"
 	confKeyTLS           = "tls"
 	confKeySecurity      = "security"
+
+	// Network section keys.
+	confKeyNetwork          = "network"
+	confKeyNetworkService   = "service"
+	confKeyNetworkHeartbeat = "heartbeat"
+	confKeyNetworkFabric    = "fabric"
 
 	// XDR keys.
 	confKeyXdr         = "xdr"
@@ -269,4 +274,50 @@ func GetDigestLogFile(aerospikeConfigSpec AerospikeConfigSpec) (*string, error) 
 	}
 
 	return nil, fmt.Errorf("xdr not configured")
+}
+
+func GetServiceTLSNameAndPort(aeroConf *AerospikeConfigSpec) (string, int) {
+	if networkConfTmp, ok := aeroConf.Value[confKeyNetwork]; ok {
+		networkConf := networkConfTmp.(map[string]interface{})
+		serviceConf := networkConf[confKeyService].(map[string]interface{})
+		if tlsName, ok := serviceConf["tls-name"]; ok {
+			if tlsPort, portConfigured := serviceConf["tls-port"]; portConfigured {
+				return tlsName.(string), int(tlsPort.(float64))
+			} else {
+				return tlsName.(string), ServiceTLSPort
+			}
+		}
+	}
+	return "", 0
+}
+
+func GetServicePort(aeroConf *AerospikeConfigSpec) int {
+	return GetPortFromConfig(aeroConf, confKeyNetworkService, "port", ServicePort)
+}
+
+func GetHeartbeatPort(aeroConf *AerospikeConfigSpec) int {
+	return GetPortFromConfig(aeroConf, confKeyNetworkHeartbeat, "port", HeartbeatPort)
+}
+
+func GetHeartbeatTLSPort(aeroConf *AerospikeConfigSpec) int {
+	return GetPortFromConfig(aeroConf, confKeyNetworkHeartbeat, "tls-port", HeartbeatTLSPort)
+}
+
+func GetFabricPort(aeroConf *AerospikeConfigSpec) int {
+	return GetPortFromConfig(aeroConf, confKeyNetworkFabric, "port", FabricPort)
+}
+
+func GetFabricTLSPort(aeroConf *AerospikeConfigSpec) int {
+	return GetPortFromConfig(aeroConf, confKeyNetworkFabric, "tls-port", FabricTLSPort)
+}
+
+func GetPortFromConfig(aeroConf *AerospikeConfigSpec, connectionType string, paramName string, defaultValue int) int {
+	if networkConf, ok := aeroConf.Value[confKeyNetwork]; ok {
+		if connectionConfig, ok := networkConf.(map[string]interface{})[connectionType]; ok {
+			if port, ok := connectionConfig.(map[string]interface{})[paramName]; ok {
+				return int(port.(float64))
+			}
+		}
+	}
+	return defaultValue
 }

--- a/controllers/client_policy.go
+++ b/controllers/client_policy.go
@@ -56,7 +56,7 @@ func (r *AerospikeClusterReconciler) getClientPolicy(aeroCluster *asdbv1alpha1.A
 	policy.ClusterName = aeroCluster.Name
 
 	// tls config
-	if tlsName := getServiceTLSName(aeroCluster); tlsName != "" {
+	if tlsName, _ := asdbv1alpha1.GetServiceTLSNameAndPort(aeroCluster.Spec.AerospikeConfig); tlsName != "" {
 		r.Log.V(1).Info("Set tls config in aerospike client policy")
 		clientCertSpec := aeroCluster.Spec.OperatorClientCertSpec
 		tlsConf := tls.Config{

--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -150,12 +150,13 @@ func (r *AerospikeClusterReconciler) getBaseConfData(aeroCluster *asdbv1alpha1.A
 	workDir := asdbv1alpha1.GetWorkDirectory(rack.AerospikeConfig)
 
 	// Include initialization and restart scripts
+	_, tlsPort := asdbv1alpha1.GetServiceTLSNameAndPort(aeroCluster.Spec.AerospikeConfig)
 	initializeTemplateInput := initializeTemplateInput{
 		WorkDir:         workDir,
 		MultiPodPerHost: aeroCluster.Spec.MultiPodPerHost,
 		NetworkPolicy:   aeroCluster.Spec.AerospikeNetworkPolicy,
-		PodPort:         asdbv1alpha1.ServicePort,
-		PodTLSPort:      asdbv1alpha1.ServiceTLSPort,
+		PodPort:         int32(asdbv1alpha1.GetServicePort(aeroCluster.Spec.AerospikeConfig)),
+		PodTLSPort:      int32(tlsPort),
 		HostNetwork:     aeroCluster.Spec.PodSpec.HostNetwork,
 	}
 

--- a/controllers/statefulset.go
+++ b/controllers/statefulset.go
@@ -38,6 +38,54 @@ const (
 	initConfDirName = "initconfigs"
 )
 
+type PortInfo struct {
+	connectionType string
+	configParam    string
+	defaultPort    int
+	exposedOnHost  bool
+}
+
+var defaultContainerPorts = map[string]PortInfo{
+	asdbv1alpha1.ServicePortName: {
+		connectionType: "service",
+		configParam:    "port",
+		defaultPort:    asdbv1alpha1.ServicePort,
+		exposedOnHost:  true,
+	},
+	asdbv1alpha1.ServiceTLSPortName: {
+		connectionType: "service",
+		configParam:    "tls-port",
+		defaultPort:    asdbv1alpha1.ServiceTLSPort,
+		exposedOnHost:  true,
+	},
+	asdbv1alpha1.FabricPortName: {
+		connectionType: "fabric",
+		configParam:    "port",
+		defaultPort:    asdbv1alpha1.FabricPort,
+	},
+	asdbv1alpha1.FabricTLSPortName: {
+		connectionType: "fabric",
+		configParam:    "tls-port",
+		defaultPort:    asdbv1alpha1.FabricTLSPort,
+	},
+	asdbv1alpha1.HeartbeatPortName: {
+		connectionType: "heartbeat",
+		configParam:    "port",
+		defaultPort:    asdbv1alpha1.HeartbeatPort,
+	},
+	asdbv1alpha1.HeartbeatTLSPortName: {
+		connectionType: "heartbeat",
+		configParam:    "tls-port",
+		defaultPort:    asdbv1alpha1.HeartbeatTLSPort,
+	},
+	asdbv1alpha1.InfoPortName: {
+		connectionType: "info",
+		configParam:    "port",
+		defaultPort:    asdbv1alpha1.InfoPort,
+		exposedOnHost:  true,
+	},
+}
+
 func (r *AerospikeClusterReconciler) createSTS(aeroCluster *asdbv1alpha1.AerospikeCluster, namespacedName types.NamespacedName, rackState RackState) (*appsv1.StatefulSet, error) {
 	replicas := int32(rackState.Size)
 
@@ -54,20 +102,21 @@ func (r *AerospikeClusterReconciler) createSTS(aeroCluster *asdbv1alpha1.Aerospi
 		}
 	}
 
-	ports := getSTSContainerPort(aeroCluster.Spec.MultiPodPerHost)
+	ports := getSTSContainerPort(aeroCluster.Spec.MultiPodPerHost, aeroCluster.Spec.AerospikeConfig)
 
 	ls := utils.LabelsForAerospikeClusterRack(aeroCluster.Name, rackState.Rack.ID)
 
+	tlsName, _ := asdbv1alpha1.GetServiceTLSNameAndPort(aeroCluster.Spec.AerospikeConfig)
 	envVarList := []corev1.EnvVar{
 		newSTSEnvVar("MY_POD_NAME", "metadata.name"),
 		newSTSEnvVar("MY_POD_NAMESPACE", "metadata.namespace"),
 		newSTSEnvVar("MY_POD_IP", "status.podIP"),
 		newSTSEnvVar("MY_HOST_IP", "status.hostIP"),
-		newSTSEnvVarStatic("MY_POD_TLS_NAME", getServiceTLSName(aeroCluster)),
+		newSTSEnvVarStatic("MY_POD_TLS_NAME", tlsName),
 		newSTSEnvVarStatic("MY_POD_CLUSTER_NAME", aeroCluster.Name),
 	}
 
-	if name := getServiceTLSName(aeroCluster); name != "" {
+	if tlsName != "" {
 		envVarList = append(envVarList, newSTSEnvVarStatic("MY_POD_TLS_ENABLED", "true"))
 	}
 
@@ -396,7 +445,7 @@ func (r *AerospikeClusterReconciler) createSTSHeadlessSvc(aeroCluster *asdbv1alp
 					Selector:                 ls,
 					Ports: []corev1.ServicePort{
 						{
-							Port: 3000,
+							Port: int32(asdbv1alpha1.GetServicePort(aeroCluster.Spec.AerospikeConfig)),
 							Name: "info",
 						},
 					},
@@ -438,16 +487,16 @@ func (r *AerospikeClusterReconciler) createPodService(aeroCluster *asdbv1alpha1.
 			Ports: []corev1.ServicePort{
 				{
 					Name: "info",
-					Port: asdbv1alpha1.ServicePort,
+					Port: int32(asdbv1alpha1.GetServicePort(aeroCluster.Spec.AerospikeConfig)),
 				},
 			},
 			ExternalTrafficPolicy: "Local",
 		},
 	}
-	if name := getServiceTLSName(aeroCluster); name != "" {
+	if tlsName, tlsPort := asdbv1alpha1.GetServiceTLSNameAndPort(aeroCluster.Spec.AerospikeConfig); tlsName != "" {
 		service.Spec.Ports = append(service.Spec.Ports, corev1.ServicePort{
 			Name: "tls",
-			Port: asdbv1alpha1.ServiceTLSPort,
+			Port: int32(tlsPort),
 		})
 	}
 	// Set AerospikeCluster instance as the owner and controller.
@@ -852,79 +901,22 @@ func (r *AerospikeClusterReconciler) updateSTSContainerResources(aeroCluster *as
 	st.Spec.Template.Spec.Containers[0].Resources = *aeroCluster.Spec.Resources
 }
 
-func getSTSContainerPort(multiPodPerHost bool) []corev1.ContainerPort {
+func getSTSContainerPort(multiPodPerHost bool, aeroConf *asdbv1alpha1.AerospikeConfigSpec) []corev1.ContainerPort {
 	var ports []corev1.ContainerPort
-	if multiPodPerHost {
-		// Create ports without hostPort setting
-		ports = []corev1.ContainerPort{
-			{
-				Name:          asdbv1alpha1.ServicePortName,
-				ContainerPort: asdbv1alpha1.ServicePort,
-			},
-			{
-				Name:          asdbv1alpha1.ServiceTLSPortName,
-				ContainerPort: asdbv1alpha1.ServiceTLSPort,
-			},
-			{
-				Name:          asdbv1alpha1.HeartbeatPortName,
-				ContainerPort: asdbv1alpha1.HeartbeatPort,
-			},
-			{
-				Name:          asdbv1alpha1.HeartbeatTLSPortName,
-				ContainerPort: asdbv1alpha1.HeartbeatTLSPort,
-			},
-			{
-				Name:          asdbv1alpha1.FabricPortName,
-				ContainerPort: asdbv1alpha1.FabricPort,
-			},
-			{
-				Name:          asdbv1alpha1.FabricTLSPortName,
-				ContainerPort: asdbv1alpha1.FabricTLSPort,
-			},
-			{
-				Name:          asdbv1alpha1.InfoPortName,
-				ContainerPort: asdbv1alpha1.InfoPort,
-			},
+	for portName, portInfo := range defaultContainerPorts {
+		containerPort := corev1.ContainerPort{
+			Name:          portName,
+			ContainerPort: int32(asdbv1alpha1.GetPortFromConfig(aeroConf, portInfo.connectionType, portInfo.configParam, portInfo.defaultPort)),
 		}
-	} else {
 		// Single pod per host. Enable hostPort setting
 		// The hostPort setting applies to the Kubernetes containers.
 		// The container port will be exposed to the external network at <hostIP>:<hostPort>,
 		// where the hostIP is the IP address of the Kubernetes node where
 		// the container is running and the hostPort is the port requested by the user
-		ports = []corev1.ContainerPort{
-			{
-				Name:          asdbv1alpha1.ServicePortName,
-				ContainerPort: asdbv1alpha1.ServicePort,
-				HostPort:      asdbv1alpha1.ServicePort,
-			},
-			{
-				Name:          asdbv1alpha1.ServiceTLSPortName,
-				ContainerPort: asdbv1alpha1.ServiceTLSPort,
-				HostPort:      asdbv1alpha1.ServiceTLSPort,
-			},
-			{
-				Name:          asdbv1alpha1.HeartbeatPortName,
-				ContainerPort: asdbv1alpha1.HeartbeatPort,
-			},
-			{
-				Name:          asdbv1alpha1.HeartbeatTLSPortName,
-				ContainerPort: asdbv1alpha1.HeartbeatTLSPort,
-			},
-			{
-				Name:          asdbv1alpha1.FabricPortName,
-				ContainerPort: asdbv1alpha1.FabricPort,
-			},
-			{
-				Name:          asdbv1alpha1.FabricTLSPortName,
-				ContainerPort: asdbv1alpha1.FabricTLSPort,
-			},
-			{
-				Name:          asdbv1alpha1.InfoPortName,
-				ContainerPort: asdbv1alpha1.InfoPort,
-				HostPort:      asdbv1alpha1.InfoPort,
-			},
+		if (!multiPodPerHost) && portInfo.exposedOnHost {
+			containerPort.HostPort = containerPort.ContainerPort
 		}
+		ports = append(ports, containerPort)
 	}
 	return ports
 }


### PR DESCRIPTION
Here is current logic:
- All AS ports are hardcoded in [constants here](https://github.com/aerospike/aerospike-kubernetes-operator/blob/1a3f18c7a01f54b9392cd3832b650bb3a5886378/api/v1alpha1/utils.go#L23-L39).
- All these ports are injected into AS config in [web hook](https://github.com/aerospike/aerospike-kubernetes-operator/blob/1a3f18c7a01f54b9392cd3832b650bb3a5886378/api/v1alpha1/aerospikecluster_mutating_webhook.go#L307-L368). Thus nobody can set other values.
- The same constants are also used to specify ports in [pod's specs](https://github.com/aerospike/aerospike-kubernetes-operator/blob/38a528566e31e986f8f869d7b326547a7a9345e1/controllers/statefulset.go#L850-L921).
- Also these consts are used [to establish connections to AS cluster](https://github.com/aerospike/aerospike-kubernetes-operator/blob/9341bc18de827e4b0c07761c2beb3d9393635c37/controllers/aero_info_calls.go#L181-L200).
- **access** and **alternate access** ports are set to service port (and tls service port). Later these 4 ports [are replaced in the config by aerospike-init container](https://github.com/aerospike/aerospike-kubernetes-operator/blob/38a528566e31e986f8f869d7b326547a7a9345e1/controllers/scripts/create-aerospike-conf.sh#L80-L81) depending on network policy and MultiPodPerHost flag.

What was changed:
- All values for ports are now taken from CR config. Port constants are only used as default values.
- **access** and **alternate access** ports are now set to 65535 and this value is replaced by init container.
- validation added to rack forbidding any network configurations specific to rack. The problem is that we use the same heartbeat configuration for all hosts when adding mesh-seed-address-port in create-aerospike-conf.sh. Thus if different rack would have different port configuration heartbeating gets broken.