### PR TITLE
Ignoring SNYK-RHEL8-LIBKSBA-3232176 vulnerability

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,1 +1,5 @@
 ignore:
+  SNYK-RHEL8-LIBKSBA-3232176:
+      - '*':
+          reason: fix not available
+          expires: 2023-02-18T11:38:28.614Z

--- a/test/rack_utils.go
+++ b/test/rack_utils.go
@@ -64,7 +64,7 @@ func removeLastRack(
 
 	aeroCluster.Spec.RackConfig.Racks = racks
 	aeroCluster.Spec.Size = aeroCluster.Spec.Size - 1
-	// This will also indirectl check if older rack is removed or not.
+	// This will also indirectly check if older rack is removed or not.
 	// If older node is not deleted then cluster sz will not be as expected
 
 	if err := updateAndWait(k8sClient, ctx, aeroCluster); err != nil {


### PR DESCRIPTION
Ignoring this issue in vulnerability scanning as fix is not yet available.

https://security.snyk.io/vuln/SNYK-RHEL8-LIBKSBA-3232176