### PR TITLE
Test: Dynamic RF Update TCs

### DIFF
--- a/.github/workflows/webhook-tests.yml
+++ b/.github/workflows/webhook-tests.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'enhancement/**'
     paths:  # Only run on PRs when eviction webhook or cluster-related code or tests change
       - 'internal/webhook/**'
       - 'api/v1/**'

--- a/test/cluster/dynamic_config_test.go
+++ b/test/cluster/dynamic_config_test.go
@@ -79,6 +79,7 @@ var _ = Describe(
 							getNonSCInMemoryNamespaceConfig("mem"))
 						aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyXdr] = map[string]interface{}{
 							"dcs": []map[string]interface{}{
+								// #nosec G101 test config path, not real credentials
 								{
 									"name":      "dc1",
 									"auth-mode": "internal",
@@ -712,7 +713,6 @@ var _ = Describe(
 
 				It(
 					"Should update replication-factor dynamically", func() {
-
 						By("Modify dynamic config by adding fields")
 
 						aeroCluster, err := getCluster(

--- a/test/envtests/cluster/access_control_webhook_test.go
+++ b/test/envtests/cluster/access_control_webhook_test.go
@@ -89,7 +89,11 @@ var _ = Describe("AerospikeCluster access control validation (envtests)", func()
 					Namespace: clusterNamespacedName.Namespace,
 				},
 			}
-			_ = envtests.K8sClient.Delete(ctx, aeroCluster)
+			Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+			Expect(testCluster.CleanupPVC(
+				envtests.K8sClient,
+				clusterNamespacedName.Namespace,
+				clusterNamespacedName.Name)).ToNot(HaveOccurred())
 		})
 
 		Context("spec.aerospikeAccessControl (validation)", func() {
@@ -196,7 +200,11 @@ var _ = Describe("AerospikeCluster access control validation (envtests)", func()
 					Namespace: clusterNamespacedName.Namespace,
 				},
 			}
-			_ = envtests.K8sClient.Delete(ctx, aeroCluster)
+			Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+			Expect(testCluster.CleanupPVC(
+				envtests.K8sClient,
+				clusterNamespacedName.Namespace,
+				clusterNamespacedName.Name)).ToNot(HaveOccurred())
 		})
 		Context("spec.aerospikeAccessControl (users)", func() {
 			Context("negative", func() {

--- a/test/envtests/cluster/access_control_webhook_test.go
+++ b/test/envtests/cluster/access_control_webhook_test.go
@@ -76,11 +76,10 @@ func adminOperatorCertForTest() *asdbv1.AerospikeOperatorClientCertSpec {
 var _ = Describe("AerospikeCluster access control validation (envtests)", func() {
 	const (
 		clusterName = "access-control-webhook-cluster"
-		testNs      = "default"
 	)
 
 	ctx := context.TODO()
-	clusterNamespacedName := test.GetNamespacedName(clusterName, testNs)
+	clusterNamespacedName := test.GetNamespacedName(clusterName, testutil.DefaultNamespace)
 
 	Context("Deploy validation", func() {
 		AfterEach(func() {

--- a/test/envtests/cluster/access_control_webhook_test.go
+++ b/test/envtests/cluster/access_control_webhook_test.go
@@ -90,10 +90,6 @@ var _ = Describe("AerospikeCluster access control validation (envtests)", func()
 				},
 			}
 			Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
-			Expect(testCluster.CleanupPVC(
-				envtests.K8sClient,
-				clusterNamespacedName.Namespace,
-				clusterNamespacedName.Name)).ToNot(HaveOccurred())
 		})
 
 		Context("spec.aerospikeAccessControl (validation)", func() {
@@ -201,10 +197,6 @@ var _ = Describe("AerospikeCluster access control validation (envtests)", func()
 				},
 			}
 			Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
-			Expect(testCluster.CleanupPVC(
-				envtests.K8sClient,
-				clusterNamespacedName.Namespace,
-				clusterNamespacedName.Name)).ToNot(HaveOccurred())
 		})
 		Context("spec.aerospikeAccessControl (users)", func() {
 			Context("negative", func() {

--- a/test/envtests/cluster/cluster_webhook_test.go
+++ b/test/envtests/cluster/cluster_webhook_test.go
@@ -22,13 +22,12 @@ import (
 var _ = Describe("AerospikeCluster validation", func() {
 	const (
 		clusterName = "invalid-cluster"
-		testNs      = "default" // use same test namespace as suite_test.go
 	)
 
 	ctx := context.TODO()
 
 	// Create namespaced name for cluster
-	clusterNamespacedName := test.GetNamespacedName(clusterName, testNs)
+	clusterNamespacedName := test.GetNamespacedName(clusterName, testutil.DefaultNamespace)
 
 	AfterEach(func() {
 		aeroCluster := &asdbv1.AerospikeCluster{
@@ -948,7 +947,8 @@ var _ = Describe("AerospikeCluster validation", func() {
 
 	Context("Update validation", func() {
 		const updateValidationClusterName = "update-validation-cluster"
-		updateValidationClusterNamespacedName := test.GetNamespacedName(updateValidationClusterName, testNs)
+		updateValidationClusterNamespacedName := test.GetNamespacedName(
+			updateValidationClusterName, testutil.DefaultNamespace)
 
 		AfterEach(func() {
 			aeroCluster := &asdbv1.AerospikeCluster{

--- a/test/envtests/cluster/cluster_webhook_test.go
+++ b/test/envtests/cluster/cluster_webhook_test.go
@@ -37,10 +37,6 @@ var _ = Describe("AerospikeCluster validation", func() {
 		}
 		// Delete the cluster after each test
 		Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
-		Expect(testCluster.CleanupPVC(
-			envtests.K8sClient,
-			clusterNamespacedName.Namespace,
-			clusterNamespacedName.Name)).ToNot(HaveOccurred())
 	})
 
 	Context("Deploy validation", func() {
@@ -960,10 +956,6 @@ var _ = Describe("AerospikeCluster validation", func() {
 				},
 			}
 			Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
-			Expect(testCluster.CleanupPVC(
-				envtests.K8sClient,
-				updateValidationClusterNamespacedName.Namespace,
-				updateValidationClusterNamespacedName.Name)).ToNot(HaveOccurred())
 		})
 
 		Context("spec.storage", func() {

--- a/test/envtests/cluster/cluster_webhook_test.go
+++ b/test/envtests/cluster/cluster_webhook_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -37,8 +36,11 @@ var _ = Describe("AerospikeCluster validation", func() {
 			},
 		}
 		// Delete the cluster after each test
-		err := envtests.K8sClient.Delete(ctx, aeroCluster)
-		Expect(err).To(Or(Succeed(), MatchError(errors.IsNotFound, "should be NotFound or Succeed")))
+		Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+		Expect(testCluster.CleanupPVC(
+			envtests.K8sClient,
+			clusterNamespacedName.Namespace,
+			clusterNamespacedName.Name)).ToNot(HaveOccurred())
 	})
 
 	Context("Deploy validation", func() {
@@ -957,7 +959,11 @@ var _ = Describe("AerospikeCluster validation", func() {
 					Namespace: updateValidationClusterNamespacedName.Namespace,
 				},
 			}
-			_ = envtests.K8sClient.Delete(ctx, aeroCluster)
+			Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+			Expect(testCluster.CleanupPVC(
+				envtests.K8sClient,
+				updateValidationClusterNamespacedName.Namespace,
+				updateValidationClusterNamespacedName.Name)).ToNot(HaveOccurred())
 		})
 
 		Context("spec.storage", func() {

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -47,8 +47,8 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 	// apNamespaceConfig returns an AP namespace config for envtest.
 	apNamespaceConfig := func(name string, rf int, device string) map[string]interface{} {
 		return map[string]interface{}{
-			"name":               name,
-			"replication-factor": rf,
+			asdbv1.ConfKeyName:              name,
+			asdbv1.ConfKeyReplicationFactor: rf,
 			asdbv1.ConfKeyStorageEngine: map[string]interface{}{
 				"type":    "device",
 				"devices": []interface{}{device},
@@ -59,15 +59,15 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 	// scNamespaceConfig returns an SC namespace config for envtest.
 	scNamespaceConfig := func(name string, rf int) map[string]interface{} {
 		cfg := apNamespaceConfig(name, rf, testutil.DefaultDevicePath)
-		cfg["strong-consistency"] = true
+		cfg[asdbv1.ConfKeyStrongConsistency] = true
 
 		return cfg
 	}
 
 	inMemoryNS := func(name string, rf int) map[string]interface{} {
 		return map[string]interface{}{
-			"name":               name,
-			"replication-factor": rf,
+			asdbv1.ConfKeyName:              name,
+			asdbv1.ConfKeyReplicationFactor: rf,
 			asdbv1.ConfKeyStorageEngine: map[string]interface{}{
 				"type":      "memory",
 				"data-size": 1073741824,
@@ -76,13 +76,14 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 	}
 
 	// updateNamespaceRF creates a cluster with one namespace (AP or SC), updates its RF to newRF,
-	// and returns the update error. namespaceType is "AP" or "SC".
-	updateNamespaceRF := func(namespaceType string, size int32, initialRF, newRF int) error {
+	// and returns the Update error. If rackCount is 0, the RF change is applied to spec.aerospikeConfig
+	// only. If rackCount > 0, RackConfig is populated with that many racks (each with InputAerospikeConfig
+	// for the namespace), and the RF change is applied only to each rack's InputAerospikeConfig.
+	updateNamespaceRF := func(isSCNamespace bool, size int32, initialRF, newRF int, rackCount int) error {
 		var nsConfig map[string]interface{}
-		switch namespaceType {
-		case "SC":
+		if isSCNamespace {
 			nsConfig = scNamespaceConfig(namespaceName, initialRF)
-		default:
+		} else {
 			nsConfig = apNamespaceConfig(namespaceName, initialRF, testutil.DefaultDevicePath)
 		}
 
@@ -90,15 +91,53 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 		aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{nsConfig}
 
+		if rackCount > 0 {
+			racks := make([]asdbv1.Rack, rackCount)
+			for i := 0; i < rackCount; i++ {
+				var rackNS map[string]interface{}
+				if isSCNamespace {
+					rackNS = scNamespaceConfig(namespaceName, initialRF)
+				} else {
+					rackNS = apNamespaceConfig(namespaceName, initialRF, testutil.DefaultDevicePath)
+				}
+				racks[i] = asdbv1.Rack{
+					ID: i + 1,
+					InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+						Value: map[string]interface{}{
+							asdbv1.ConfKeyNamespace: []interface{}{rackNS},
+						},
+					},
+				}
+			}
+			aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+				Namespaces: []string{namespaceName},
+				Racks:      racks,
+			}
+		}
+
 		err := envtests.K8sClient.Create(ctx, aeroCluster)
 		Expect(err).ToNot(HaveOccurred())
 
 		current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
 		Expect(err).ToNot(HaveOccurred())
 
+		if rackCount > 0 {
+			for i := range current.Spec.RackConfig.Racks {
+				rack := &current.Spec.RackConfig.Racks[i]
+				Expect(rack.InputAerospikeConfig).ToNot(BeNil())
+				nsList := rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+				nsConf := nsList[0].(map[string]interface{})
+				nsConf[asdbv1.ConfKeyReplicationFactor] = newRF
+				nsList[0] = nsConf
+				rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+			}
+
+			return envtests.K8sClient.Update(ctx, current)
+		}
+
 		nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
 		nsConf := nsList[0].(map[string]interface{})
-		nsConf["replication-factor"] = newRF
+		nsConf[asdbv1.ConfKeyReplicationFactor] = newRF
 		nsList[0] = nsConf
 		current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
 
@@ -112,7 +151,11 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 				Namespace: clusterNamespacedName.Namespace,
 			},
 		}
-		_ = envtests.K8sClient.Delete(ctx, aeroCluster)
+		Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+		Expect(testCluster.CleanupPVC(
+			envtests.K8sClient,
+			clusterNamespacedName.Namespace,
+			clusterNamespacedName.Name)).ToNot(HaveOccurred())
 	})
 
 	Context("Deploy validation", func() {
@@ -243,7 +286,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 		Context("spec.aerospikeConfig (replication-factor)", func() {
 			Context("negative", func() {
 				It("rejects RF change attempted for SC namespace", func() {
-					err := updateNamespaceRF("SC", 3, 2, 3)
+					err := updateNamespaceRF(true, 3, 2, 3, 0)
 					Expect(err).To(HaveOccurred())
 					envtests.NewStatusErrorMatcher().
 						WithMessageSubstrings(
@@ -268,7 +311,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 
 					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
 					nsConf := nsList[0].(map[string]interface{})
-					nsConf["replication-factor"] = 3
+					nsConf[asdbv1.ConfKeyReplicationFactor] = 3
 					nsList[0] = nsConf
 					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
 					current.Spec.Size = 4
@@ -300,7 +343,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 
 					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
 					nsConf := nsList[0].(map[string]interface{})
-					nsConf["replication-factor"] = 3
+					nsConf[asdbv1.ConfKeyReplicationFactor] = 3
 					nsList[0] = nsConf
 					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
 
@@ -319,7 +362,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 				It("rejects RF update in spec.aerospikeConfig.namespaces (above schema max 256)", func() {
 					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
 					// update to RF=257 (above schema max 256)
-					err := updateNamespaceRF("AP", 3, 2, rfAboveSchemaMax)
+					err := updateNamespaceRF(false, 3, 2, rfAboveSchemaMax, 0)
 					Expect(err).To(HaveOccurred())
 
 					envtests.NewStatusErrorMatcher().
@@ -351,8 +394,8 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					// Update RF for test2 and test3 in one update
 					for i := range nsList {
 						nsConf := nsList[i].(map[string]interface{})
-						if nsConf["name"] == namespaceName2 || nsConf["name"] == namespaceName3 {
-							nsConf["replication-factor"] = 3
+						if nsConf[asdbv1.ConfKeyName] == namespaceName2 || nsConf["name"] == namespaceName3 {
+							nsConf[asdbv1.ConfKeyReplicationFactor] = 3
 							nsList[i] = nsConf
 						}
 					}
@@ -373,29 +416,29 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 			Context("positive", func() {
 				It("allows RF increase", func() {
 					// Pre-conditions: size ≥ 3; AP namespace; RF=2; enableDynamicConfigUpdate=true
-					Expect(updateNamespaceRF("AP", 3, 2, 3)).To(Succeed())
+					Expect(updateNamespaceRF(false, 3, 2, 3, 0)).To(Succeed())
 				})
 
 				It("allows RF decrease", func() {
 					// Pre-conditions: AP namespace; RF initially 3; enableDynamicConfigUpdate=true
-					Expect(updateNamespaceRF("AP", 3, 3, 2)).To(Succeed())
+					Expect(updateNamespaceRF(false, 3, 3, 2, 0)).To(Succeed())
 				})
 
 				It("allows no-op RF update (same RF value)", func() {
 					// Pre-conditions: AP namespace; RF=3; enableDynamicConfigUpdate=true; update to same RF
-					Expect(updateNamespaceRF("AP", 3, 3, 3)).To(Succeed())
+					Expect(updateNamespaceRF(false, 3, 3, 3, 0)).To(Succeed())
 				})
 				It("allows RF increase greater than cluster size", func() {
 					// Pre-conditions: size ≥ 3; AP namespace; RF=2; enableDynamicConfigUpdate=true
-					Expect(updateNamespaceRF("AP", 3, 2, 4)).To(Succeed())
+					Expect(updateNamespaceRF(false, 3, 2, 4, 0)).To(Succeed())
 				})
 
 				It("allows RF set to minimum value (RF=1)", func() {
-					Expect(updateNamespaceRF("AP", 2, 2, 1)).To(Succeed())
+					Expect(updateNamespaceRF(false, 2, 2, 1, 0)).To(Succeed())
 				})
 
 				It("allows RF set to maximum allowed (RF = cluster size)", func() {
-					Expect(updateNamespaceRF("AP", 3, 2, 3)).To(Succeed())
+					Expect(updateNamespaceRF(false, 3, 2, 3, 0)).To(Succeed())
 				})
 
 				It("allow RF remove from spec.aerospikeConfig", func() {
@@ -475,7 +518,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					nsList, ok := rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
 					Expect(ok).To(BeTrue())
 					nsConf := nsList[0].(map[string]interface{})
-					nsConf["replication-factor"] = 3
+					nsConf[asdbv1.ConfKeyReplicationFactor] = 3
 					nsList[0] = nsConf
 					rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
 
@@ -491,16 +534,82 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						Validate(err)
 				})
 
-				It("rejects RF update in rackConfig for value above schema max 256)", func() {
+				It("rejects RF update in rackConfig for value above schema max 256", func() {
 					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
 					// update to RF=257 (above schema max 256)
-					err := updateNamespaceRF("AP", 3, 2, rfAboveSchemaMax)
+					err := updateNamespaceRF(false, 3, 2, rfAboveSchemaMax, 1)
 					Expect(err).To(HaveOccurred())
 
 					envtests.NewStatusErrorMatcher().
 						WithMessageSubstrings(
 							"vaerospikecluster.kb.io",
 							"replication-factor Must be less than or equal to 256 ",
+						).
+						Validate(err)
+				})
+				It("rejects RF update when namespace addition rollout is still in progress", func() {
+					// Spec: desired config includes test + test2. Status: deployed rack config only lists "test"
+					// (simulates test2 not yet rolled out). RF change on test2 must be rejected.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						inMemoryNS(namespaceName, 2),
+						inMemoryNS(namespaceName2, 2),
+					}
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{namespaceName, namespaceName2},
+						Racks:      []asdbv1.Rack{{ID: 1}},
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current := &asdbv1.AerospikeCluster{}
+					err = envtests.K8sClient.Get(ctx, clusterNamespacedName, current)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Status must be non-nil on AerospikeConfig or the webhook skips the rollout check.
+					current.Status.AerospikeConfig = current.Spec.AerospikeConfig.DeepCopy()
+					// Deployed / effective rack config: only "test" is present — "test2" not in status yet.
+					current.Status.RackConfig = asdbv1.RackConfig{
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								AerospikeConfig: asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											inMemoryNS(namespaceName, 2),
+										},
+									},
+								},
+							},
+						},
+					}
+
+					err = envtests.K8sClient.Status().Update(ctx, current)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = envtests.K8sClient.Get(ctx, clusterNamespacedName, current)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Single-field RF change for test2 only (spec still lists both namespaces).
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					for i := range nsList {
+						nsConf := nsList[i].(map[string]interface{})
+						if nsConf[asdbv1.ConfKeyName] == namespaceName2 {
+							nsConf[asdbv1.ConfKeyReplicationFactor] = 3
+							nsList[i] = nsConf
+						}
+					}
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"namespace addition rollout is still in progress",
 						).
 						Validate(err)
 				})
@@ -526,7 +635,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 
 					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
 					nsConf := nsList[0].(map[string]interface{})
-					nsConf["replication-factor"] = 3
+					nsConf[asdbv1.ConfKeyReplicationFactor] = 3
 					nsList[0] = nsConf
 					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
 
@@ -558,7 +667,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 
 					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
 					nsConf := nsList[0].(map[string]interface{})
-					nsConf["replication-factor"] = 4
+					nsConf[asdbv1.ConfKeyReplicationFactor] = 4
 					nsList[0] = nsConf
 					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
 
@@ -567,10 +676,11 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 				})
 
 				It("allows adding RF to existing namespace in RackConfig.namespaces", func() {
-					// Preconditions: RackConfig.namespaces has "test". Rack has no InputAerospikeConfig (uses global).
-					// Global has test with RF=2.
-					// Update: Add InputAerospikeConfig to rack with test at RF=3.
-					// Must succeed: rack acquires RF override for namespace already in rackConfig.namespaces.
+					// Create: Global in-memory namespace "test" with RF=2. RackConfig.namespaces includes "test".
+					// Rack 1 has no InputAerospikeConfig (rack-level config comes only from global merge).
+					// Update: Add InputAerospikeConfig on rack 1 with explicit namespace "test" and RF=2
+					// (rack-level override for a namespace already listed in RackConfig.namespaces).
+					// Expect: webhook validation succeeds (single-namespace RF change).
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
@@ -590,7 +700,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					// Add RF to existing "test" namespace in rack (rack had no override before)
 					current.Spec.RackConfig.Racks[0].InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
 						Value: map[string]interface{}{
-							asdbv1.ConfKeyNamespace: []interface{}{inMemoryNS(namespaceName, 2)},
+							asdbv1.ConfKeyNamespace: []interface{}{inMemoryNS(namespaceName, 2)}, // RF=2
 						},
 					}
 
@@ -622,7 +732,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 
 						nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
 						nsConf := nsList[0].(map[string]interface{})
-						nsConf["replication-factor"] = newRF
+						nsConf[asdbv1.ConfKeyReplicationFactor] = newRF
 						nsList[0] = nsConf
 						current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
 

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -464,6 +464,37 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					err = envtests.K8sClient.Update(ctx, current)
 					Expect(err).ToNot(HaveOccurred())
 				})
+
+				It("allows adding replication-factor to namespace that had none on create", func() {
+					// Create: AP namespace in spec.aerospikeConfig without replication-factor key.
+					// Update: set replication-factor to 3 in spec.aerospikeConfig only.
+					apNamespaceNoRF := map[string]interface{}{
+						asdbv1.ConfKeyName: namespaceName,
+						asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+							"type":    "device",
+							"devices": []interface{}{testutil.DefaultDevicePath},
+						},
+					}
+
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{apNamespaceNoRF}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf[asdbv1.ConfKeyReplicationFactor] = 3
+					nsList[0] = nsConf
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).ToNot(HaveOccurred())
+				})
 			})
 		})
 
@@ -612,39 +643,6 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 			})
 
 			Context("positive", func() {
-				It("allows adding RF to existing namespace in RackConfig.namespaces", func() {
-					// Create: Global in-memory namespace "test" with RF=2. RackConfig.namespaces includes "test".
-					// Rack 1 has no InputAerospikeConfig (rack-level config comes only from global merge).
-					// Update: Add InputAerospikeConfig on rack 1 with explicit namespace "test" and RF=2
-					// (rack-level override for a namespace already listed in RackConfig.namespaces).
-					// Expect: webhook validation succeeds (single-namespace RF change).
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						inMemoryNS(namespaceName, 2),
-					}
-					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{namespaceName},
-						Racks:      []asdbv1.Rack{{ID: 1}}, // no InputAerospikeConfig; rack inherits from global
-					}
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).ToNot(HaveOccurred())
-
-					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-					Expect(err).ToNot(HaveOccurred())
-
-					// Add RF to existing "test" namespace in rack (rack had no override before)
-					current.Spec.RackConfig.Racks[0].InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
-						Value: map[string]interface{}{
-							asdbv1.ConfKeyNamespace: []interface{}{inMemoryNS(namespaceName, 2)}, // RF=2
-						},
-					}
-
-					err = envtests.K8sClient.Update(ctx, current)
-					Expect(err).ToNot(HaveOccurred())
-				})
-
 				DescribeTable("allows rack-aware RF increase when consistent across racks",
 					func(size int32, rackCount int, newRF int) {
 						aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -616,65 +616,6 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 			})
 
 			Context("positive", func() {
-				It("allows rack-aware RF increase when consistent across racks", func() {
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{namespaceName},
-						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
-					}
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
-					}
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).ToNot(HaveOccurred())
-
-					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-					Expect(err).ToNot(HaveOccurred())
-
-					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					nsConf := nsList[0].(map[string]interface{})
-					nsConf[asdbv1.ConfKeyReplicationFactor] = 3
-					nsList[0] = nsConf
-					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-
-					err = envtests.K8sClient.Update(ctx, current)
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				It("allows rack-aware RF increase greater than cluster size", func() {
-					// Pre-conditions: size ≥ 3; AP namespace; RF=2; enableDynamicConfigUpdate=true
-					// spec.aerospikeConfig.namespaces: test has RF = 2 during cluster creation.
-					// spec.rackConfig.aerospikeConfig.namespaces: test has RF = 2 during cluster creation.
-					// update RF for test2 to 4 in spec.rackConfig.aerospikeConfig.namespaces.
-					// must succeed because RF is consistent across racks.
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{namespaceName2},
-						Racks:      []asdbv1.Rack{{ID: 1}},
-					}
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
-					}
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).ToNot(HaveOccurred())
-
-					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-					Expect(err).ToNot(HaveOccurred())
-
-					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					nsConf := nsList[0].(map[string]interface{})
-					nsConf[asdbv1.ConfKeyReplicationFactor] = 4
-					nsList[0] = nsConf
-					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-
-					err = envtests.K8sClient.Update(ctx, current)
-					Expect(err).ToNot(HaveOccurred())
-				})
-
 				It("allows adding RF to existing namespace in RackConfig.namespaces", func() {
 					// Create: Global in-memory namespace "test" with RF=2. RackConfig.namespaces includes "test".
 					// Rack 1 has no InputAerospikeConfig (rack-level config comes only from global merge).

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -348,19 +348,6 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						Validate(err)
 				})
 
-				It("rejects RF change on SC namespace (misconfigured type)", func() {
-					// "RF change on misconfigured namespace type": In envtest we cannot have cluster state.
-					// We test the same rejection as "RF change for SC namespace" – SC namespace cannot have RF updated.
-					err := updateSCNamespaceRF(2, 2, 1)
-					Expect(err).To(HaveOccurred())
-					envtests.NewStatusErrorMatcher().
-						WithMessageSubstrings(
-							"vaerospikecluster.kb.io",
-							"replication-factor cannot be updated for SC namespaces",
-						).
-						Validate(err)
-				})
-
 				It("rejects RF update in spec.aerospikeConfig.namespaces (above schema max 256)", func() {
 					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
 					// update to RF=257 (above schema max 256)
@@ -408,6 +395,10 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 				It("allows no-op RF update (same RF value)", func() {
 					// Pre-conditions: AP namespace; RF=3; enableDynamicConfigUpdate=true; update to same RF
 					updateAPNamespaceRF(3, 3, 3)
+				})
+				It("allows RF increase greater than cluster size for AP namespace", func() {
+					// Pre-conditions: size ≥ 3; AP namespace; RF=2; enableDynamicConfigUpdate=true
+					updateAPNamespaceRF(3, 2, 4)
 				})
 
 				It("allows RF set to minimum value (RF=1)", func() {
@@ -728,11 +719,43 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					Expect(err).ToNot(HaveOccurred())
 				})
 
+				It("allows rack-aware RF increase greater than cluster size", func() {
+					// Pre-conditions: size ≥ 3; AP namespace; RF=2; enableDynamicConfigUpdate=true
+					// spec.aerospikeConfig.namespaces: test has RF = 2 during cluster creation.
+					// spec.rackConfig.aerospikeConfig.namespaces: test has RF = 2 during cluster creation.
+					// update RF for test2 to 4 in spec.rackConfig.aerospikeConfig.namespaces.
+					// must succeed because RF is consistent across racks.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{namespaceName2},
+						Racks:      []asdbv1.Rack{{ID: 1}},
+					}
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf["replication-factor"] = 4
+					nsList[0] = nsConf
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
 				It("allow adding namespace to rackConfig.namespaces with RF", func() {
 					// Preconditions: Global namespace test, RF=2.
 					// Rack 1 namespace test, RF=2.
-					// Update: add namespace "other" to rackConfig.namespaces with RF=3.
-					// must succeed because namespace "other" is not in spec.rackConfig.namespaces
+					// Update: add namespace "test2" to rackConfig.namespaces with RF=3.
+					// must succeed because namespace "test2" is not in spec.rackConfig.namespaces
 					memNS := func(name string, rf int) map[string]interface{} {
 						return map[string]interface{}{
 							"name":               name,
@@ -769,15 +792,76 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
 					Expect(err).ToNot(HaveOccurred())
 
-					// Namespace "other" is not in spec.rackConfig.namespaces
+					// Add Namespace "test2" in spec.rackConfig.namespaces with RF = 3
 					current.Spec.RackConfig.Racks[0].InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
 						Value: map[string]interface{}{
-							asdbv1.ConfKeyNamespace: []interface{}{memNS("other", 3)},
+							asdbv1.ConfKeyNamespace: []interface{}{memNS(namespaceName2, 3)},
 						},
 					}
 
 					err = envtests.K8sClient.Update(ctx, current)
 					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("allow removing replication-factor from namespace in rack aerospikeConfig", func() {
+					// Create: global + rack have test and test2, both RF=2; rackConfig.namespaces lists both.
+					// Update: rack patch for "test" omits replication-factor (inherits via merge with global).
+					memNS := func(name string) map[string]interface{} {
+						return map[string]interface{}{
+							"name":               name,
+							"replication-factor": 2,
+							asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+								"type":      "memory",
+								"data-size": 1073741824,
+							},
+						}
+					}
+					removeRF := map[string]interface{}{
+						"name": namespaceName2,
+						asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+							"type":      "memory",
+							"data-size": 1073741824,
+						},
+					}
+
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 1)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						memNS(namespaceName), memNS(namespaceName2),
+					}
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{namespaceName, namespaceName2},
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											memNS(namespaceName), memNS(namespaceName2),
+										},
+									},
+								},
+							},
+						},
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
+						Value: map[string]interface{}{
+							asdbv1.ConfKeyNamespace: []interface{}{
+								memNS(namespaceName),
+								removeRF,
+							},
+						},
+					}
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 		})

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -43,20 +43,21 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 	clusterNamespacedName := test.GetNamespacedName(clusterName, testNs)
 
 	// apNamespaceConfig returns an AP namespace config for envtest.
-	apNamespaceConfig := func(name string, rf int) map[string]interface{} {
+	apNamespaceConfig := func(name string, rf int, device string) map[string]interface{} {
 		return map[string]interface{}{
 			"name":               name,
 			"replication-factor": rf,
 			asdbv1.ConfKeyStorageEngine: map[string]interface{}{
-				"type":    "device",
-				"devices": []interface{}{"/test/dev/xvdf"},
+				"type": "device",
+				// "devices": []interface{}{"/test/dev/xvdf"},
+				"devices": []interface{}{device},
 			},
 		}
 	}
 
 	// scNamespaceConfig returns an SC namespace config for envtest.
 	scNamespaceConfig := func(name string, rf int) map[string]interface{} {
-		cfg := apNamespaceConfig(name, rf)
+		cfg := apNamespaceConfig(name, rf, "/test/dev/xvdf")
 		cfg["strong-consistency"] = true
 
 		return cfg
@@ -64,16 +65,16 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 
 	// apNamespaceWithDevice is like apNamespaceConfig(RF=2) but uses a distinct device path per namespace
 	// (required when multiple AP namespaces coexist).
-	apNamespaceWithDevice := func(name string, device string) map[string]interface{} {
-		return map[string]interface{}{
-			"name":               name,
-			"replication-factor": 2,
-			asdbv1.ConfKeyStorageEngine: map[string]interface{}{
-				"type":    "device",
-				"devices": []interface{}{device},
-			},
-		}
-	}
+	// apNamespaceWithDevice := func(name string, device string) map[string]interface{} {
+	// 	return map[string]interface{}{
+	// 		"name":               name,
+	// 		"replication-factor": 2,
+	// 		asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+	// 			"type":    "device",
+	// 			"devices": []interface{}{device},
+	// 		},
+	// 	}
+	// }
 
 	AfterEach(func() {
 		aeroCluster := &asdbv1.AerospikeCluster{
@@ -91,7 +92,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 		aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
 		aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-			apNamespaceConfig("test", initialRF),
+			apNamespaceConfig("test", initialRF, "/test/dev/xvdf"),
 		}
 
 		err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -161,7 +162,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 				It("allows AP namespace with RF greater than cluster size on deploy", func() {
 					// AP mode: replication-factor may exceed cluster size (unlike SC); see validateNamespaceReplicationFactor.
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
-					ns := apNamespaceWithDevice("test", "/test/dev/xvdf")
+					ns := apNamespaceConfig("test", 4, "/test/dev/xvdf")
 					ns["replication-factor"] = 4
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{ns}
 
@@ -186,7 +187,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2),
+											apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 										},
 									},
 								},
@@ -196,7 +197,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 3),
+											apNamespaceConfig("test", 3, "/test/dev/xvdf"),
 										},
 									},
 								},
@@ -204,7 +205,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -232,7 +233,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								AerospikeConfig: asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", maxSchemaRF),
+											apNamespaceConfig("test", maxSchemaRF, "/test/dev/xvdf"),
 										},
 									},
 								},
@@ -242,7 +243,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								AerospikeConfig: asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", maxSchemaRF),
+											apNamespaceConfig("test", maxSchemaRF, "/test/dev/xvdf"),
 										},
 									},
 								},
@@ -250,7 +251,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", maxSchemaRF),
+						apNamespaceConfig("test", maxSchemaRF, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -278,7 +279,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -310,7 +311,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(false)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -342,7 +343,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 0),
+						apNamespaceConfig("test", 0, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -376,7 +377,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -445,7 +446,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2),
+											apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 										},
 									},
 								},
@@ -455,7 +456,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2),
+											apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 										},
 									},
 								},
@@ -463,7 +464,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -500,7 +501,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceWithDevice("test", "/test/dev/xvdf"),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{"test", "test2", "test3"},
@@ -510,7 +511,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceWithDevice("test2", "/test/dev/xvdg"),
+											apNamespaceConfig("test2", 2, "/test/dev/xvdg"),
 										},
 									},
 								},
@@ -520,7 +521,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceWithDevice("test3", "/test/dev/xvdh"),
+											apNamespaceConfig("test3", 2, "/test/dev/xvdh"),
 										},
 									},
 								},
@@ -601,8 +602,8 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceWithDevice("test", "/test/dev/xvdf"),
-						apNamespaceWithDevice("test2", "/test/dev/xvdg"),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig("test2", 2, "/test/dev/xvdg"),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{"test", "test2"},
@@ -612,7 +613,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceWithDevice("test", "/test/dev/xvdf"),
+											apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 										},
 									},
 								},
@@ -622,7 +623,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceWithDevice("test2", "/test/dev/xvdg"),
+											apNamespaceConfig("test2", 2, "/test/dev/xvdg"),
 										},
 									},
 								},
@@ -683,7 +684,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -719,7 +720,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2),
+						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/test/testutil"
 )
 
-var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtests)", func() {
+var _ = Describe("AerospikeCluster dynamic replication-factor validation", func() {
 	const (
 		clusterName       = "dynamic-rf-webhook-cluster"
 		testNs            = "default"
@@ -79,39 +79,20 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 		}
 	}
 
-	// updateAPNamespaceRF creates a cluster with one AP namespace (initialRF),
-	// updates its replication-factor to newRF, and expects the update to succeed.
-	updateAPNamespaceRF := func(size int32, initialRF, newRF int) {
-		aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
-		aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-			apNamespaceConfig(namespaceName, initialRF, defaultDevicePath),
+	// updateNamespaceRF creates a cluster with one namespace (AP or SC), updates its RF to newRF,
+	// and returns the update error. namespaceType is "AP" or "SC".
+	updateNamespaceRF := func(namespaceType string, size int32, initialRF, newRF int) error {
+		var nsConfig map[string]interface{}
+		switch namespaceType {
+		case "SC":
+			nsConfig = scNamespaceConfig(namespaceName, initialRF)
+		default:
+			nsConfig = apNamespaceConfig(namespaceName, initialRF, defaultDevicePath)
 		}
 
-		err := envtests.K8sClient.Create(ctx, aeroCluster)
-		Expect(err).ToNot(HaveOccurred())
-
-		current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-		Expect(err).ToNot(HaveOccurred())
-
-		nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-		nsConf := nsList[0].(map[string]interface{})
-		nsConf["replication-factor"] = newRF
-		nsList[0] = nsConf
-		current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-
-		err = envtests.K8sClient.Update(ctx, current)
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	// updateSCNamespaceRF creates a cluster with one SC namespace (initialRF),
-	// updates its replication-factor to newRF, and returns the error from the update.
-	updateSCNamespaceRF := func(size int32, initialRF, newRF int) error {
 		aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
 		aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-			scNamespaceConfig(namespaceName, initialRF),
-		}
+		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{nsConfig}
 
 		err := envtests.K8sClient.Create(ctx, aeroCluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -141,11 +122,12 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 	Context("Deploy validation", func() {
 		Context("spec.aerospikeConfig (replication-factor)", func() {
 			Context("negative", func() {
-				It("rejects RF > cluster size for SC namespace", func() {
-					// SC namespace: replication-factor cannot exceed cluster size.
+				// Bug: https://aerospike.atlassian.net/browse/KO-484
+				It("rejects invalid RF value (zero or negative)", func() {
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						scNamespaceConfig(namespaceName, 5), // RF=5 > size=2
+						apNamespaceConfig(namespaceName, 0, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -154,8 +136,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					envtests.NewStatusErrorMatcher().
 						WithMessageSubstrings(
 							"vaerospikecluster.kb.io",
-							"replication-factor",
-							"cannot be more than cluster size",
+							"replication-factor can not be zero or negative",
 						).
 						Validate(err)
 				})
@@ -166,7 +147,6 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					// AP mode: replication-factor may exceed cluster size (unlike SC); see validateNamespaceReplicationFactor.
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					ns := apNamespaceConfig(namespaceName, 4, defaultDevicePath)
-					ns["replication-factor"] = 4
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{ns}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -267,7 +247,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 		Context("spec.aerospikeConfig (replication-factor)", func() {
 			Context("negative", func() {
 				It("rejects RF change attempted for SC namespace", func() {
-					err := updateSCNamespaceRF(3, 2, 3)
+					err := updateNamespaceRF("SC", 3, 2, 3)
 					Expect(err).To(HaveOccurred())
 					envtests.NewStatusErrorMatcher().
 						WithMessageSubstrings(
@@ -340,47 +320,10 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						Validate(err)
 				})
 
-				// Bug: https://aerospike.atlassian.net/browse/KO-484
-				It("rejects invalid RF value (zero or negative)", func() {
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 0, defaultDevicePath),
-					}
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).To(HaveOccurred())
-
-					envtests.NewStatusErrorMatcher().
-						WithMessageSubstrings(
-							"vaerospikecluster.kb.io",
-							"replication-factor can not be zero or negative",
-						).
-						Validate(err)
-				})
-
 				It("rejects RF update in spec.aerospikeConfig.namespaces (above schema max 256)", func() {
 					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
 					// update to RF=257 (above schema max 256)
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
-					}
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).ToNot(HaveOccurred())
-
-					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-					Expect(err).ToNot(HaveOccurred())
-
-					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					nsConf := nsList[0].(map[string]interface{})
-					nsConf["replication-factor"] = rfAboveSchemaMax
-					nsList[0] = nsConf
-					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-
-					err = envtests.K8sClient.Update(ctx, current)
+					err := updateNamespaceRF("AP", 3, 2, rfAboveSchemaMax)
 					Expect(err).To(HaveOccurred())
 
 					envtests.NewStatusErrorMatcher().
@@ -393,35 +336,34 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 			})
 
 			Context("positive", func() {
-				It("allows basic RF increase for AP namespace", func() {
+				It("allows RF increase", func() {
 					// Pre-conditions: size ≥ 3; AP namespace; RF=2; enableDynamicConfigUpdate=true
-					updateAPNamespaceRF(3, 2, 3)
+					Expect(updateNamespaceRF("AP", 3, 2, 3)).To(Succeed())
 				})
 
-				It("allows basic RF decrease for AP namespace", func() {
+				It("allows RF decrease", func() {
 					// Pre-conditions: AP namespace; RF initially 3; enableDynamicConfigUpdate=true
-					updateAPNamespaceRF(3, 3, 2)
+					Expect(updateNamespaceRF("AP", 3, 3, 2)).To(Succeed())
 				})
 
 				It("allows no-op RF update (same RF value)", func() {
 					// Pre-conditions: AP namespace; RF=3; enableDynamicConfigUpdate=true; update to same RF
-					updateAPNamespaceRF(3, 3, 3)
+					Expect(updateNamespaceRF("AP", 3, 3, 3)).To(Succeed())
 				})
-				It("allows RF increase greater than cluster size for AP namespace", func() {
+				It("allows RF increase greater than cluster size", func() {
 					// Pre-conditions: size ≥ 3; AP namespace; RF=2; enableDynamicConfigUpdate=true
-					updateAPNamespaceRF(3, 2, 4)
+					Expect(updateNamespaceRF("AP", 3, 2, 4)).To(Succeed())
 				})
 
 				It("allows RF set to minimum value (RF=1)", func() {
-					updateAPNamespaceRF(2, 2, 1)
+					Expect(updateNamespaceRF("AP", 2, 2, 1)).To(Succeed())
 				})
 
 				It("allows RF set to maximum allowed (RF = cluster size)", func() {
-					const clusterSize = 3
-					updateAPNamespaceRF(clusterSize, 2, clusterSize)
+					Expect(updateNamespaceRF("AP", 3, 2, 3)).To(Succeed())
 				})
 
-				It("allow RF remove from spec.aerospikeConfig for AP namespace", func() {
+				It("allow RF remove from spec.aerospikeConfig", func() {
 					// Create: one AP namespace with RF=2.
 					// Update: remove replication-factor from that namespace block. Must succeed.
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
@@ -696,29 +638,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 				It("rejects RF update in rackConfig for value above schema max 256)", func() {
 					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
 					// update to RF=257 (above schema max 256)
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{namespaceName},
-						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
-					}
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
-					}
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).ToNot(HaveOccurred())
-
-					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-					Expect(err).ToNot(HaveOccurred())
-
-					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					nsConf := nsList[0].(map[string]interface{})
-					nsConf["replication-factor"] = rfAboveSchemaMax
-					nsList[0] = nsConf
-					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-
-					err = envtests.K8sClient.Update(ctx, current)
+					err := updateNamespaceRF("AP", 3, 2, rfAboveSchemaMax)
 					Expect(err).To(HaveOccurred())
 
 					envtests.NewStatusErrorMatcher().

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -68,15 +68,16 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 		return cfg
 	}
 
-	AfterEach(func() {
-		aeroCluster := &asdbv1.AerospikeCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      clusterNamespacedName.Name,
-				Namespace: clusterNamespacedName.Namespace,
+	inMemoryNS := func(name string, rf int) map[string]interface{} {
+		return map[string]interface{}{
+			"name":               name,
+			"replication-factor": rf,
+			asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+				"type":      "memory",
+				"data-size": 1073741824,
 			},
 		}
-		_ = envtests.K8sClient.Delete(ctx, aeroCluster)
-	})
+	}
 
 	// updateAPNamespaceRF creates a cluster with one AP namespace (initialRF),
 	// updates its replication-factor to newRF, and expects the update to succeed.
@@ -126,6 +127,16 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 
 		return envtests.K8sClient.Update(ctx, current)
 	}
+
+	AfterEach(func() {
+		aeroCluster := &asdbv1.AerospikeCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterNamespacedName.Name,
+				Namespace: clusterNamespacedName.Namespace,
+			},
+		}
+		_ = envtests.K8sClient.Delete(ctx, aeroCluster)
+	})
 
 	Context("Deploy validation", func() {
 		Context("spec.aerospikeConfig (replication-factor)", func() {
@@ -408,6 +419,34 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 				It("allows RF set to maximum allowed (RF = cluster size)", func() {
 					const clusterSize = 3
 					updateAPNamespaceRF(clusterSize, 2, clusterSize)
+				})
+
+				It("allow RF remove from spec.aerospikeConfig for AP namespace", func() {
+					// Create: one AP namespace with RF=2.
+					// Update: remove replication-factor from that namespace block. Must succeed.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					apNamespaceNoRF := map[string]interface{}{
+						"name": namespaceName,
+						asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+							"type":    "device",
+							"devices": []interface{}{defaultDevicePath},
+						},
+					}
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{apNamespaceNoRF}
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 		})
@@ -756,21 +795,10 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					// Rack 1 namespace test, RF=2.
 					// Update: add namespace "test2" to rackConfig.namespaces with RF=3.
 					// must succeed because namespace "test2" is not in spec.rackConfig.namespaces
-					memNS := func(name string, rf int) map[string]interface{} {
-						return map[string]interface{}{
-							"name":               name,
-							"replication-factor": rf,
-							asdbv1.ConfKeyStorageEngine: map[string]interface{}{
-								"type":      "memory",
-								"data-size": 1073741824,
-							},
-						}
-					}
-
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 1)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						memNS(namespaceName, 2),
+						inMemoryNS(namespaceName, 2),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{namespaceName},
@@ -779,7 +807,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								ID: 1,
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{memNS(namespaceName, 2)},
+										asdbv1.ConfKeyNamespace: []interface{}{inMemoryNS(namespaceName, 2)},
 									},
 								},
 							},
@@ -795,7 +823,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					// Add Namespace "test2" in spec.rackConfig.namespaces with RF = 3
 					current.Spec.RackConfig.Racks[0].InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
 						Value: map[string]interface{}{
-							asdbv1.ConfKeyNamespace: []interface{}{memNS(namespaceName2, 3)},
+							asdbv1.ConfKeyNamespace: []interface{}{inMemoryNS(namespaceName2, 3)},
 						},
 					}
 
@@ -803,19 +831,9 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					Expect(err).NotTo(HaveOccurred())
 				})
 
-				It("allow removing replication-factor from namespace in rack aerospikeConfig", func() {
+				It("allow removing replication-factor from namespace in rackConfig.aerospikeConfig", func() {
 					// Create: global + rack have test and test2, both RF=2; rackConfig.namespaces lists both.
 					// Update: rack patch for "test" omits replication-factor (inherits via merge with global).
-					memNS := func(name string) map[string]interface{} {
-						return map[string]interface{}{
-							"name":               name,
-							"replication-factor": 2,
-							asdbv1.ConfKeyStorageEngine: map[string]interface{}{
-								"type":      "memory",
-								"data-size": 1073741824,
-							},
-						}
-					}
 					removeRF := map[string]interface{}{
 						"name": namespaceName2,
 						asdbv1.ConfKeyStorageEngine: map[string]interface{}{
@@ -827,7 +845,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 1)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						memNS(namespaceName), memNS(namespaceName2),
+						inMemoryNS(namespaceName, 2), inMemoryNS(namespaceName2, 2),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{namespaceName, namespaceName2},
@@ -837,7 +855,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											memNS(namespaceName), memNS(namespaceName2),
+											inMemoryNS(namespaceName, 2), inMemoryNS(namespaceName2, 2),
 										},
 									},
 								},
@@ -854,7 +872,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					current.Spec.RackConfig.Racks[0].InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
 						Value: map[string]interface{}{
 							asdbv1.ConfKeyNamespace: []interface{}{
-								memNS(namespaceName),
+								inMemoryNS(namespaceName, 2),
 								removeRF,
 							},
 						},

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -35,8 +35,14 @@ import (
 
 var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtests)", func() {
 	const (
-		clusterName = "dynamic-rf-webhook-cluster"
-		testNs      = "default"
+		clusterName       = "dynamic-rf-webhook-cluster"
+		testNs            = "default"
+		maxSchemaRF       = 256
+		rfAboveSchemaMax  = 257
+		defaultDevicePath = "/test/dev/xvdf"
+		namespaceName     = "test"
+		namespaceName2    = "test2"
+		namespaceName3    = "test3"
 	)
 
 	ctx := context.TODO()
@@ -48,8 +54,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 			"name":               name,
 			"replication-factor": rf,
 			asdbv1.ConfKeyStorageEngine: map[string]interface{}{
-				"type": "device",
-				// "devices": []interface{}{"/test/dev/xvdf"},
+				"type":    "device",
 				"devices": []interface{}{device},
 			},
 		}
@@ -57,24 +62,11 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 
 	// scNamespaceConfig returns an SC namespace config for envtest.
 	scNamespaceConfig := func(name string, rf int) map[string]interface{} {
-		cfg := apNamespaceConfig(name, rf, "/test/dev/xvdf")
+		cfg := apNamespaceConfig(name, rf, defaultDevicePath)
 		cfg["strong-consistency"] = true
 
 		return cfg
 	}
-
-	// apNamespaceWithDevice is like apNamespaceConfig(RF=2) but uses a distinct device path per namespace
-	// (required when multiple AP namespaces coexist).
-	// apNamespaceWithDevice := func(name string, device string) map[string]interface{} {
-	// 	return map[string]interface{}{
-	// 		"name":               name,
-	// 		"replication-factor": 2,
-	// 		asdbv1.ConfKeyStorageEngine: map[string]interface{}{
-	// 			"type":    "device",
-	// 			"devices": []interface{}{device},
-	// 		},
-	// 	}
-	// }
 
 	AfterEach(func() {
 		aeroCluster := &asdbv1.AerospikeCluster{
@@ -92,7 +84,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 		aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
 		aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-			apNamespaceConfig("test", initialRF, "/test/dev/xvdf"),
+			apNamespaceConfig(namespaceName, initialRF, defaultDevicePath),
 		}
 
 		err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -117,7 +109,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 		aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
 		aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-			scNamespaceConfig("test", initialRF),
+			scNamespaceConfig(namespaceName, initialRF),
 		}
 
 		err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -142,7 +134,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					// SC namespace: replication-factor cannot exceed cluster size.
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						scNamespaceConfig("test", 5), // RF=5 > size=2
+						scNamespaceConfig(namespaceName, 5), // RF=5 > size=2
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -162,7 +154,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 				It("allows AP namespace with RF greater than cluster size on deploy", func() {
 					// AP mode: replication-factor may exceed cluster size (unlike SC); see validateNamespaceReplicationFactor.
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
-					ns := apNamespaceConfig("test", 4, "/test/dev/xvdf")
+					ns := apNamespaceConfig(namespaceName, 4, defaultDevicePath)
 					ns["replication-factor"] = 4
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{ns}
 
@@ -180,14 +172,14 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test"},
+						Namespaces: []string{namespaceName},
 						Racks: []asdbv1.Rack{
 							{
 								ID: 1,
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+											apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 										},
 									},
 								},
@@ -197,7 +189,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 3, "/test/dev/xvdf"),
+											apNamespaceConfig(namespaceName, 3, defaultDevicePath),
 										},
 									},
 								},
@@ -205,7 +197,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -222,18 +214,17 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 
 			Context("positive", func() {
 				It("allows rack-aware deploy with replication-factor 256 in aerospikeConfig and all racks (schema max)", func() {
-					const maxSchemaRF = 256
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test"},
+						Namespaces: []string{namespaceName},
 						Racks: []asdbv1.Rack{
 							{
 								ID: 1,
 								AerospikeConfig: asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", maxSchemaRF, "/test/dev/xvdf"),
+											apNamespaceConfig(namespaceName, maxSchemaRF, defaultDevicePath),
 										},
 									},
 								},
@@ -243,7 +234,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								AerospikeConfig: asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", maxSchemaRF, "/test/dev/xvdf"),
+											apNamespaceConfig(namespaceName, maxSchemaRF, defaultDevicePath),
 										},
 									},
 								},
@@ -251,7 +242,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", maxSchemaRF, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, maxSchemaRF, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -279,7 +270,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -311,7 +302,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(false)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -343,7 +334,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 0, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 0, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -373,11 +364,10 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 				It("rejects RF update in spec.aerospikeConfig.namespaces (above schema max 256)", func() {
 					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
 					// update to RF=257 (above schema max 256)
-					const rfAboveSchemaMax = 257
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -439,14 +429,14 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test"},
+						Namespaces: []string{namespaceName},
 						Racks: []asdbv1.Rack{
 							{
 								ID: 1,
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+											apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 										},
 									},
 								},
@@ -456,7 +446,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+											apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 										},
 									},
 								},
@@ -464,7 +454,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -501,17 +491,17 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test", "test2", "test3"},
+						Namespaces: []string{namespaceName, namespaceName2, namespaceName3},
 						Racks: []asdbv1.Rack{
 							{
 								ID: 1,
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test2", 2, "/test/dev/xvdg"),
+											apNamespaceConfig(namespaceName2, 2, "/test/dev/xvdg"),
 										},
 									},
 								},
@@ -521,7 +511,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test3", 2, "/test/dev/xvdh"),
+											apNamespaceConfig(namespaceName3, 2, "/test/dev/xvdh"),
 										},
 									},
 								},
@@ -602,18 +592,18 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
-						apNamespaceConfig("test2", 2, "/test/dev/xvdg"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName2, 2, "/test/dev/xvdg"),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test", "test2"},
+						Namespaces: []string{namespaceName, namespaceName2},
 						Racks: []asdbv1.Rack{
 							{
 								ID: 1,
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+											apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 										},
 									},
 								},
@@ -623,7 +613,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test2", 2, "/test/dev/xvdg"),
+											apNamespaceConfig(namespaceName2, 2, "/test/dev/xvdg"),
 										},
 									},
 								},
@@ -676,15 +666,14 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 				It("rejects RF update in rackConfig for value above schema max 256)", func() {
 					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
 					// update to RF=257 (above schema max 256)
-					const rfAboveSchemaMax = 257
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test"},
+						Namespaces: []string{namespaceName},
 						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -716,11 +705,11 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test"},
+						Namespaces: []string{namespaceName},
 						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2, "/test/dev/xvdf"),
+						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -758,16 +747,16 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 1)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						memNS("test", 2),
+						memNS(namespaceName, 2),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test"},
+						Namespaces: []string{namespaceName},
 						Racks: []asdbv1.Rack{
 							{
 								ID: 1,
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{memNS("test", 2)},
+										asdbv1.ConfKeyNamespace: []interface{}{memNS(namespaceName, 2)},
 									},
 								},
 							},

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -152,10 +152,6 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 			},
 		}
 		Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
-		Expect(testCluster.CleanupPVC(
-			envtests.K8sClient,
-			clusterNamespacedName.Namespace,
-			clusterNamespacedName.Name)).ToNot(HaveOccurred())
 	})
 
 	Context("Deploy validation", func() {

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -1,0 +1,465 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/test"
+	testCluster "github.com/aerospike/aerospike-kubernetes-operator/v4/test/cluster"
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/test/envtests"
+)
+
+var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtests)", func() {
+	const (
+		clusterName = "dynamic-rf-webhook-cluster"
+		testNs      = "default"
+	)
+
+	ctx := context.TODO()
+	clusterNamespacedName := test.GetNamespacedName(clusterName, testNs)
+
+	// apNamespaceConfig returns an AP (non-strong-consistency) namespace config for envtest.
+	apNamespaceConfig := func(name string, rf int) map[string]interface{} {
+		return map[string]interface{}{
+			"name":               name,
+			"replication-factor": rf,
+			asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+				"type":    "device",
+				"devices": []interface{}{"/test/dev/xvdf"},
+			},
+		}
+	}
+
+	// scNamespaceConfig returns an SC (strong-consistency) namespace config for envtest.
+	scNamespaceConfig := func(name string, rf int) map[string]interface{} {
+		cfg := apNamespaceConfig(name, rf)
+		cfg["strong-consistency"] = true
+
+		return cfg
+	}
+
+	AfterEach(func() {
+		aeroCluster := &asdbv1.AerospikeCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterNamespacedName.Name,
+				Namespace: clusterNamespacedName.Namespace,
+			},
+		}
+		_ = envtests.K8sClient.Delete(ctx, aeroCluster)
+	})
+
+	// updateAPNamespaceRF creates a cluster with one AP namespace (initialRF),
+	// updates its replication-factor to newRF, and expects the update to succeed.
+	updateAPNamespaceRF := func(size int32, initialRF, newRF int) {
+		aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
+		aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+			apNamespaceConfig("test", initialRF),
+		}
+
+		err := envtests.K8sClient.Create(ctx, aeroCluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+		Expect(err).ToNot(HaveOccurred())
+
+		nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+		nsConf := nsList[0].(map[string]interface{})
+		nsConf["replication-factor"] = newRF
+		nsList[0] = nsConf
+		current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+		err = envtests.K8sClient.Update(ctx, current)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	// updateSCNamespaceRF creates a cluster with one SC namespace (initialRF),
+	// updates its replication-factor to newRF, and returns the error from the update.
+	updateSCNamespaceRF := func(size int32, initialRF, newRF int) error {
+		aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
+		aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+		aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+			scNamespaceConfig("test", initialRF),
+		}
+
+		err := envtests.K8sClient.Create(ctx, aeroCluster)
+		Expect(err).ToNot(HaveOccurred())
+
+		current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+		Expect(err).ToNot(HaveOccurred())
+
+		nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+		nsConf := nsList[0].(map[string]interface{})
+		nsConf["replication-factor"] = newRF
+		nsList[0] = nsConf
+		current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+		return envtests.K8sClient.Update(ctx, current)
+	}
+
+	Context("Deploy validation", func() {
+		Context("spec.aerospikeConfig (replication-factor)", func() {
+			Context("negative", func() {
+				It("rejects RF > cluster size for SC namespace", func() {
+					// SC namespace: replication-factor cannot exceed cluster size.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						scNamespaceConfig("test", 5), // RF=5 > size=2
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"replication-factor",
+							"cannot be more than cluster size",
+						).
+						Validate(err)
+				})
+			})
+		})
+	})
+
+	Context("Update validation", func() {
+		Context("spec.aerospikeConfig (replication-factor)", func() {
+			Context("negative", func() {
+				It("rejects RF change attempted for SC namespace", func() {
+					err := updateSCNamespaceRF(2, 2, 5)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"replication-factor cannot be updated for SC namespaces",
+						).
+						Validate(err)
+				})
+
+				It("rejects multiple namespaces' RF changed in a single update", func() {
+					// Rack-aware cluster with two racks so we have two "name@rackID" entries; change both RFs.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceConfig("test", 2),
+										},
+									},
+								},
+							},
+							{
+								ID: 2,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceConfig("test", 2),
+										},
+									},
+								},
+							},
+						},
+					}
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Change RF in both racks (update both rack configs) to trigger "multiple namespaces at the same time".
+					for i := range current.Spec.RackConfig.Racks {
+						rack := &current.Spec.RackConfig.Racks[i]
+						if rack.InputAerospikeConfig != nil && rack.InputAerospikeConfig.Value != nil {
+							nsList, ok := rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+							if ok && len(nsList) > 0 {
+								nsConf := nsList[0].(map[string]interface{})
+								nsConf["replication-factor"] = 3
+								nsList[0] = nsConf
+								rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+							}
+						}
+					}
+
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf["replication-factor"] = 3
+					nsList[0] = nsConf
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"cannot update replication-factor for multiple namespaces at the same time",
+						).
+						Validate(err)
+				})
+
+				It("rejects RF change combined with unrelated spec changes", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf["replication-factor"] = 3
+					nsList[0] = nsConf
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+					// Change another field alongside RF update.
+					current.Spec.Size = 4
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"when updating replication-factor",
+							"no other fields",
+						).
+						Validate(err)
+				})
+
+				It("rejects rack-aware create when RF values are mismatched across racks", func() {
+					// Create with two racks; same namespace has RF=2 in rack 1 and RF=3 in rack 2.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								AerospikeConfig: asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceConfig("test", 2),
+										},
+									},
+								},
+							},
+							{
+								ID: 2,
+								AerospikeConfig: asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceConfig("test", 3),
+										},
+									},
+								},
+							},
+						},
+					}
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"different replication-factor values across racks",
+						).
+						Validate(err)
+				})
+
+				It("rejects RF update when enableDynamicConfigUpdate is false", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(false)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf["replication-factor"] = 3
+					nsList[0] = nsConf
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"enableDynamicConfigUpdate",
+							"to be set to true",
+						).
+						Validate(err)
+				})
+
+				It("rejects invalid RF value (zero or negative)", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 0),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"replication-factor",
+						).
+						Validate(err)
+				})
+
+				It("rejects RF change on SC namespace (misconfigured type)", func() {
+					// "RF change on misconfigured namespace type": In envtest we cannot have cluster state.
+					// We test the same rejection as "RF change for SC namespace" – SC namespace cannot have RF updated.
+					err := updateSCNamespaceRF(2, 2, 1)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"replication-factor cannot be updated for SC namespaces",
+						).
+						Validate(err)
+				})
+
+				It("rejects RF change on namespace missing from rackConfig", func() {
+					// Rack-aware cluster: namespace "other" in aerospikeConfig but not in rackConfig.Namespaces.
+					// If the webhook validates that RF changes only apply to namespaces in rackConfig, it should reject.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"}, // "other" is not listed
+						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
+					}
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 2),
+						apNamespaceConfig("other", 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Change RF for "other" (namespace not in rackConfig.Namespaces).
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					otherConf := nsList[1].(map[string]interface{})
+					otherConf["replication-factor"] = 3
+					nsList[1] = otherConf
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					// Skip if webhook does not yet validate namespace-in-rackConfig for RF updates.
+					if err == nil {
+						Skip("webhook does not reject RF change on namespace missing from rackConfig")
+					}
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings("vaerospikecluster.kb.io",
+							"device /test/dev/xvdf is already being referenced",
+							"in multiple namespaces (test, other)").
+						Validate(err)
+				})
+			})
+
+			Context("positive", func() {
+				It("allows basic RF increase for AP namespace", func() {
+					// Pre-conditions: size ≥ 3; AP namespace; RF=2; enableDynamicConfigUpdate=true
+					updateAPNamespaceRF(3, 2, 3)
+				})
+
+				It("allows basic RF decrease for AP namespace", func() {
+					// Pre-conditions: AP namespace; RF initially 3; enableDynamicConfigUpdate=true
+					updateAPNamespaceRF(3, 3, 2)
+				})
+
+				It("allows no-op RF update (same RF value)", func() {
+					// Pre-conditions: AP namespace; RF=3; enableDynamicConfigUpdate=true; update to same RF
+					updateAPNamespaceRF(3, 3, 3)
+				})
+
+				It("allows rack-aware RF increase when consistent across racks", func() {
+					// Pre-conditions: two racks (id:1, id:2); AP namespace RF=2 in both; enableDynamicConfigUpdate=true
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
+					}
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf["replication-factor"] = 3
+					nsList[0] = nsConf
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("allows RF set to minimum value (RF=1)", func() {
+					updateAPNamespaceRF(2, 2, 1)
+				})
+
+				It("allows RF set to maximum allowed (RF = cluster size)", func() {
+					const clusterSize = 3
+					updateAPNamespaceRF(clusterSize, 2, clusterSize)
+				})
+			})
+		})
+	})
+})

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -35,18 +35,16 @@ import (
 
 var _ = Describe("AerospikeCluster dynamic replication-factor validation", func() {
 	const (
-		clusterName       = "dynamic-rf-webhook-cluster"
-		testNs            = "default"
-		maxSchemaRF       = 256
-		rfAboveSchemaMax  = 257
-		defaultDevicePath = "/test/dev/xvdf"
-		namespaceName     = "test"
-		namespaceName2    = "test2"
-		namespaceName3    = "test3"
+		clusterName      = "dynamic-rf-webhook-cluster"
+		maxSchemaRF      = 256
+		rfAboveSchemaMax = 257
+		namespaceName    = "test"
+		namespaceName2   = "test2"
+		namespaceName3   = "test3"
 	)
 
 	ctx := context.TODO()
-	clusterNamespacedName := test.GetNamespacedName(clusterName, testNs)
+	clusterNamespacedName := test.GetNamespacedName(clusterName, testutil.DefaultNamespace)
 
 	// apNamespaceConfig returns an AP namespace config for envtest.
 	apNamespaceConfig := func(name string, rf int, device string) map[string]interface{} {
@@ -62,7 +60,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 
 	// scNamespaceConfig returns an SC namespace config for envtest.
 	scNamespaceConfig := func(name string, rf int) map[string]interface{} {
-		cfg := apNamespaceConfig(name, rf, defaultDevicePath)
+		cfg := apNamespaceConfig(name, rf, testutil.DefaultDevicePath)
 		cfg["strong-consistency"] = true
 
 		return cfg
@@ -87,7 +85,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 		case "SC":
 			nsConfig = scNamespaceConfig(namespaceName, initialRF)
 		default:
-			nsConfig = apNamespaceConfig(namespaceName, initialRF, defaultDevicePath)
+			nsConfig = apNamespaceConfig(namespaceName, initialRF, testutil.DefaultDevicePath)
 		}
 
 		aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
@@ -127,7 +125,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 0, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 0, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -146,7 +144,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 				It("allows AP namespace with RF greater than cluster size on deploy", func() {
 					// AP mode: replication-factor may exceed cluster size (unlike SC); see validateNamespaceReplicationFactor.
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
-					ns := apNamespaceConfig(namespaceName, 4, defaultDevicePath)
+					ns := apNamespaceConfig(namespaceName, 4, testutil.DefaultDevicePath)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{ns}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -170,7 +168,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+											apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 										},
 									},
 								},
@@ -180,7 +178,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName, 3, defaultDevicePath),
+											apNamespaceConfig(namespaceName, 3, testutil.DefaultDevicePath),
 										},
 									},
 								},
@@ -188,7 +186,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -215,7 +213,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 								AerospikeConfig: asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName, maxSchemaRF, defaultDevicePath),
+											apNamespaceConfig(namespaceName, maxSchemaRF, testutil.DefaultDevicePath),
 										},
 									},
 								},
@@ -225,7 +223,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 								AerospikeConfig: asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName, maxSchemaRF, defaultDevicePath),
+											apNamespaceConfig(namespaceName, maxSchemaRF, testutil.DefaultDevicePath),
 										},
 									},
 								},
@@ -233,7 +231,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, maxSchemaRF, defaultDevicePath),
+						apNamespaceConfig(namespaceName, maxSchemaRF, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -261,7 +259,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -293,7 +291,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(false)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -369,7 +367,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -382,7 +380,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						"name": namespaceName,
 						asdbv1.ConfKeyStorageEngine: map[string]interface{}{
 							"type":    "device",
-							"devices": []interface{}{defaultDevicePath},
+							"devices": []interface{}{testutil.DefaultDevicePath},
 						},
 					}
 					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{apNamespaceNoRF}
@@ -408,7 +406,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+											apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 										},
 									},
 								},
@@ -418,7 +416,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+											apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 										},
 									},
 								},
@@ -426,7 +424,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -463,7 +461,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{namespaceName, namespaceName2, namespaceName3},
@@ -564,7 +562,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 						apNamespaceConfig(namespaceName2, 2, "/test/dev/xvdg"),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
@@ -575,7 +573,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+											apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 										},
 									},
 								},
@@ -659,7 +657,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -691,7 +689,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						Racks:      []asdbv1.Rack{{ID: 1}},
 					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, defaultDevicePath),
+						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -21,6 +21,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/test"
 	testCluster "github.com/aerospike/aerospike-kubernetes-operator/v4/test/cluster"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/test/envtests"
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/test/testutil"
 )
 
 var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtests)", func() {
@@ -39,7 +42,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 	ctx := context.TODO()
 	clusterNamespacedName := test.GetNamespacedName(clusterName, testNs)
 
-	// apNamespaceConfig returns an AP (non-strong-consistency) namespace config for envtest.
+	// apNamespaceConfig returns an AP namespace config for envtest.
 	apNamespaceConfig := func(name string, rf int) map[string]interface{} {
 		return map[string]interface{}{
 			"name":               name,
@@ -51,12 +54,25 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 		}
 	}
 
-	// scNamespaceConfig returns an SC (strong-consistency) namespace config for envtest.
+	// scNamespaceConfig returns an SC namespace config for envtest.
 	scNamespaceConfig := func(name string, rf int) map[string]interface{} {
 		cfg := apNamespaceConfig(name, rf)
 		cfg["strong-consistency"] = true
 
 		return cfg
+	}
+
+	// apNamespaceWithDevice is like apNamespaceConfig(RF=2) but uses a distinct device path per namespace
+	// (required when multiple AP namespaces coexist).
+	apNamespaceWithDevice := func(name string, device string) map[string]interface{} {
+		return map[string]interface{}{
+			"name":               name,
+			"replication-factor": 2,
+			asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+				"type":    "device",
+				"devices": []interface{}{device},
+			},
+		}
 	}
 
 	AfterEach(func() {
@@ -140,25 +156,26 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						Validate(err)
 				})
 			})
-		})
-	})
 
-	Context("Update validation", func() {
-		Context("spec.aerospikeConfig (replication-factor)", func() {
-			Context("negative", func() {
-				It("rejects RF change attempted for SC namespace", func() {
-					err := updateSCNamespaceRF(2, 2, 5)
-					Expect(err).To(HaveOccurred())
-					envtests.NewStatusErrorMatcher().
-						WithMessageSubstrings(
-							"vaerospikecluster.kb.io",
-							"replication-factor cannot be updated for SC namespaces",
-						).
-						Validate(err)
+			Context("positive", func() {
+				It("allows AP namespace with RF greater than cluster size on deploy", func() {
+					// AP mode: replication-factor may exceed cluster size (unlike SC); see validateNamespaceReplicationFactor.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
+					ns := apNamespaceWithDevice("test", "/test/dev/xvdf")
+					ns["replication-factor"] = 4
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{ns}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
 				})
+			})
+		})
 
-				It("rejects multiple namespaces' RF changed in a single update", func() {
-					// Rack-aware cluster with two racks so we have two "name@rackID" entries; change both RFs.
+		Context("spec.rackConfig (replication-factor)", func() {
+			Context("negative", func() {
+				It("rejects rack-aware create when RF values are mismatched across racks", func() {
+					// Per-rack RF must be set via InputAerospikeConfig. Preset AerospikeConfig is ignored on create:
+					// mutating webhook copies global config into each rack when InputAerospikeConfig is nil.
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
@@ -179,7 +196,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
 									Value: map[string]interface{}{
 										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2),
+											apNamespaceConfig("test", 3),
 										},
 									},
 								},
@@ -191,38 +208,68 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).ToNot(HaveOccurred())
-
-					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-					Expect(err).ToNot(HaveOccurred())
-
-					// Change RF in both racks (update both rack configs) to trigger "multiple namespaces at the same time".
-					for i := range current.Spec.RackConfig.Racks {
-						rack := &current.Spec.RackConfig.Racks[i]
-						if rack.InputAerospikeConfig != nil && rack.InputAerospikeConfig.Value != nil {
-							nsList, ok := rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-							if ok && len(nsList) > 0 {
-								nsConf := nsList[0].(map[string]interface{})
-								nsConf["replication-factor"] = 3
-								nsList[0] = nsConf
-								rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-							}
-						}
-					}
-
-					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					nsConf := nsList[0].(map[string]interface{})
-					nsConf["replication-factor"] = 3
-					nsList[0] = nsConf
-					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-
-					err = envtests.K8sClient.Update(ctx, current)
 					Expect(err).To(HaveOccurred())
 
 					envtests.NewStatusErrorMatcher().
 						WithMessageSubstrings(
 							"vaerospikecluster.kb.io",
-							"cannot update replication-factor for multiple namespaces at the same time",
+							"different replication-factor values across racks",
+						).
+						Validate(err)
+				})
+			})
+
+			Context("positive", func() {
+				It("allows rack-aware deploy with replication-factor 256 in aerospikeConfig and all racks (schema max)", func() {
+					const maxSchemaRF = 256
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								AerospikeConfig: asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceConfig("test", maxSchemaRF),
+										},
+									},
+								},
+							},
+							{
+								ID: 2,
+								AerospikeConfig: asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceConfig("test", maxSchemaRF),
+										},
+									},
+								},
+							},
+						},
+					}
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", maxSchemaRF),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+	})
+
+	Context("Update validation", func() {
+		Context("spec.aerospikeConfig (replication-factor)", func() {
+			Context("negative", func() {
+				It("rejects RF change attempted for SC namespace", func() {
+					err := updateSCNamespaceRF(3, 2, 3)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"replication-factor cannot be updated for SC namespaces",
 						).
 						Validate(err)
 				})
@@ -245,7 +292,6 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					nsConf["replication-factor"] = 3
 					nsList[0] = nsConf
 					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-					// Change another field alongside RF update.
 					current.Spec.Size = 4
 
 					err = envtests.K8sClient.Update(ctx, current)
@@ -256,50 +302,6 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 							"vaerospikecluster.kb.io",
 							"when updating replication-factor",
 							"no other fields",
-						).
-						Validate(err)
-				})
-
-				It("rejects rack-aware create when RF values are mismatched across racks", func() {
-					// Create with two racks; same namespace has RF=2 in rack 1 and RF=3 in rack 2.
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test"},
-						Racks: []asdbv1.Rack{
-							{
-								ID: 1,
-								AerospikeConfig: asdbv1.AerospikeConfigSpec{
-									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 2),
-										},
-									},
-								},
-							},
-							{
-								ID: 2,
-								AerospikeConfig: asdbv1.AerospikeConfigSpec{
-									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig("test", 3),
-										},
-									},
-								},
-							},
-						},
-					}
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig("test", 2),
-					}
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).To(HaveOccurred())
-
-					envtests.NewStatusErrorMatcher().
-						WithMessageSubstrings(
-							"vaerospikecluster.kb.io",
-							"different replication-factor values across racks",
 						).
 						Validate(err)
 				})
@@ -335,6 +337,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						Validate(err)
 				})
 
+				// Bug: https://aerospike.atlassian.net/browse/KO-484
 				It("rejects invalid RF value (zero or negative)", func() {
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
@@ -348,7 +351,7 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					envtests.NewStatusErrorMatcher().
 						WithMessageSubstrings(
 							"vaerospikecluster.kb.io",
-							"replication-factor",
+							"replication-factor can not be zero or negative",
 						).
 						Validate(err)
 				})
@@ -366,18 +369,14 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 						Validate(err)
 				})
 
-				It("rejects RF change on namespace missing from rackConfig", func() {
-					// Rack-aware cluster: namespace "other" in aerospikeConfig but not in rackConfig.Namespaces.
-					// If the webhook validates that RF changes only apply to namespaces in rackConfig, it should reject.
+				It("rejects RF update in spec.aerospikeConfig.namespaces (above schema max 256)", func() {
+					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
+					// update to RF=257 (above schema max 256)
+					const rfAboveSchemaMax = 257
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{"test"}, // "other" is not listed
-						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
-					}
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
 						apNamespaceConfig("test", 2),
-						apNamespaceConfig("other", 2),
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -386,23 +385,20 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
 					Expect(err).ToNot(HaveOccurred())
 
-					// Change RF for "other" (namespace not in rackConfig.Namespaces).
 					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					otherConf := nsList[1].(map[string]interface{})
-					otherConf["replication-factor"] = 3
-					nsList[1] = otherConf
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf["replication-factor"] = rfAboveSchemaMax
+					nsList[0] = nsConf
 					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
 
 					err = envtests.K8sClient.Update(ctx, current)
-					// Skip if webhook does not yet validate namespace-in-rackConfig for RF updates.
-					if err == nil {
-						Skip("webhook does not reject RF change on namespace missing from rackConfig")
-					}
+					Expect(err).To(HaveOccurred())
 
 					envtests.NewStatusErrorMatcher().
-						WithMessageSubstrings("vaerospikecluster.kb.io",
-							"device /test/dev/xvdf is already being referenced",
-							"in multiple namespaces (test, other)").
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"replication-factor Must be less than or equal to 256 ",
+						).
 						Validate(err)
 				})
 			})
@@ -423,8 +419,299 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					updateAPNamespaceRF(3, 3, 3)
 				})
 
+				It("allows RF set to minimum value (RF=1)", func() {
+					updateAPNamespaceRF(2, 2, 1)
+				})
+
+				It("allows RF set to maximum allowed (RF = cluster size)", func() {
+					const clusterSize = 3
+					updateAPNamespaceRF(clusterSize, 2, clusterSize)
+				})
+			})
+		})
+
+		Context("spec.rackConfig (replication-factor)", func() {
+			Context("negative", func() {
+				It("rejects RF update if RF is inconsistent across racks for same namespace)", func() {
+					// Same namespace "test" on rack 1 and 2;
+					// update RF only in rack 1 Input — must stay consistent across racks.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceConfig("test", 2),
+										},
+									},
+								},
+							},
+							{
+								ID: 2,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceConfig("test", 2),
+										},
+									},
+								},
+							},
+						},
+					}
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					rack := &current.Spec.RackConfig.Racks[0]
+					Expect(rack.InputAerospikeConfig).ToNot(BeNil())
+					nsList, ok := rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					Expect(ok).To(BeTrue())
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf["replication-factor"] = 3
+					nsList[0] = nsConf
+					rack.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"different replication-factor values across racks",
+							"replication-factor must be the same in every rack",
+						).
+						Validate(err)
+				})
+
+				It("rejects simultaneous RF update across multiple namespaces", func() {
+					// Preconditons: Global namespace test, RF 2.
+					// Rack 1 namespace - test2, RF 2; rack 2 namespace test3, RF 2.
+					// Single update bumps RF for test2 and test3 to 3 → must fail (one namespace per RF update).
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceWithDevice("test", "/test/dev/xvdf"),
+					}
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test", "test2", "test3"},
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceWithDevice("test2", "/test/dev/xvdg"),
+										},
+									},
+								},
+							},
+							{
+								ID: 2,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceWithDevice("test3", "/test/dev/xvdh"),
+										},
+									},
+								},
+							},
+						},
+					}
+					aeroCluster.Spec.Storage.Volumes = append(aeroCluster.Spec.Storage.Volumes,
+						asdbv1.VolumeSpec{
+							Name: "ns-xvdg",
+							Source: asdbv1.VolumeSource{
+								PersistentVolume: &asdbv1.PersistentVolumeSpec{
+									Size:         resource.MustParse("1Gi"),
+									StorageClass: testutil.StorageClass,
+									VolumeMode:   corev1.PersistentVolumeBlock,
+								},
+							},
+							Aerospike: &asdbv1.AerospikeServerVolumeAttachment{
+								Path: "/test/dev/xvdg",
+							},
+						},
+						asdbv1.VolumeSpec{
+							Name: "ns-xvdh",
+							Source: asdbv1.VolumeSource{
+								PersistentVolume: &asdbv1.PersistentVolumeSpec{
+									Size:         resource.MustParse("1Gi"),
+									StorageClass: testutil.StorageClass,
+									VolumeMode:   corev1.PersistentVolumeBlock,
+								},
+							},
+							Aerospike: &asdbv1.AerospikeServerVolumeAttachment{
+								Path: "/test/dev/xvdh",
+							},
+						},
+					)
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					rack1 := &current.Spec.RackConfig.Racks[0]
+					Expect(rack1.InputAerospikeConfig).ToNot(BeNil())
+					nsList1, ok := rack1.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					Expect(ok).To(BeTrue())
+					ns2 := nsList1[0].(map[string]interface{})
+					ns2["replication-factor"] = 3
+					nsList1[0] = ns2
+					rack1.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList1
+
+					rack2 := &current.Spec.RackConfig.Racks[1]
+					Expect(rack2.InputAerospikeConfig).ToNot(BeNil())
+					nsList2, ok := rack2.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					Expect(ok).To(BeTrue())
+					ns3 := nsList2[0].(map[string]interface{})
+					ns3["replication-factor"] = 3
+					nsList2[0] = ns3
+					rack2.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList2
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"cannot update replication-factor for multiple namespaces at the same time",
+						).
+						Validate(err)
+				})
+
+				It("rejects RF update if RF is inconsistent in spec.aerospikeConfig.namespaces"+
+					"and spec.rackConfig.aerospikeConfig for the same namespace", func() {
+					// Create: namespace test via rack 1 input, test2 via rack 2 input; both RF 2.
+					// spec.rackConfig.aerospikeConfig.namespaces: test has RF = 2 during cluster creation.
+					// update RF for test to 3 in spec.rackConfig.aerospikeConfig.namespaces.
+					// must fail because RF is inconsistent in spec.aerospikeConfig.namespaces
+					// and spec.rackConfig.aerospikeConfig for the same namespace(test)
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceWithDevice("test", "/test/dev/xvdf"),
+						apNamespaceWithDevice("test2", "/test/dev/xvdg"),
+					}
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test", "test2"},
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceWithDevice("test", "/test/dev/xvdf"),
+										},
+									},
+								},
+							},
+							{
+								ID: 2,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{
+											apNamespaceWithDevice("test2", "/test/dev/xvdg"),
+										},
+									},
+								},
+							},
+						},
+					}
+					aeroCluster.Spec.Storage.Volumes = append(aeroCluster.Spec.Storage.Volumes,
+						asdbv1.VolumeSpec{
+							Name: "ns-xvdg",
+							Source: asdbv1.VolumeSource{
+								PersistentVolume: &asdbv1.PersistentVolumeSpec{
+									Size:         resource.MustParse("1Gi"),
+									StorageClass: testutil.StorageClass,
+									VolumeMode:   corev1.PersistentVolumeBlock,
+								},
+							},
+							Aerospike: &asdbv1.AerospikeServerVolumeAttachment{
+								Path: "/test/dev/xvdg",
+							},
+						},
+					)
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Update replication-factor for both namespaces in one request.
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					for i := range nsList {
+						nsConf := nsList[i].(map[string]interface{})
+						nsConf["replication-factor"] = 3
+						nsList[i] = nsConf
+					}
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"different replication-factor values across racks",
+							"replication-factor must be the same in every rack",
+						).
+						Validate(err)
+				})
+
+				It("rejects RF update in rackConfig for value above schema max 256)", func() {
+					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
+					// update to RF=257 (above schema max 256)
+					const rfAboveSchemaMax = 257
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks:      []asdbv1.Rack{{ID: 1}, {ID: 2}},
+					}
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						apNamespaceConfig("test", 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					nsConf := nsList[0].(map[string]interface{})
+					nsConf["replication-factor"] = rfAboveSchemaMax
+					nsList[0] = nsConf
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"replication-factor Must be less than or equal to 256 ",
+						).
+						Validate(err)
+				})
+			})
+
+			Context("positive", func() {
 				It("allows rack-aware RF increase when consistent across racks", func() {
-					// Pre-conditions: two racks (id:1, id:2); AP namespace RF=2 in both; enableDynamicConfigUpdate=true
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
@@ -451,13 +738,56 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation (envtes
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("allows RF set to minimum value (RF=1)", func() {
-					updateAPNamespaceRF(2, 2, 1)
-				})
+				It("allow adding namespace to rackConfig.namespaces with RF", func() {
+					// Preconditions: Global namespace test, RF=2.
+					// Rack 1 namespace test, RF=2.
+					// Update: add namespace "other" to rackConfig.namespaces with RF=3.
+					// must succeed because namespace "other" is not in spec.rackConfig.namespaces
+					memNS := func(name string, rf int) map[string]interface{} {
+						return map[string]interface{}{
+							"name":               name,
+							"replication-factor": rf,
+							asdbv1.ConfKeyStorageEngine: map[string]interface{}{
+								"type":      "memory",
+								"data-size": 1073741824,
+							},
+						}
+					}
 
-				It("allows RF set to maximum allowed (RF = cluster size)", func() {
-					const clusterSize = 3
-					updateAPNamespaceRF(clusterSize, 2, clusterSize)
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 1)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						memNS("test", 2),
+					}
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks: []asdbv1.Rack{
+							{
+								ID: 1,
+								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
+									Value: map[string]interface{}{
+										asdbv1.ConfKeyNamespace: []interface{}{memNS("test", 2)},
+									},
+								},
+							},
+						},
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					// Namespace "other" is not in spec.rackConfig.namespaces
+					current.Spec.RackConfig.Racks[0].InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
+						Value: map[string]interface{}{
+							asdbv1.ConfKeyNamespace: []interface{}{memNS("other", 3)},
+						},
+					}
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})

--- a/test/envtests/cluster/dynamic_rf_webhook_test.go
+++ b/test/envtests/cluster/dynamic_rf_webhook_test.go
@@ -21,8 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -331,6 +329,45 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						).
 						Validate(err)
 				})
+
+				It("rejects simultaneous RF update across multiple namespaces", func() {
+					// Multiple namespaces in global aerospikeConfig;
+					// single update changes RF for 2+ namespaces → must fail.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
+					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+						inMemoryNS(namespaceName, 2),
+						inMemoryNS(namespaceName2, 2),
+						inMemoryNS(namespaceName3, 2),
+					}
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+
+					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+					// Update RF for test2 and test3 in one update
+					for i := range nsList {
+						nsConf := nsList[i].(map[string]interface{})
+						if nsConf["name"] == namespaceName2 || nsConf["name"] == namespaceName3 {
+							nsConf["replication-factor"] = 3
+							nsList[i] = nsConf
+						}
+					}
+					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"vaerospikecluster.kb.io",
+							"cannot update replication-factor for multiple namespaces at the same time",
+						).
+						Validate(err)
+				})
 			})
 
 			Context("positive", func() {
@@ -454,185 +491,6 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 						Validate(err)
 				})
 
-				It("rejects simultaneous RF update across multiple namespaces", func() {
-					// Preconditons: Global namespace test, RF 2.
-					// Rack 1 namespace - test2, RF 2; rack 2 namespace test3, RF 2.
-					// Single update bumps RF for test2 and test3 to 3 → must fail (one namespace per RF update).
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
-					}
-					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{namespaceName, namespaceName2, namespaceName3},
-						Racks: []asdbv1.Rack{
-							{
-								ID: 1,
-								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
-									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName2, 2, "/test/dev/xvdg"),
-										},
-									},
-								},
-							},
-							{
-								ID: 2,
-								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
-									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName3, 2, "/test/dev/xvdh"),
-										},
-									},
-								},
-							},
-						},
-					}
-					aeroCluster.Spec.Storage.Volumes = append(aeroCluster.Spec.Storage.Volumes,
-						asdbv1.VolumeSpec{
-							Name: "ns-xvdg",
-							Source: asdbv1.VolumeSource{
-								PersistentVolume: &asdbv1.PersistentVolumeSpec{
-									Size:         resource.MustParse("1Gi"),
-									StorageClass: testutil.StorageClass,
-									VolumeMode:   corev1.PersistentVolumeBlock,
-								},
-							},
-							Aerospike: &asdbv1.AerospikeServerVolumeAttachment{
-								Path: "/test/dev/xvdg",
-							},
-						},
-						asdbv1.VolumeSpec{
-							Name: "ns-xvdh",
-							Source: asdbv1.VolumeSource{
-								PersistentVolume: &asdbv1.PersistentVolumeSpec{
-									Size:         resource.MustParse("1Gi"),
-									StorageClass: testutil.StorageClass,
-									VolumeMode:   corev1.PersistentVolumeBlock,
-								},
-							},
-							Aerospike: &asdbv1.AerospikeServerVolumeAttachment{
-								Path: "/test/dev/xvdh",
-							},
-						},
-					)
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).ToNot(HaveOccurred())
-
-					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-					Expect(err).ToNot(HaveOccurred())
-
-					rack1 := &current.Spec.RackConfig.Racks[0]
-					Expect(rack1.InputAerospikeConfig).ToNot(BeNil())
-					nsList1, ok := rack1.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					Expect(ok).To(BeTrue())
-					ns2 := nsList1[0].(map[string]interface{})
-					ns2["replication-factor"] = 3
-					nsList1[0] = ns2
-					rack1.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList1
-
-					rack2 := &current.Spec.RackConfig.Racks[1]
-					Expect(rack2.InputAerospikeConfig).ToNot(BeNil())
-					nsList2, ok := rack2.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					Expect(ok).To(BeTrue())
-					ns3 := nsList2[0].(map[string]interface{})
-					ns3["replication-factor"] = 3
-					nsList2[0] = ns3
-					rack2.InputAerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList2
-
-					err = envtests.K8sClient.Update(ctx, current)
-					Expect(err).To(HaveOccurred())
-
-					envtests.NewStatusErrorMatcher().
-						WithMessageSubstrings(
-							"vaerospikecluster.kb.io",
-							"cannot update replication-factor for multiple namespaces at the same time",
-						).
-						Validate(err)
-				})
-
-				It("rejects RF update if RF is inconsistent in spec.aerospikeConfig.namespaces"+
-					"and spec.rackConfig.aerospikeConfig for the same namespace", func() {
-					// Create: namespace test via rack 1 input, test2 via rack 2 input; both RF 2.
-					// spec.rackConfig.aerospikeConfig.namespaces: test has RF = 2 during cluster creation.
-					// update RF for test to 3 in spec.rackConfig.aerospikeConfig.namespaces.
-					// must fail because RF is inconsistent in spec.aerospikeConfig.namespaces
-					// and spec.rackConfig.aerospikeConfig for the same namespace(test)
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 4)
-					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
-					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
-						apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
-						apNamespaceConfig(namespaceName2, 2, "/test/dev/xvdg"),
-					}
-					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
-						Namespaces: []string{namespaceName, namespaceName2},
-						Racks: []asdbv1.Rack{
-							{
-								ID: 1,
-								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
-									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
-										},
-									},
-								},
-							},
-							{
-								ID: 2,
-								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
-									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{
-											apNamespaceConfig(namespaceName2, 2, "/test/dev/xvdg"),
-										},
-									},
-								},
-							},
-						},
-					}
-					aeroCluster.Spec.Storage.Volumes = append(aeroCluster.Spec.Storage.Volumes,
-						asdbv1.VolumeSpec{
-							Name: "ns-xvdg",
-							Source: asdbv1.VolumeSource{
-								PersistentVolume: &asdbv1.PersistentVolumeSpec{
-									Size:         resource.MustParse("1Gi"),
-									StorageClass: testutil.StorageClass,
-									VolumeMode:   corev1.PersistentVolumeBlock,
-								},
-							},
-							Aerospike: &asdbv1.AerospikeServerVolumeAttachment{
-								Path: "/test/dev/xvdg",
-							},
-						},
-					)
-
-					err := envtests.K8sClient.Create(ctx, aeroCluster)
-					Expect(err).ToNot(HaveOccurred())
-
-					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
-					Expect(err).ToNot(HaveOccurred())
-
-					// Update replication-factor for both namespaces in one request.
-					nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
-					for i := range nsList {
-						nsConf := nsList[i].(map[string]interface{})
-						nsConf["replication-factor"] = 3
-						nsList[i] = nsConf
-					}
-					current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
-
-					err = envtests.K8sClient.Update(ctx, current)
-					Expect(err).To(HaveOccurred())
-
-					envtests.NewStatusErrorMatcher().
-						WithMessageSubstrings(
-							"vaerospikecluster.kb.io",
-							"different replication-factor values across racks",
-							"replication-factor must be the same in every rack",
-						).
-						Validate(err)
-				})
-
 				It("rejects RF update in rackConfig for value above schema max 256)", func() {
 					// Pre-conditions: AP namespace; RF=2; enableDynamicConfigUpdate=true;
 					// update to RF=257 (above schema max 256)
@@ -708,28 +566,19 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("allow adding namespace to rackConfig.namespaces with RF", func() {
-					// Preconditions: Global namespace test, RF=2.
-					// Rack 1 namespace test, RF=2.
-					// Update: add namespace "test2" to rackConfig.namespaces with RF=3.
-					// must succeed because namespace "test2" is not in spec.rackConfig.namespaces
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 1)
+				It("allows adding RF to existing namespace in RackConfig.namespaces", func() {
+					// Preconditions: RackConfig.namespaces has "test". Rack has no InputAerospikeConfig (uses global).
+					// Global has test with RF=2.
+					// Update: Add InputAerospikeConfig to rack with test at RF=3.
+					// Must succeed: rack acquires RF override for namespace already in rackConfig.namespaces.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
 					aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
 						inMemoryNS(namespaceName, 2),
 					}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{namespaceName},
-						Racks: []asdbv1.Rack{
-							{
-								ID: 1,
-								InputAerospikeConfig: &asdbv1.AerospikeConfigSpec{
-									Value: map[string]interface{}{
-										asdbv1.ConfKeyNamespace: []interface{}{inMemoryNS(namespaceName, 2)},
-									},
-								},
-							},
-						},
+						Racks:      []asdbv1.Rack{{ID: 1}}, // no InputAerospikeConfig; rack inherits from global
 					}
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
@@ -738,16 +587,51 @@ var _ = Describe("AerospikeCluster dynamic replication-factor validation", func(
 					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
 					Expect(err).ToNot(HaveOccurred())
 
-					// Add Namespace "test2" in spec.rackConfig.namespaces with RF = 3
+					// Add RF to existing "test" namespace in rack (rack had no override before)
 					current.Spec.RackConfig.Racks[0].InputAerospikeConfig = &asdbv1.AerospikeConfigSpec{
 						Value: map[string]interface{}{
-							asdbv1.ConfKeyNamespace: []interface{}{inMemoryNS(namespaceName2, 3)},
+							asdbv1.ConfKeyNamespace: []interface{}{inMemoryNS(namespaceName, 2)},
 						},
 					}
 
 					err = envtests.K8sClient.Update(ctx, current)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).ToNot(HaveOccurred())
 				})
+
+				DescribeTable("allows rack-aware RF increase when consistent across racks",
+					func(size int32, rackCount int, newRF int) {
+						aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, size)
+						aeroCluster.Spec.EnableDynamicConfigUpdate = ptr.To(true)
+						racks := make([]asdbv1.Rack, rackCount)
+						for i := 0; i < rackCount; i++ {
+							racks[i] = asdbv1.Rack{ID: i + 1}
+						}
+						aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+							Namespaces: []string{namespaceName},
+							Racks:      racks,
+						}
+						aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = []interface{}{
+							apNamespaceConfig(namespaceName, 2, testutil.DefaultDevicePath),
+						}
+
+						err := envtests.K8sClient.Create(ctx, aeroCluster)
+						Expect(err).ToNot(HaveOccurred())
+
+						current, err := testCluster.GetCluster(envtests.K8sClient, ctx, clusterNamespacedName)
+						Expect(err).ToNot(HaveOccurred())
+
+						nsList := current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace].([]interface{})
+						nsConf := nsList[0].(map[string]interface{})
+						nsConf["replication-factor"] = newRF
+						nsList[0] = nsConf
+						current.Spec.AerospikeConfig.Value[asdbv1.ConfKeyNamespace] = nsList
+
+						err = envtests.K8sClient.Update(ctx, current)
+						Expect(err).ToNot(HaveOccurred())
+					},
+					Entry("RF within cluster size", int32(4), 2, 3),
+					Entry("RF greater than cluster size", int32(3), 1, 4),
+				)
 
 				It("allow removing replication-factor from namespace in rackConfig.aerospikeConfig", func() {
 					// Create: global + rack have test and test2, both RF=2; rackConfig.namespaces lists both.

--- a/test/envtests/eviction/eviction_webhook_test.go
+++ b/test/envtests/eviction/eviction_webhook_test.go
@@ -14,6 +14,7 @@ import (
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/test/envtests"
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/test/testutil"
 )
 
 var _ = Describe("Pod eviction webhook", func() {
@@ -24,11 +25,10 @@ var _ = Describe("Pod eviction webhook", func() {
 
 	const (
 		podName = "test-evict-pod"
-		testNs  = "default"
 	)
 
 	BeforeEach(func() {
-		pod = getDummyPodWithAerospikeLabels(podName, testNs)
+		pod = getDummyPodWithAerospikeLabels(podName, testutil.DefaultNamespace)
 	})
 
 	AfterEach(func() {
@@ -36,7 +36,9 @@ var _ = Describe("Pod eviction webhook", func() {
 		_ = envtests.K8sClient.Delete(ctx, pod)
 
 		Eventually(func() bool {
-			err := envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testNs}, &corev1.Pod{})
+			err := envtests.K8sClient.Get(ctx, client.ObjectKey{
+				Name:      podName,
+				Namespace: testutil.DefaultNamespace}, &corev1.Pod{})
 			return apierrors.IsNotFound(err)
 		}, 10*time.Second, 500*time.Millisecond).Should(BeTrue())
 	})
@@ -52,22 +54,23 @@ var _ = Describe("Pod eviction webhook", func() {
 
 			// Wait until pod is visible
 			Eventually(func() error {
-				return envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testNs}, pod)
+				return envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testutil.DefaultNamespace}, pod)
 			}, 5*time.Second, 500*time.Millisecond).Should(Succeed())
 
 			By("creating eviction object")
 			eviction := &policyv1.Eviction{
-				ObjectMeta:    metav1.ObjectMeta{Name: podName, Namespace: testNs},
+				ObjectMeta:    metav1.ObjectMeta{Name: podName, Namespace: testutil.DefaultNamespace},
 				DeleteOptions: &metav1.DeleteOptions{},
 			}
 
 			By("attempting eviction")
-			err := envtests.ClientSet.CoreV1().Pods(testNs).EvictV1(ctx, eviction)
+			err := envtests.ClientSet.CoreV1().Pods(testutil.DefaultNamespace).EvictV1(ctx, eviction)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Optionally verify Pod deletion
 			Eventually(func() bool {
-				err := envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testNs}, &corev1.Pod{})
+				err := envtests.K8sClient.Get(ctx,
+					client.ObjectKey{Name: podName, Namespace: testutil.DefaultNamespace}, &corev1.Pod{})
 				return apierrors.IsNotFound(err)
 			}, 5*time.Second, 500*time.Millisecond).Should(BeTrue())
 		})
@@ -90,23 +93,23 @@ var _ = Describe("Pod eviction webhook", func() {
 
 				// Wait until pod is visible
 				Eventually(func() error {
-					return envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testNs}, pod)
+					return envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testutil.DefaultNamespace}, pod)
 				}, 5*time.Second, 500*time.Millisecond).Should(Succeed())
 
 				By("creating eviction object")
 				eviction := &policyv1.Eviction{
-					ObjectMeta:    metav1.ObjectMeta{Name: podName, Namespace: testNs},
+					ObjectMeta:    metav1.ObjectMeta{Name: podName, Namespace: testutil.DefaultNamespace},
 					DeleteOptions: &metav1.DeleteOptions{},
 				}
 
 				By("attempting eviction")
-				err := envtests.ClientSet.CoreV1().Pods(testNs).EvictV1(ctx, eviction)
+				err := envtests.ClientSet.CoreV1().Pods(testutil.DefaultNamespace).EvictV1(ctx, eviction)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("blocked by admission webhook"))
 
 				By("verifying if eviction-blocked annotation is set")
 				Eventually(func() bool {
-					_ = envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testNs}, pod)
+					_ = envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testutil.DefaultNamespace}, pod)
 					return pod.Annotations != nil && pod.Annotations[asdbv1.EvictionBlockedAnnotation] != ""
 				}, 5*time.Second, 500*time.Millisecond).Should(BeTrue())
 			})
@@ -122,20 +125,21 @@ var _ = Describe("Pod eviction webhook", func() {
 				Expect(envtests.K8sClient.Create(ctx, pod)).To(Succeed())
 
 				Eventually(func() error {
-					return envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testNs}, pod)
+					return envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testutil.DefaultNamespace}, pod)
 				}, 5*time.Second, 500*time.Millisecond).Should(Succeed())
 
 				By("attempting eviction")
 				eviction := &policyv1.Eviction{
-					ObjectMeta:    metav1.ObjectMeta{Name: podName, Namespace: testNs},
+					ObjectMeta:    metav1.ObjectMeta{Name: podName, Namespace: testutil.DefaultNamespace},
 					DeleteOptions: &metav1.DeleteOptions{},
 				}
 
-				err := envtests.ClientSet.CoreV1().Pods(testNs).EvictV1(ctx, eviction)
+				err := envtests.ClientSet.CoreV1().Pods(testutil.DefaultNamespace).EvictV1(ctx, eviction)
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func() bool {
-					err := envtests.K8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: testNs}, &corev1.Pod{})
+					err := envtests.K8sClient.Get(ctx,
+						client.ObjectKey{Name: podName, Namespace: testutil.DefaultNamespace}, &corev1.Pod{})
 					return apierrors.IsNotFound(err)
 				}, 5*time.Second, 500*time.Millisecond).Should(BeTrue())
 			})
@@ -147,11 +151,11 @@ var _ = Describe("Pod eviction webhook", func() {
 
 				By("attempting to evict non-existent pod")
 				eviction := &policyv1.Eviction{
-					ObjectMeta:    metav1.ObjectMeta{Name: nonExistentPodName, Namespace: testNs},
+					ObjectMeta:    metav1.ObjectMeta{Name: nonExistentPodName, Namespace: testutil.DefaultNamespace},
 					DeleteOptions: &metav1.DeleteOptions{},
 				}
 
-				err := envtests.ClientSet.CoreV1().Pods(testNs).EvictV1(ctx, eviction)
+				err := envtests.ClientSet.CoreV1().Pods(testutil.DefaultNamespace).EvictV1(ctx, eviction)
 				// Should not be blocked by webhook (let API server handle NotFound)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("not found"))

--- a/test/testutil/defaults.go
+++ b/test/testutil/defaults.go
@@ -17,6 +17,8 @@ const (
 	Pre810ServerVersion = "8.0.0.0"
 	StorageClass        = "ssd"
 	ClusterNameConfig   = "cluster-name"
+	DefaultNamespace    = "default"
+	DefaultDevicePath   = "/test/dev/xvdf"
 )
 
 var (


### PR DESCRIPTION
This PR is created to add 'Dynamic RF Update' TCs in test/envtests

**TCs Added:**
**Deploy validation — spec.aerospikeConfig (replication-factor)**
  negative: rejects RF > cluster size for SC namespace
  positive: allows AP namespace with RF greater than cluster size on deploy

**Deploy validation — spec.rackConfig (replication-factor)**
  negative: rejects rack-aware create when RF values are mismatched across racks
  positive: allows rack-aware deploy with replication-factor 256 in aerospikeConfig and all racks (schema max)

**Update validation — spec.aerospikeConfig (replication-factor)**
  negative: rejects RF change attempted for SC namespace
  negative: rejects RF change combined with unrelated spec changes
  negative: rejects RF update when enableDynamicConfigUpdate is false
  negative: rejects invalid RF value (zero or negative)
  negative: rejects RF update in spec.aerospikeConfig.namespaces (above schema max 256)
  positive: allows basic RF increase for AP namespace
  positive: allows basic RF decrease for AP namespace
  positive: allows no-op RF update (same RF value)
  positive: allows RF increase greater than cluster size for AP namespace
  positive: allows RF set to minimum value (RF=1)
  positive: allows RF set to maximum allowed (RF = cluster size)
  positive: allow RF remove from spec.aerospikeConfig for AP namespace

**Update validation — spec.rackConfig (replication-factor)**
  negative: rejects RF update if RF is inconsistent across racks for same namespace)
  negative: rejects simultaneous RF update across multiple namespaces
  negative: rejects RF update if RF is inconsistent in spec.aerospikeConfig.namespaces and spec.rackConfig.aerospikeConfig for the same namespace
  negative: rejects RF update in rackConfig for value above schema max 256)
  positive: allows rack-aware RF increase when consistent across racks
  positive: allows rack-aware RF increase greater than cluster size
  positive: allow adding namespace to rackConfig.namespaces with RF
  positive: allow removing replication-factor from namespace in rackConfig.aerospikeConfig