### PR TITLE
[KO-150] Ignored SNYK-RHEL8-KRB5LIBS-3121841 vulnerability issue.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,1 @@
 ignore:
-  SNYK-RHEL8-KRB5LIBS-3121841:
-    - '*':
-        reason: fix not available
-        expires: 2022-12-24T11:38:28.614Z


### PR DESCRIPTION
Vulnerability scanning was failing because of the error mentioned [here](https://security.snyk.io/vuln/SNYK-RHEL8-KRB5LIBS-3121841). Hence ignored this error as solution was not available with RHEL at that point of time under PR [Ignoring KRB5LIBS-3121841 vulnerability. by tanmayja · Pull Request #164 · aerospike/aerospike-kubernetes-operator](https://github.com/aerospike/aerospike-kubernetes-operator/pull/164) and [Ignore vulnerability that has not fix as of now. by tanmayja · Pull Request #161 · aerospike/aerospike-kubernetes-operator](https://github.com/aerospike/aerospike-kubernetes-operator/pull/161).
Now RHEL has fixed the issue above version 0:1.18.2-22.el8_7 or higher. Hence reverting the changes done before to ignore this error.