### PR TITLE
Auto escape ${un} and ${dn} in LDAP security configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ boolean isNightly() {
 }
 
 String getVersion() {
-    def prefix = "2.0.0"
+    def prefix = "2.1.0"
     def candidateName = ""
     if(isNightly()) {
         def timestamp = new Date().format("yyyy-MM-dd")
@@ -92,10 +92,27 @@ String getVersion() {
         candidateName =  "candidate-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
     }
 
+    def candidateNameMax = 30 - prefix.length()
+    candidateName = abbreviate(candidateName, candidateNameMax)
     version = "${prefix}-${candidateName}"
     return normalizeVersion(version)
 }
 
 String normalizeVersion(String version) {
     return version.toLowerCase().replaceAll(/[^a-zA-Z0-9-.]+/, "-").replaceAll(/(^-+)|(-+$)/,"")
+}
+
+String abbreviate(String str, int length) {
+  if(str.length() <= length) {
+    return str
+  }
+
+  def parts = str.split("[._\\-/]")
+  def abbreviated = ""
+  for(part in parts) {
+    abbreviated += part.substring(0,Math.min(part.length(), 2))
+    abbreviated += "-"
+  }
+
+  return abbreviated.substring(0, abbreviated.length()-1)
 }

--- a/api/v1beta1/aerospikecluster_mutating_webhook.go
+++ b/api/v1beta1/aerospikecluster_mutating_webhook.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -258,6 +259,11 @@ func (c *AerospikeCluster) setDefaultAerospikeConfigs(
 		if err := setDefaultXDRConf(asLog, configSpec); err != nil {
 			return err
 		}
+	}
+
+	// escape LDAP configuration
+	if err := escapeLDAPConfiguration(configSpec); err != nil {
+		return err
 	}
 
 	return nil
@@ -633,4 +639,65 @@ func isNameExist(names []string, name string) bool {
 		}
 	}
 	return false
+}
+
+// escapeLDAPConfiguration escapes LDAP variables ${un} and ${dn} to
+// $${_DNE}{un} and $${_DNE}{dn} to prevent aerospike container images
+// template expansion from messing up the LDAP section.
+func escapeLDAPConfiguration(configSpec AerospikeConfigSpec) error {
+	config := configSpec.Value
+
+	if _, ok := config["security"]; ok {
+		security, ok := config["security"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf(
+				"security conf not in valid format %v", config["security"],
+			)
+		}
+
+		if _, ok := security["ldap"]; ok {
+			security["ldap"] = escapeValue(security["ldap"])
+		}
+	}
+
+	return nil
+}
+
+func escapeValue(valueGeneric interface{}) interface{} {
+	switch value := valueGeneric.(type) {
+	case string:
+		return escapeString(value)
+	case []interface{}:
+		var modifiedSlice []interface{}
+		for _, item := range value {
+			modifiedSlice = append(modifiedSlice, escapeValue(item))
+		}
+		return modifiedSlice
+	case []string:
+		var modifiedSlice []string
+		for _, item := range value {
+			modifiedSlice = append(modifiedSlice, escapeString(item))
+		}
+		return modifiedSlice
+	case map[string]interface{}:
+		modifiedMap := map[string]interface{}{}
+		for key, mapValue := range value {
+			modifiedMap[escapeString(key)] = escapeValue(mapValue)
+		}
+		return modifiedMap
+	case map[string]string:
+		modifiedMap := map[string]string{}
+		for key, mapValue := range value {
+			modifiedMap[escapeString(key)] = escapeString(mapValue)
+		}
+		return modifiedMap
+	default:
+		return value
+	}
+}
+
+func escapeString(str string) string {
+	str = strings.ReplaceAll(str, "${un}", "$${_DNE}{un}")
+	str = strings.ReplaceAll(str, "${dn}", "$${_DNE}{dn}")
+	return str
 }

--- a/api/v1beta1/aerospikecluster_validating_webhook.go
+++ b/api/v1beta1/aerospikecluster_validating_webhook.go
@@ -866,7 +866,7 @@ func validateNamespaceConfig(
 		}
 	}
 
-	// Vaidate index-type
+	// Validate index-type
 	for _, nsConfInterface := range nsConfInterfaceList {
 		nsConf, ok := nsConfInterface.(map[string]interface{})
 		if !ok {
@@ -1002,9 +1002,7 @@ func validateEnableSecurityConfig(newConfSpec, oldConfSpec *AerospikeConfigSpec)
 	// auth-enabled and auth-disabled node can co-exist
 	oldSec, oldSecConfFound := oldConf["security"]
 	newSec, newSecConfFound := newConf["security"]
-	if oldSecConfFound != oldSecConfFound {
-		return fmt.Errorf("cannot update cluster security config")
-	}
+
 	if oldSecConfFound && newSecConfFound {
 		oldSecFlag, oldEnableSecurityFlagFound := oldSec.(map[string]interface{})["enable-security"]
 		newSecFlag, newEnableSecurityFlagFound := newSec.(map[string]interface{})["enable-security"]

--- a/config/samples/ldap_cluster_cr.yaml
+++ b/config/samples/ldap_cluster_cr.yaml
@@ -66,19 +66,15 @@ spec:
       ldap:
         # The patterns are based on the demo OpenLDAP deployment.
         # You need to adapt them to your setup.
-        # Note: $${DNE}{un} evaluates to ${un} in the generated
-        # Aerospike configuration. The additional ${DNE} is to prevent
-        # double substitution that happens in Aerospike server container
-        # images.
         query-base-dn: 'dc=example,dc=org'
         server: ldap://openldap.default.svc.cluster.local:1389
         disable-tls: true
         query-user-dn: "cn=admin,dc=example,dc=org"
         query-user-password-file: /etc/aerospike/secret/ldap-passwd.txt
-        user-dn-pattern: 'cn=$${DNE}{un},ou=users,dc=example,dc=org'
+        user-dn-pattern: 'cn=${un},ou=users,dc=example,dc=org'
         role-query-search-ou: true
         role-query-patterns:
-          - '(&(objectClass=groupOfNames)(member=cn=$${DNE}{un},ou=users,dc=example,dc=org))'
+          - '(&(objectClass=groupOfNames)(member=cn=${un},ou=users,dc=example,dc=org))'
         polling-period: 10
     network:
       service:

--- a/test/ldap_auth_test.go
+++ b/test/ldap_auth_test.go
@@ -160,11 +160,12 @@ func getAerospikeClusterSpecWithLDAP(
 							"query-user-dn": "cn=admin,dc=example,dc=org",
 							"query-user-password-file": "/etc/aerospike/secret" +
 								"/ldap-passwd.txt",
-							"user-dn-pattern": "cn=$${DNE}{un},ou=users," +
+							"user-dn-pattern": "cn=${un},ou=users," +
 								"dc=example,dc=org",
 							"role-query-search-ou": true,
 							"role-query-patterns": []string{
-								"(&(objectClass=groupOfNames)(member=cn=$${DNE}{un},ou=users,dc=example,dc=org))",
+								"(&(objectClass=groupOfNames)(member=cn=${un},ou=users,dc=example,dc=org))",
+								"(&(ou=db_groups)(uniqueMember=${dn}))",
 							},
 							"polling-period": 10,
 						},


### PR DESCRIPTION
Aerospike template evaluation on containers removes ${un} and ${dn} strings from LDAP query configuration in the security section. This change automatically escapes these string in the operator so that the containers get the correct LDAP config.