### PR TITLE
update default block cleaner to use blkdiscard

### DIFF
--- a/config/samples/storage/aerospike_local_volume_provisioner.yaml
+++ b/config/samples/storage/aerospike_local_volume_provisioner.yaml
@@ -12,8 +12,7 @@ data:
        hostDir: /mnt/disks
        mountDir:  /mnt/disks
        blockCleanerCommand:
-         - "/scripts/shred.sh"
-         - "2"
+         - "/scripts/blkdiscard.sh"
        volumeMode: Block
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
This was set to use shred. Shred is zeroing out multiple times to the disks. On bigger disks this can take a very long time to finish.