### PR TITLE
Add custom label to aerospike cluster cr via helm chart

### DIFF
--- a/helm-charts/aerospike-cluster/README.md
+++ b/helm-charts/aerospike-cluster/README.md
@@ -50,6 +50,7 @@ helm install aerospike ./aerospike-cluster/ \
 | `image.repository` | Aerospike server container image repository | `aerospike/aerospike-server-enterprise` |
 | `image.tag` | Aerospike server container image tag | `6.3.0.0` |
 | `imagePullSecrets` | Secrets containing credentials to pull Aerospike container image from a private registry | `{}` (nil) |
+| `customLabels` | Custom labels to add on the aerospikecluster resource | `{}` (nil) |
 | `aerospikeAccessControl` | Aerospike access control configuration. Define users and roles to be created on the cluster. | `{}` (nil) |
 | `aerospikeConfig` | Aerospike configuration | `{}` (nil) |
 | `aerospikeNetworkPolicy` | Network policy (client access configuration) | `{}` (nil) |

--- a/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
+++ b/helm-charts/aerospike-cluster/templates/aerospike-cluster-cr.yaml
@@ -7,6 +7,10 @@ metadata:
     app: {{ template "aerospike-cluster.commonName" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+
 spec:
   # Aerospike cluster size
   size: {{ .Values.replicas | default 3 }}

--- a/helm-charts/aerospike-cluster/values.yaml
+++ b/helm-charts/aerospike-cluster/values.yaml
@@ -16,6 +16,9 @@ image:
 ##   - secret_with_credentials_to_custom_registry
 imagePullSecrets: {}
 
+## Custom labels that will be applied on the aerospikecluster resource
+customLabels: {}
+
 ## Aerospike access control configuration
 aerospikeAccessControl: {}
   # users:


### PR DESCRIPTION
This change makes possible the addition of custom labels to the aerospike cluster custom ressource at deployement time using Helm