### PR TITLE
requeuing reconcilation after 1 second when scale down failure. #ko-13

### DIFF
--- a/controllers/rack.go
+++ b/controllers/rack.go
@@ -551,11 +551,8 @@ func (r *SingleClusterReconciler) scaleDownRack(
 
 		// Wait for pods to get terminated
 		if err := r.waitForSTSToBeReady(found); err != nil {
-			return found, reconcileError(
-				fmt.Errorf(
-					"failed to wait for statefulset to be ready: %v", err,
-				),
-			)
+			r.Log.Error(err, "failed to wait for statefulset to be ready")
+			return found, reconcileRequeueAfter(1)
 		}
 
 		// Fetch new object


### PR DESCRIPTION
In case of large scale down, where we gave multiple statefulsets with multiple pods in them, single reconciliation thread is getting the pod down one by one. 
when re-queue happens due to any failure(in this case sts was not getting updated in time(20sec)), exponential time keeps on getting pilled up for each requeue.
Hence making changes to enqueue the reconciliation after 1 sec in case of sts update failure, instead of waiting for exponential time off.
Attaching results file of customer issue logs and logs after making changes.
[1_sec.pdf](https://github.com/aerospike/aerospike-kubernetes-operator/files/8715650/1_sec.pdf)
[customer_exponential.pdf](https://github.com/aerospike/aerospike-kubernetes-operator/files/8715651/customer_exponential.pdf)

