### PR TITLE
Zeroize header (first 8MiB) when initMethod or wipeMethod is set to blkdiscard

### DIFF
--- a/controllers/scripts/create_pod_status_patch.py
+++ b/controllers/scripts/create_pod_status_patch.py
@@ -399,9 +399,9 @@ def init_volumes(pod_name, config):
 
             elif volume.effective_init_method == "blkdiscard":
 
-                blkdiskard = "blkdiscard {volume_path}".format(
+                blkdiscard_cmd = "blkdiscard {volume_path} && blkdiscard -z --length 8MiB {volume_path}".format(
                     volume_path=volume.get_mount_point())
-                execute(blkdiskard)
+                execute(blkdiscard_cmd)
                 logging.info(f"{volume} - Initialized")
 
             elif volume.effective_init_method == "none":
@@ -470,8 +470,8 @@ def wipe_volumes(pod_name, config):
 
                 elif volume.effective_wipe_method == "blkdiscard":
 
-                    blkdiskard = "blkdiscard {volume_path}".format(volume_path=volume.get_mount_point())
-                    execute(blkdiskard)
+                    blkdiscard_cmd = "blkdiscard {volume_path} && blkdiscard -z --length 8MiB {volume_path}".format(volume_path=volume.get_mount_point())
+                    execute(blkdiscard_cmd)
                     logging.info(f"Wiped - {volume}")
 
                 else:


### PR DESCRIPTION
- Aerospike 6+ will not startup if the first 8MiB on device are not zeroed to protect from accidentally using an unintended volume. This is applicable when using fresh block device.
- This PR enables init script to zeroize the header (first `8MiB`) when `initMethod` or `wipeMethod` are set to `blkdiscard`.
- This is also backward compatible with previous versions of Aerospike.

Reference:
- https://docs.aerospike.com/server/operations/plan/ssd/ssd_init
- https://docs.aerospike.com/server/operations/troubleshoot/startup#the-header-has-not-been-zeroized