### PR TITLE
[KO-126] Prevent config map refresh break long running init scripts

### DIFF
--- a/controllers/scripts/copy-templates.sh
+++ b/controllers/scripts/copy-templates.sh
@@ -38,5 +38,5 @@ fi
 source=$1
 destination=$2
 echo installing aerospike.conf into "${destination}"
-cp "${source}/aerospike.template.conf" "${destination}"/
-cp "${source}/peers" "${destination}"/
+\cp -L "${source}/aerospike.template.conf" "${destination}"/
+\cp -L "${source}/peers" "${destination}"/

--- a/controllers/scripts/initialize.sh
+++ b/controllers/scripts/initialize.sh
@@ -55,12 +55,12 @@ mkdir -p "${CONFIG_VOLUME}"
 bash ./copy-templates.sh /configs "${CONFIG_VOLUME}"
 
 # Copy scripts and binaries needed for warm restart.
-cp /usr/bin/curl "${CONFIG_VOLUME}"/curl
-cp /workdir/bin/kubernetes-configmap-exporter "${CONFIG_VOLUME}"/
-cp ./refresh-cmap-restart-asd.sh "${CONFIG_VOLUME}"/
+\cp /usr/bin/curl "${CONFIG_VOLUME}"/curl
+\cp /workdir/bin/kubernetes-configmap-exporter "${CONFIG_VOLUME}"/
+\cp ./refresh-cmap-restart-asd.sh "${CONFIG_VOLUME}"/
 
 if [ -f /configs/features.conf ]; then
-    cp -L /configs/features.conf "${CONFIG_VOLUME}"/
+    \cp -L /configs/features.conf "${CONFIG_VOLUME}"/
 fi
 
 # ------------------------------------------------------------------------------

--- a/controllers/scripts/initialize.sh
+++ b/controllers/scripts/initialize.sh
@@ -60,11 +60,20 @@ cp /workdir/bin/kubernetes-configmap-exporter "${CONFIG_VOLUME}"/
 cp ./refresh-cmap-restart-asd.sh "${CONFIG_VOLUME}"/
 
 if [ -f /configs/features.conf ]; then
-    cp /configs/features.conf "${CONFIG_VOLUME}"/
+    cp -L /configs/features.conf "${CONFIG_VOLUME}"/
 fi
 
+# ------------------------------------------------------------------------------
+# Run the following scripts using a copy of the configmap, so that config map
+# refresh does not break them. Refresh deletes the working dir of a running
+# script and breaks the scripts.
+# ------------------------------------------------------------------------------
+CONFIG_MAP_DIR="${CONFIG_VOLUME}/configmap"
+mkdir -p "${CONFIG_MAP_DIR}"
+\cp -r -L /configs/* "${CONFIG_MAP_DIR}"
+
 # Create Aerospike configuration
-bash ./create-aerospike-conf.sh
+bash "${CONFIG_MAP_DIR}"/create-aerospike-conf.sh
 
 # Update pod status in the k8s aerospike cluster object
-bash ./update-pod-status.sh
+bash "${CONFIG_MAP_DIR}"/update-pod-status.sh


### PR DESCRIPTION
Long running init scripts were being run from the config map folder. If and when the ConfigMap refreshed, the directory working directory for a running directory would deleted and a new one created. The running script would then not find files, when referenced WRT to its current working directory which would have been leaned up.

Fixed by running scripts from a copy of the scripts coming from configmaps.