### PR TITLE
Ignored rack-label for anti-affinity rules

### DIFF
--- a/controllers/rack.go
+++ b/controllers/rack.go
@@ -221,7 +221,8 @@ func (r *SingleClusterReconciler) reconcileRack(
 		if !res.isSuccess {
 			if res.err != nil {
 				r.Log.Error(
-					res.err, "Failed to scaleDown StatefulSet pods", "stsName", found.Name,
+					res.err, "Failed to scaleDown StatefulSet pods", "stsName",
+					found.Name,
 				)
 			}
 			return res
@@ -621,12 +622,8 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		return found, reconcileError(fmt.Errorf("cannot Rolling restart AerospikeCluster. A pod is already in failed state"))
 	}
 
-	ls := utils.LabelsForAerospikeClusterRack(
-		r.aeroCluster.Name, rackState.Rack.ID,
-	)
-
 	// Can we optimize this? Update stateful set only if there is any update for it.
-	r.updateSTSPodSpec(found, ls, rackState)
+	r.updateSTSPodSpec(found, rackState)
 
 	// This should be called before updating storage
 	initializeSTSStorage(r.aeroCluster, found, rackState)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -93,7 +93,8 @@ func GetDesiredImage(
 // belonging to the given AerospikeCluster CR name.
 func LabelsForAerospikeCluster(clName string) map[string]string {
 	return map[string]string{
-		asdbv1beta1.AerospikeAppLabel: "aerospike-cluster", asdbv1beta1.AerospikeCustomResourceLabel: clName,
+		asdbv1beta1.AerospikeAppLabel:            "aerospike-cluster",
+		asdbv1beta1.AerospikeCustomResourceLabel: clName,
 	}
 }
 
@@ -103,6 +104,13 @@ func LabelsForAerospikeClusterRack(
 ) map[string]string {
 	labels := LabelsForAerospikeCluster(clName)
 	labels[asdbv1beta1.AerospikeRackIdLabel] = strconv.Itoa(rackID)
+	return labels
+}
+
+// LabelsForPodAntiAffinity returns the labels to use for setting pod
+// anti-affinity.
+func LabelsForPodAntiAffinity(clName string) map[string]string {
+	labels := LabelsForAerospikeCluster(clName)
 	return labels
 }
 
@@ -119,7 +127,7 @@ func MergeLabels(operatorLabels, userLabels map[string]string) map[string]string
 	return mergedMap
 }
 
-// GetHash return ripmd160 hash for given string
+// GetHash return ripemd160 hash for given string
 func GetHash(str string) (string, error) {
 	var digest []byte
 	hash := ripemd160.New()


### PR DESCRIPTION
Anti-affinity rules include rack label. This could allow pods from a different rack to be scheduled in single pod per host case if the other rack is also on the same zone and region.