### PR TITLE
chore: move pods rbac to aerospike-cluster helm chart

### DIFF
--- a/helm-charts/aerospike-cluster/templates/rbac.yaml
+++ b/helm-charts/aerospike-cluster/templates/rbac.yaml
@@ -1,17 +1,16 @@
-{{- range $key, $ns := (split "," .Values.watchNamespaces) }}
-
+{{- if .Values.rbac.create }}
 # Service account used by the cluster pods to obtain pod metadata.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   # Do not change name, it's hard-coded in operator
   name: aerospike-operator-controller-manager
-  namespace: "{{ $ns }}"
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "aerospike-kubernetes-operator.fullname" $ }}
-    chart: {{ $.Chart.Name }}
-    release: {{ $.Release.Name }}
-{{- with $.Values.imagePullSecrets }}
+    app: {{ template "aerospike-cluster.commonName" . }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+{{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- range . }}
   - name: {{ . }}
@@ -23,11 +22,11 @@ imagePullSecrets:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: aerospike-cluster-{{ $ns }}-{{ $.Release.Name }}
+  name: aerospike-cluster-{{ .Release.Namespace }}-{{ .Release.Name }}
   labels:
-    app: {{ template "aerospike-kubernetes-operator.fullname" $ }}
-    chart: {{ $.Chart.Name }}
-    release: {{ $.Release.Name }}
+    app: {{ template "aerospike-cluster.commonName" . }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
 rules:
 - apiGroups:
   - ""
@@ -51,18 +50,18 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aerospike-cluster-{{ $ns }}-{{ $.Release.Name }}
+  name: aerospike-cluster-{{ .Release.Namespace }}-{{ .Release.Name }}
   labels:
-    app: {{ template "aerospike-kubernetes-operator.fullname" $ }}
-    chart: {{ $.Chart.Name }}
-    release: {{ $.Release.Name }}
+    app: {{ template "aerospike-cluster.commonName" . }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
 roleRef:
   kind: ClusterRole
-  name: aerospike-cluster-{{ $ns }}-{{ $.Release.Name }}
+  name: aerospike-cluster-{{ .Release.Namespace }}-{{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: aerospike-operator-controller-manager
-  namespace: {{ $ns }}
+  namespace: {{ .Release.Namespace }}
 ---
 {{- end }}

--- a/helm-charts/aerospike-cluster/values.yaml
+++ b/helm-charts/aerospike-cluster/values.yaml
@@ -110,3 +110,7 @@ operatorClientCert: {}
 
 ## Dev Mode
 devMode: false
+
+## Create RBAC resources
+rbac:
+  create: true

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-cluster-rbac.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-cluster-rbac.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.watchedNamespaceRbac.create }}
+{{- range $key, $ns := (split "," .Values.watchNamespaces) }}
+
+# Service account used by the cluster pods to obtain pod metadata.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  # Do not change name, it's hard-coded in operator
+  name: aerospike-operator-controller-manager
+  namespace: "{{ $ns }}"
+  labels:
+    app: {{ template "aerospike-kubernetes-operator.fullname" $ }}
+    chart: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+{{- with $.Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . }}
+  {{- end }}
+{{- end }}
+---
+
+# Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aerospike-cluster-{{ $ns }}-{{ $.Release.Name }}
+  labels:
+    app: {{ template "aerospike-kubernetes-operator.fullname" $ }}
+    chart: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - asdb.aerospike.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+
+# RoleBinding
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aerospike-cluster-{{ $ns }}-{{ $.Release.Name }}
+  labels:
+    app: {{ template "aerospike-kubernetes-operator.fullname" $ }}
+    chart: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+roleRef:
+  kind: ClusterRole
+  name: aerospike-cluster-{{ $ns }}-{{ $.Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: aerospike-operator-controller-manager
+  namespace: {{ $ns }}
+---
+{{- end }}
+{{- end }}

--- a/helm-charts/aerospike-kubernetes-operator/values.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/values.yaml
@@ -30,7 +30,8 @@ certs:
   webhookServerCertSecretName: "webhook-server-cert"
 
 ##  Operator configurations
-watchNamespaces: "default"
+## Empty value means the operator is running with cluster scope.
+watchNamespaces: ""
 
 # Registry used to pull aerospike-init image
 aerospikeKubernetesInitRegistry: "docker.io"

--- a/helm-charts/aerospike-kubernetes-operator/values.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/values.yaml
@@ -18,6 +18,10 @@ rbac:
   create: true
   # serviceAccountName: "default"
 
+## Create RBAC in watched namespace
+watchedNamespaceRbac:
+  create: true
+
 ## Ports
 # healthPort: 8081
 # metricsPort: 8080


### PR DESCRIPTION
## Context 

Using the `aerospike-kubernetes-operator` helm chart, by default, the user needs to specify a list of `watchNamespaces`, which is used by the operator as the environement variable `WATCH_NAMESPACE`. 

This implies the creation of rome rbac manifests, `Clusterrole`, `Clusterrolebinding` and `serviceAccount` that needs to be create in the target "watched" namespace. 

This process has a major drawback, which is the fact that the watched namespace needs to exist before the deployment/update of the operator. 

This process is really not convenient in a context where a user (like me :) ) needs to create multiple clusters in different namespaces, since for each new cluster we have to : 
- Create the target namespace
- Update the `watchNamespaces` in the `aerospike-kubernetes-operator` helm chart and redeploy the operator
- Deploy the `aerospike-cluster` helm chart in the target namespace. 

this definitely doesn't fits with most of the deployment process.

## This PR: 
- sets the `watchNamespace` value to `""` which will [make the operator running with cluster scope](https://github.com/aerospike/aerospike-kubernetes-operator/blob/792ab0702324cd2125ffae2109ffd07f608f662f/main.go#L188). 
- move the clusterroles rbac to the `aerospike-cluster`

This way, we don't need to touch the operator to deploy a new cluster. 

## Breaking changes

In the current state, an upgrade from chart 2.4.0 to this new version will break the operator, until the `aerospike-cluster` is also deployed. Not ideal at all

if for any reason someone want to deploy multiple helm releases of `aerospike-cluster` helm chart, he should only set the value `rbac.create: true` for the first release

## How Has This Been Tested?

Deployed on a local cluster with default values. 