### PR TITLE
Allow updating ns storage-engine after deployment.

### DIFF
--- a/api/v1beta1/aerospikecluster_validating_webhook.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook.go
@@ -1124,7 +1124,6 @@ func validateNsConfUpdate(
 		}
 
 		// Validate new namespace conf from old namespace conf. Few filds cannot be updated
-		var found bool
 		oldNsConfList := oldConf["namespaces"].([]interface{})
 
 		for _, oldSingleConfInterface := range oldNsConfList {
@@ -1138,7 +1137,6 @@ func validateNsConfUpdate(
 			}
 
 			if singleConf["name"] == oldSingleConf["name"] {
-				found = true
 
 				// replication-factor update not allowed
 				if isValueUpdated(
@@ -1149,46 +1147,9 @@ func validateNsConfUpdate(
 						oldSingleConf, singleConf,
 					)
 				}
-				if isValueUpdated(oldSingleConf, singleConf, "tls-name") {
-					return fmt.Errorf(
-						"tls-name cannot be update. old nsconf %v, new nsconf %v",
-						oldSingleConf, singleConf,
-					)
-				}
-				if isValueUpdated(
-					oldSingleConf, singleConf, "tls-authenticate-client",
-				) {
-					return fmt.Errorf(
-						"tls-authenticate-client cannot be update. old nsconf %v, new nsconf %v",
-						oldSingleConf, singleConf,
-					)
-				}
-
-				// storage-engine update not allowed for now
-				storage, ok1 := singleConf["storage-engine"]
-				oldStorage, ok2 := oldSingleConf["storage-engine"]
-				if ok1 && !ok2 || !ok1 && ok2 {
-					return fmt.Errorf(
-						"storage-engine config cannot be added or removed from existing cluster. Old namespace config %v, new namespace config %v",
-						oldSingleConf, singleConf,
-					)
-				}
-				if ok1 && ok2 && !reflect.DeepEqual(storage, oldStorage) {
-					return fmt.Errorf(
-						"storage-engine config cannot be changed. Old namespace config %v, new namespace config %v",
-						oldSingleConf, singleConf,
-					)
-				}
 			}
 		}
 
-		// Cannot add new persistent namespaces.
-		if !found && !isInMemoryNamespace(singleConf) {
-			return fmt.Errorf(
-				"new persistent storage namespace %s cannot be added. Old namespace list %v, new namespace list %v",
-				singleConf["name"], oldNsConfList, newNsConfList,
-			)
-		}
 	}
 	// Check for namespace name len
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,12 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/onsi/ginkgo v1.16.5
-	github.com/onsi/gomega v1.17.0
+	github.com/onsi/gomega v1.18.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/tools v0.1.4 // indirect
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,7 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -421,6 +422,7 @@ github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvw
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
+github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -429,6 +431,8 @@ github.com/onsi/gomega v1.12.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je4
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
+github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -744,6 +748,8 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/test/cluster_helper.go
+++ b/test/cluster_helper.go
@@ -99,6 +99,7 @@ func rollingRestartClusterTest(
 	if _, ok := aeroCluster.Spec.AerospikeConfig.Value["service"]; !ok {
 		aeroCluster.Spec.AerospikeConfig.Value["service"] = map[string]interface{}{}
 	}
+
 	aeroCluster.Spec.AerospikeConfig.Value["service"].(map[string]interface{})["proto-fd-max"] = defaultProtofdmax + 1
 
 	err = k8sClient.Update(ctx, aeroCluster)
@@ -117,18 +118,67 @@ func rollingRestartClusterTest(
 
 	// Verify that the change has been applied on the cluster.
 	return validateAerospikeConfigServiceClusterUpdate(
-		log, k8sClient, ctx, clusterNamespacedName, []string{"proto-fd-max"},
+		log, k8sClient, ctx, aeroCluster, clusterNamespacedName, []string{"proto-fd-max"},
 	)
 }
 
-func validateAerospikeConfigServiceClusterUpdate(
+func rollingRestartClusterByUpdatingNamespaceStorageTest(
 	log logr.Logger, k8sClient client.Client, ctx goctx.Context,
-	clusterNamespacedName types.NamespacedName, updatedKeys []string,
+	clusterNamespacedName types.NamespacedName,
 ) error {
 	aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
 	if err != nil {
 		return err
 	}
+
+	// Change namespace storage-engine
+	aeroCluster.Spec.AerospikeConfig.Value["namespaces"].([]interface{})[0].(map[string]interface{})["storage-engine"].(map[string]interface{})["data-in-memory"] = true
+	aeroCluster.Spec.AerospikeConfig.Value["namespaces"].([]interface{})[0].(map[string]interface{})["storage-engine"].(map[string]interface{})["filesize"] = 2000000000
+
+	err = k8sClient.Update(ctx, aeroCluster)
+	if err != nil {
+		return err
+	}
+
+	err = waitForAerospikeCluster(
+		k8sClient, ctx, aeroCluster, int(aeroCluster.Spec.Size), retryInterval,
+		getTimeout(aeroCluster.Spec.Size),
+	)
+
+	return err
+}
+
+func rollingRestartClusterByAddingNamespaceDynamicallyTest(
+	log logr.Logger, k8sClient client.Client, ctx goctx.Context, dynamicNs map[string]interface{},
+	clusterNamespacedName types.NamespacedName,
+) error {
+	aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+	if err != nil {
+		return err
+	}
+
+	// Change namespace list
+	nsList := aeroCluster.Spec.AerospikeConfig.Value["namespaces"].([]interface{})
+	nsList = append(nsList, dynamicNs)
+	aeroCluster.Spec.AerospikeConfig.Value["namespaces"] = nsList
+
+	err = k8sClient.Update(ctx, aeroCluster)
+	if err != nil {
+		return err
+	}
+
+	err = waitForAerospikeCluster(
+		k8sClient, ctx, aeroCluster, int(aeroCluster.Spec.Size), retryInterval,
+		getTimeout(aeroCluster.Spec.Size),
+	)
+
+	return err
+}
+
+func validateAerospikeConfigServiceClusterUpdate(
+	log logr.Logger, k8sClient client.Client, ctx goctx.Context,
+	aeroCluster *asdbv1beta1.AerospikeCluster, clusterNamespacedName types.NamespacedName, updatedKeys []string,
+) error {
 
 	for _, pod := range aeroCluster.Status.Pods {
 		// TODO:

--- a/test/cluster_helper.go
+++ b/test/cluster_helper.go
@@ -118,7 +118,7 @@ func rollingRestartClusterTest(
 
 	// Verify that the change has been applied on the cluster.
 	return validateAerospikeConfigServiceClusterUpdate(
-		log, k8sClient, ctx, aeroCluster, clusterNamespacedName, []string{"proto-fd-max"},
+		log, k8sClient, ctx, clusterNamespacedName, []string{"proto-fd-max"},
 	)
 }
 
@@ -177,8 +177,12 @@ func rollingRestartClusterByAddingNamespaceDynamicallyTest(
 
 func validateAerospikeConfigServiceClusterUpdate(
 	log logr.Logger, k8sClient client.Client, ctx goctx.Context,
-	aeroCluster *asdbv1beta1.AerospikeCluster, clusterNamespacedName types.NamespacedName, updatedKeys []string,
+	clusterNamespacedName types.NamespacedName, updatedKeys []string,
 ) error {
+	aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+	if err != nil {
+		return err
+	}
 
 	for _, pod := range aeroCluster.Status.Pods {
 		// TODO:

--- a/test/test_client.go
+++ b/test/test_client.go
@@ -15,7 +15,6 @@ import (
 	aerospikecluster "github.com/aerospike/aerospike-kubernetes-operator/controllers"
 	as "github.com/ashishshinde/aerospike-client-go/v5"
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +34,7 @@ type FromSecretPasswordProvider struct {
 func (pp FromSecretPasswordProvider) Get(
 	_ string, userSpec *asdbv1beta1.AerospikeUserSpec,
 ) (string, error) {
-	secret := &corev1.Secret{}
+	secret := &v1.Secret{}
 	secretName := userSpec.SecretName
 	// Assuming secret is in same namespace
 	err := (*pp.k8sClient).Get(


### PR DESCRIPTION
Allow adding ns dynamically. If ns uses persistent storage then storage should be
given in CR's storage section while deploying the cluster.

(enables encryption at rest)