### PR TITLE
Add rights to read configmaps for aerospike-operator-controller-manager svc account

### DIFF
--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-cluster-rbac.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-cluster-rbac.yaml
@@ -35,6 +35,7 @@ rules:
   - pods
   - nodes
   - services
+  - configmaps
   verbs:
   - get
   - list


### PR DESCRIPTION
This right is needed to do fast restart

bash /etc/aerospike/refresh-cmap-restart-asd.sh am6-aerospikes99-preprod aerospikes99-23
+++ realpath /etc/aerospike/refresh-cmap-restart-asd.sh
++ dirname /etc/aerospike/refresh-cmap-restart-asd.sh
+ script_dir=/etc/aerospike
+ cd /etc/aerospike
+ '[' -z am6-aerospikes99-preprod ']'
+ '[' -z aerospikes99-23 ']'
+ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/aerospike
+ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/aerospike
+ mkdir -p configmap
+ chmod +x ./kubernetes-configmap-exporter
+ ./kubernetes-configmap-exporter am6-aerospikes99-preprod aerospikes99-23 configmap
panic: configmaps "aerospikes99-23" is forbidden: User "system:serviceaccount:am6-aerospikes99-preprod:aerospike-operator-controller-manager" cannot get resource "configmaps" in API group "" in the namespace "am6-aerospikes99-preprod"