### PR TITLE
KO-153: Integrated pre-commit git-hooks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,76 @@
+
+linters-settings:
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  govet:
+    check-shadowing: true
+    enable:
+      - fieldalignment
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - unused
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - goconst
+    - gocritic
+    - gofmt
+    - goimports
+    - gocyclo
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - nakedret
+    - prealloc # pre-allocate slices with define size if the slice size is known in advance
+    - predeclared
+    - revive
+    - staticcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - whitespace
+    - lll
+    - wsl # White space linter
+
+run:
+  issues-exit-code: 1
+  go: '1.18'
+#  skip-dirs:
+#    - sample
+#  skip-files:
+#    - sample
+
+issues:
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+  # It's a super-useful option for integration of golangci-lint into existing large codebase.
+  # It's not practical to fix all existing issues at the moment of integration:
+  # much better don't allow issues in new code.
+  #
+  # Default: false.
+  new: true
+  # Show only new issues created after git revision `REV`.
+  new-from-rev: HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.1 # change this to the latest version
+    hooks:
+      - id: go-mod-tidy
+      - id: golangci-lint
+        args:
+          - --config=.golangci.yml
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace


### PR DESCRIPTION
- Added golangci-lint configuration file
- Integrated pre-commit tool for git hooks
   - Install pre-commit using `pip install pre-commit` or `brew install pre-commit`
   - Install required git hooks by running `pre-commit install` from the repo root
   
NOTE: To bypass githook during git commit, append  `--no-verify` param in the git commit command

Pre-commit Ref: https://pre-commit.com/#install