### PR TITLE
Giving write permission to bin/k8s in jenkins for it to be cleaned.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
             stages {
                 stage("Checkout") {
                     steps {
+                        sh "chmod -R 744 bin || true"
                         checkout([
                             $class: 'GitSCM',
                             branches: scm.branches,
@@ -97,6 +98,12 @@ pipeline {
     post {
         always {
             junit testResults: '**/junit.xml', keepLongStdio: true
+        }
+        cleanup {
+            script {
+                sh "chmod -R 744 bin || true"
+            }
+            cleanWs()
         }
     }
 }

--- a/test/cleanup-test-namespace.sh
+++ b/test/cleanup-test-namespace.sh
@@ -15,36 +15,37 @@ kubectl -n test2 delete aerospikecluster --all
 kubectl -n aerospike delete aerospikecluster --all
 
 # Force delete pods
-kubectl delete pod --selector 'app=aerospike-cluster' --grace-period=0 --force --namespace test || true
-kubectl delete pod --selector 'app=aerospike-cluster' --grace-period=0 --force --namespace test1 || true
-kubectl delete pod --selector 'app=aerospike-cluster' --grace-period=0 --force --namespace test2 || true
-kubectl delete pod --selector 'app=aerospike-cluster' --grace-period=0 --force --namespace aerospike || true
+kubectl delete pod --selector 'app=aerospike-cluster' --grace-period=0 --force --namespace test --ignore-not-found
+kubectl delete pod --selector 'app=aerospike-cluster' --grace-period=0 --force --namespace test1 --ignore-not-found
+kubectl delete pod --selector 'app=aerospike-cluster' --grace-period=0 --force --namespace test2 --ignore-not-found
+kubectl delete pod --selector 'app=aerospike-cluster' --grace-period=0 --force --namespace aerospike --ignore-not-found
 
 # Delete PVCs
 echo "Removing PVCs"
-kubectl -n test delete pvc --selector 'app=aerospike-cluster' || true
+kubectl -n test delete pvc --selector 'app=aerospike-cluster' --ignore-not-found
 
 # Delete the secrets
 echo "Removing secrets"
-kubectl -n test delete secret --selector 'app=aerospike-cluster' || true
+kubectl -n test delete secret --selector 'app=aerospike-cluster' --ignore-not-found
 
 # Delete rbac accounts and auth
 echo "Removing RBAC"
-kubectl delete clusterrolebinding aerospike-cluster-rolebinding || true
-kubectl delete clusterrole aerospike-cluster-role || true
+kubectl delete clusterrolebinding aerospike-cluster-rolebinding --ignore-not-found
+kubectl delete clusterrole aerospike-cluster-role --ignore-not-found
 
-kubectl -n test delete serviceaccount aerospike-operator-controller-manager || true
-kubectl -n test1 delete serviceaccount aerospike-operator-controller-manager || true
-kubectl -n test2 delete serviceaccount aerospike-operator-controller-manager || true
-kubectl -n aerospike delete serviceaccount aerospike-operator-controller-manager || true
+kubectl -n test delete serviceaccount aerospike-operator-controller-manager --ignore-not-found
+kubectl -n test1 delete serviceaccount aerospike-operator-controller-manager --ignore-not-found
+kubectl -n test2 delete serviceaccount aerospike-operator-controller-manager --ignore-not-found
+kubectl -n aerospike delete serviceaccount aerospike-operator-controller-manager --ignore-not-found
 
 # Uninstall the operator
 echo "Removing test operator deployment"
 OPERATOR_NS=test
-kubectl delete subscription -n $OPERATOR_NS $(kubectl get subscription -n $OPERATOR_NS | grep aerospike-kubernetes-operator | cut -f 1 -d ' ') || true
-kubectl delete clusterserviceversion -n $OPERATOR_NS $(kubectl get clusterserviceversion -n $OPERATOR_NS | grep aerospike-kubernetes-operator | cut -f 1 -d ' ') || true
-kubectl delete job $(kubectl get job -o=jsonpath='{.items[?(@.status.succeeded==1)].metadata.name}' -n $OPERATOR_NS) -n $OPERATOR_NS || true
-kubectl delete CatalogSource $(kubectl get CatalogSource -n $OPERATOR_NS | grep aerospike-kubernetes-operator  | cut -f 1 -d ' ') || true
+kubectl delete subscription -n $OPERATOR_NS $(kubectl get subscription -n $OPERATOR_NS | grep aerospike-kubernetes-operator | cut -f 1 -d ' ') --ignore-not-found
+kubectl delete clusterserviceversion -n $OPERATOR_NS $(kubectl get clusterserviceversion -n $OPERATOR_NS | grep aerospike-kubernetes-operator | cut -f 1 -d ' ') --ignore-not-found
+kubectl delete job $(kubectl get job -o=jsonpath='{.items[?(@.status.succeeded==1)].metadata.name}' -n $OPERATOR_NS) -n $OPERATOR_NS --ignore-not-found
+kubectl delete CatalogSource $(kubectl get CatalogSource -n $OPERATOR_NS | grep aerospike-kubernetes-operator  | cut -f 1 -d ' ') --ignore-not-found
+kubectl delete crd aerospikeclusters.asdb.aerospike.com --ignore-not-found
 
 # Delete webhook configurations. Web hooks from older versions linger around and intercept requests.
 kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io $(kubectl get  mutatingwebhookconfigurations.admissionregistration.k8s.io | grep aerospike | cut -f 1 -d " ")
@@ -60,5 +61,5 @@ for namespace in $namespaces; do
 
   # Delete namespaces
   echo "Removing namespace $namespace"
-  kubectl delete namespace "$namespace" || true
+  kubectl delete namespace "$namespace" --ignore-not-found
 done


### PR DESCRIPTION
After upgrading `envtest` version, `setup-envtest` downloads some binaries in bin/k8s. 
In Jenkins, user does not have the write permission to this directory due to which cleanup is failing.
Hence adding the permission and cleaning the workspace after Jenkins run finished.