### PR TITLE
[OPS-5449] Only drop user's and roles that were previously created by the operator

### DIFF
--- a/controllers/reconciler.go
+++ b/controllers/reconciler.go
@@ -110,7 +110,9 @@ func (r *SingleClusterReconciler) reconcileAccessControl() error {
 	if err != nil {
 		return err
 	}
-	enabled, err := asdbv1beta1.IsSecurityEnabled(version, r.aeroCluster.Spec.AerospikeConfig)
+	enabled, err := asdbv1beta1.IsSecurityEnabled(
+		version, r.aeroCluster.Spec.AerospikeConfig,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster security status: %v", err)
 	}
@@ -146,7 +148,19 @@ func (r *SingleClusterReconciler) reconcileAccessControl() error {
 
 	pp := r.getPasswordProvider()
 
-	err = ReconcileAccessControl(&r.aeroCluster.Spec, aeroClient, pp, r.Log)
+	statusAsSpec, err := asdbv1beta1.CopyStatusToSpec(
+		r.aeroCluster.Status.
+			AerospikeClusterStatusSpec,
+	)
+	if err != nil {
+		r.Log.Error(err, "Failed to copy spec in status", "err", err)
+		return err
+	}
+
+	err = ReconcileAccessControl(
+		&r.aeroCluster.Spec, statusAsSpec,
+		aeroClient, pp, r.Log,
+	)
 	return err
 }
 

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,7 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
A fix for OPS-5449, which works but runs the risk of not dropping users if there are failures and changes in a quick
succession.

A proper fix requires the server to mark users and roles as external in client queries.