### PR TITLE
fix: make role create code stop always returning err in isCreate

### DIFF
--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -438,14 +438,16 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 	}
 
 	if isCreate {
-		if err := roleCreate.createRole(client, adminPolicy, logger, recorder, aeroCluster); err != nil {
+		var errorCreate error
+
+		if errorCreate = roleCreate.createRole(client, adminPolicy, logger, recorder, aeroCluster); errorCreate != nil {
 			recorder.Eventf(
 				aeroCluster, corev1.EventTypeWarning, "RoleCreateFailed",
 				"Failed to Create Role %s", roleCreate.name,
 			)
 		}
 
-		return err
+		return errorCreate
 	}
 
 	if errorUpdate := roleCreate.updateRole(


### PR DESCRIPTION
There was a bug in aerospikeRoleCreateUpdate.execute where isCreate, reached when err from QueryRole contains "Invalid role", shadows that same err variable.

The err variable is shadowed in the "if err :=" block, goes out of scope, and the previous err ("Invalid role") is returned instead of nil. Fix this by renaming the error to avoid shadowing.