### PR TITLE
WIP: fix: prevent data loss during scale-down and failure recovery of failed pods [KO-536]

### DIFF
--- a/api/v1/aerospikecluster_types.go
+++ b/api/v1/aerospikecluster_types.go
@@ -883,9 +883,18 @@ type AerospikeStorageSpec struct { //nolint:govet // for readability
 	LocalStorageClasses []string `json:"localStorageClasses,omitempty"`
 
 	// DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-	// by AKO. It only considers local storage classes given in the localStorageClasses field.
+	// by AKO as part of a planned operation (rolling restart, image upgrade).
+	// It only considers local storage classes given in the localStorageClasses field.
 	// +optional
 	DeleteLocalStorageOnRestart *bool `json:"deleteLocalStorageOnRestart,omitempty"`
+
+	// DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+	// Defaults to false.
+	// WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+	// Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+	// Requires localStorageClasses to be non-empty.
+	// +optional
+	DeleteLocalStorageOnPodFailureRecovery *bool `json:"deleteLocalStorageOnPodFailureRecovery,omitempty"`
 
 	// Volumes list to attach to created pods.
 	// +patchMergeKey=name

--- a/api/v1/aerospikecluster_types.go
+++ b/api/v1/aerospikecluster_types.go
@@ -888,13 +888,13 @@ type AerospikeStorageSpec struct { //nolint:govet // for readability
 	// +optional
 	DeleteLocalStorageOnRestart *bool `json:"deleteLocalStorageOnRestart,omitempty"`
 
-	// DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+	// DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
 	// Defaults to false.
 	// WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
 	// Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
 	// Requires localStorageClasses to be non-empty.
 	// +optional
-	DeleteLocalStorageOnPodFailureRecovery *bool `json:"deleteLocalStorageOnPodFailureRecovery,omitempty"`
+	DeleteLocalStorageOnPodRecovery *bool `json:"deleteLocalStorageOnPodRecovery,omitempty"`
 
 	// Volumes list to attach to created pods.
 	// +patchMergeKey=name

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -749,8 +749,8 @@ func (in *AerospikeStorageSpec) DeepCopyInto(out *AerospikeStorageSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.DeleteLocalStorageOnPodFailureRecovery != nil {
-		in, out := &in.DeleteLocalStorageOnPodFailureRecovery, &out.DeleteLocalStorageOnPodFailureRecovery
+	if in.DeleteLocalStorageOnPodRecovery != nil {
+		in, out := &in.DeleteLocalStorageOnPodRecovery, &out.DeleteLocalStorageOnPodRecovery
 		*out = new(bool)
 		**out = **in
 	}

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -749,6 +749,11 @@ func (in *AerospikeStorageSpec) DeepCopyInto(out *AerospikeStorageSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeleteLocalStorageOnPodFailureRecovery != nil {
+		in, out := &in.DeleteLocalStorageOnPodFailureRecovery, &out.DeleteLocalStorageOnPodFailureRecovery
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]VolumeSpec, len(*in))

--- a/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
+++ b/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
@@ -6475,10 +6475,19 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
+                            deleteLocalStorageOnPodFailureRecovery:
+                              description: |-
+                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                Defaults to false.
+                                WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                                Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                                Requires localStorageClasses to be non-empty.
+                              type: boolean
                             deleteLocalStorageOnRestart:
                               description: |-
                                 DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                                by AKO. It only considers local storage classes given in the localStorageClasses field.
+                                by AKO as part of a planned operation (rolling restart, image upgrade).
+                                It only considers local storage classes given in the localStorageClasses field.
                               type: boolean
                             filesystemVolumePolicy:
                               description: FileSystemVolumePolicy contains default
@@ -8110,10 +8119,19 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
+                            deleteLocalStorageOnPodFailureRecovery:
+                              description: |-
+                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                Defaults to false.
+                                WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                                Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                                Requires localStorageClasses to be non-empty.
+                              type: boolean
                             deleteLocalStorageOnRestart:
                               description: |-
                                 DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                                by AKO. It only considers local storage classes given in the localStorageClasses field.
+                                by AKO as part of a planned operation (rolling restart, image upgrade).
+                                It only considers local storage classes given in the localStorageClasses field.
                               type: boolean
                             filesystemVolumePolicy:
                               description: FileSystemVolumePolicy contains default
@@ -8812,10 +8830,19 @@ spec:
                     description: CleanupThreads contains the maximum number of cleanup
                       threads(dd or blkdiscard) per init container.
                     type: integer
+                  deleteLocalStorageOnPodFailureRecovery:
+                    description: |-
+                      DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                      Defaults to false.
+                      WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                      Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                      Requires localStorageClasses to be non-empty.
+                    type: boolean
                   deleteLocalStorageOnRestart:
                     description: |-
                       DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                      by AKO. It only considers local storage classes given in the localStorageClasses field.
+                      by AKO as part of a planned operation (rolling restart, image upgrade).
+                      It only considers local storage classes given in the localStorageClasses field.
                     type: boolean
                   filesystemVolumePolicy:
                     description: FileSystemVolumePolicy contains default policies
@@ -15978,10 +16005,19 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
+                            deleteLocalStorageOnPodFailureRecovery:
+                              description: |-
+                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                Defaults to false.
+                                WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                                Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                                Requires localStorageClasses to be non-empty.
+                              type: boolean
                             deleteLocalStorageOnRestart:
                               description: |-
                                 DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                                by AKO. It only considers local storage classes given in the localStorageClasses field.
+                                by AKO as part of a planned operation (rolling restart, image upgrade).
+                                It only considers local storage classes given in the localStorageClasses field.
                               type: boolean
                             filesystemVolumePolicy:
                               description: FileSystemVolumePolicy contains default
@@ -17613,10 +17649,19 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
+                            deleteLocalStorageOnPodFailureRecovery:
+                              description: |-
+                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                Defaults to false.
+                                WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                                Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                                Requires localStorageClasses to be non-empty.
+                              type: boolean
                             deleteLocalStorageOnRestart:
                               description: |-
                                 DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                                by AKO. It only considers local storage classes given in the localStorageClasses field.
+                                by AKO as part of a planned operation (rolling restart, image upgrade).
+                                It only considers local storage classes given in the localStorageClasses field.
                               type: boolean
                             filesystemVolumePolicy:
                               description: FileSystemVolumePolicy contains default
@@ -18382,10 +18427,19 @@ spec:
                     description: CleanupThreads contains the maximum number of cleanup
                       threads(dd or blkdiscard) per init container.
                     type: integer
+                  deleteLocalStorageOnPodFailureRecovery:
+                    description: |-
+                      DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                      Defaults to false.
+                      WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                      Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                      Requires localStorageClasses to be non-empty.
+                    type: boolean
                   deleteLocalStorageOnRestart:
                     description: |-
                       DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                      by AKO. It only considers local storage classes given in the localStorageClasses field.
+                      by AKO as part of a planned operation (rolling restart, image upgrade).
+                      It only considers local storage classes given in the localStorageClasses field.
                     type: boolean
                   filesystemVolumePolicy:
                     description: FileSystemVolumePolicy contains default policies

--- a/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
+++ b/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
@@ -6475,9 +6475,9 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
-                            deleteLocalStorageOnPodFailureRecovery:
+                            deleteLocalStorageOnPodRecovery:
                               description: |-
-                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                                 Defaults to false.
                                 WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                                 Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -8119,9 +8119,9 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
-                            deleteLocalStorageOnPodFailureRecovery:
+                            deleteLocalStorageOnPodRecovery:
                               description: |-
-                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                                 Defaults to false.
                                 WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                                 Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -8830,9 +8830,9 @@ spec:
                     description: CleanupThreads contains the maximum number of cleanup
                       threads(dd or blkdiscard) per init container.
                     type: integer
-                  deleteLocalStorageOnPodFailureRecovery:
+                  deleteLocalStorageOnPodRecovery:
                     description: |-
-                      DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                      DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                       Defaults to false.
                       WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                       Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -16005,9 +16005,9 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
-                            deleteLocalStorageOnPodFailureRecovery:
+                            deleteLocalStorageOnPodRecovery:
                               description: |-
-                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                                 Defaults to false.
                                 WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                                 Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -17649,9 +17649,9 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
-                            deleteLocalStorageOnPodFailureRecovery:
+                            deleteLocalStorageOnPodRecovery:
                               description: |-
-                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                                 Defaults to false.
                                 WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                                 Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -18427,9 +18427,9 @@ spec:
                     description: CleanupThreads contains the maximum number of cleanup
                       threads(dd or blkdiscard) per init container.
                     type: integer
-                  deleteLocalStorageOnPodFailureRecovery:
+                  deleteLocalStorageOnPodRecovery:
                     description: |-
-                      DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                      DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                       Defaults to false.
                       WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                       Only enable this when the data on the local disk is known to be corrupted or unrecoverable.

--- a/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
@@ -6475,10 +6475,19 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
+                            deleteLocalStorageOnPodFailureRecovery:
+                              description: |-
+                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                Defaults to false.
+                                WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                                Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                                Requires localStorageClasses to be non-empty.
+                              type: boolean
                             deleteLocalStorageOnRestart:
                               description: |-
                                 DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                                by AKO. It only considers local storage classes given in the localStorageClasses field.
+                                by AKO as part of a planned operation (rolling restart, image upgrade).
+                                It only considers local storage classes given in the localStorageClasses field.
                               type: boolean
                             filesystemVolumePolicy:
                               description: FileSystemVolumePolicy contains default
@@ -8110,10 +8119,19 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
+                            deleteLocalStorageOnPodFailureRecovery:
+                              description: |-
+                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                Defaults to false.
+                                WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                                Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                                Requires localStorageClasses to be non-empty.
+                              type: boolean
                             deleteLocalStorageOnRestart:
                               description: |-
                                 DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                                by AKO. It only considers local storage classes given in the localStorageClasses field.
+                                by AKO as part of a planned operation (rolling restart, image upgrade).
+                                It only considers local storage classes given in the localStorageClasses field.
                               type: boolean
                             filesystemVolumePolicy:
                               description: FileSystemVolumePolicy contains default
@@ -8812,10 +8830,19 @@ spec:
                     description: CleanupThreads contains the maximum number of cleanup
                       threads(dd or blkdiscard) per init container.
                     type: integer
+                  deleteLocalStorageOnPodFailureRecovery:
+                    description: |-
+                      DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                      Defaults to false.
+                      WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                      Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                      Requires localStorageClasses to be non-empty.
+                    type: boolean
                   deleteLocalStorageOnRestart:
                     description: |-
                       DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                      by AKO. It only considers local storage classes given in the localStorageClasses field.
+                      by AKO as part of a planned operation (rolling restart, image upgrade).
+                      It only considers local storage classes given in the localStorageClasses field.
                     type: boolean
                   filesystemVolumePolicy:
                     description: FileSystemVolumePolicy contains default policies
@@ -15978,10 +16005,19 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
+                            deleteLocalStorageOnPodFailureRecovery:
+                              description: |-
+                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                Defaults to false.
+                                WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                                Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                                Requires localStorageClasses to be non-empty.
+                              type: boolean
                             deleteLocalStorageOnRestart:
                               description: |-
                                 DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                                by AKO. It only considers local storage classes given in the localStorageClasses field.
+                                by AKO as part of a planned operation (rolling restart, image upgrade).
+                                It only considers local storage classes given in the localStorageClasses field.
                               type: boolean
                             filesystemVolumePolicy:
                               description: FileSystemVolumePolicy contains default
@@ -17613,10 +17649,19 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
+                            deleteLocalStorageOnPodFailureRecovery:
+                              description: |-
+                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                Defaults to false.
+                                WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                                Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                                Requires localStorageClasses to be non-empty.
+                              type: boolean
                             deleteLocalStorageOnRestart:
                               description: |-
                                 DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                                by AKO. It only considers local storage classes given in the localStorageClasses field.
+                                by AKO as part of a planned operation (rolling restart, image upgrade).
+                                It only considers local storage classes given in the localStorageClasses field.
                               type: boolean
                             filesystemVolumePolicy:
                               description: FileSystemVolumePolicy contains default
@@ -18382,10 +18427,19 @@ spec:
                     description: CleanupThreads contains the maximum number of cleanup
                       threads(dd or blkdiscard) per init container.
                     type: integer
+                  deleteLocalStorageOnPodFailureRecovery:
+                    description: |-
+                      DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                      Defaults to false.
+                      WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
+                      Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
+                      Requires localStorageClasses to be non-empty.
+                    type: boolean
                   deleteLocalStorageOnRestart:
                     description: |-
                       DeleteLocalStorageOnRestart enables the deletion of local storage PVCs when a pod is restarted or rescheduled
-                      by AKO. It only considers local storage classes given in the localStorageClasses field.
+                      by AKO as part of a planned operation (rolling restart, image upgrade).
+                      It only considers local storage classes given in the localStorageClasses field.
                     type: boolean
                   filesystemVolumePolicy:
                     description: FileSystemVolumePolicy contains default policies

--- a/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
@@ -6475,9 +6475,9 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
-                            deleteLocalStorageOnPodFailureRecovery:
+                            deleteLocalStorageOnPodRecovery:
                               description: |-
-                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                                 Defaults to false.
                                 WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                                 Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -8119,9 +8119,9 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
-                            deleteLocalStorageOnPodFailureRecovery:
+                            deleteLocalStorageOnPodRecovery:
                               description: |-
-                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                                 Defaults to false.
                                 WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                                 Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -8830,9 +8830,9 @@ spec:
                     description: CleanupThreads contains the maximum number of cleanup
                       threads(dd or blkdiscard) per init container.
                     type: integer
-                  deleteLocalStorageOnPodFailureRecovery:
+                  deleteLocalStorageOnPodRecovery:
                     description: |-
-                      DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                      DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                       Defaults to false.
                       WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                       Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -16005,9 +16005,9 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
-                            deleteLocalStorageOnPodFailureRecovery:
+                            deleteLocalStorageOnPodRecovery:
                               description: |-
-                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                                 Defaults to false.
                                 WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                                 Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -17649,9 +17649,9 @@ spec:
                               description: CleanupThreads contains the maximum number
                                 of cleanup threads(dd or blkdiscard) per init container.
                               type: integer
-                            deleteLocalStorageOnPodFailureRecovery:
+                            deleteLocalStorageOnPodRecovery:
                               description: |-
-                                DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                                DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                                 Defaults to false.
                                 WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                                 Only enable this when the data on the local disk is known to be corrupted or unrecoverable.
@@ -18427,9 +18427,9 @@ spec:
                     description: CleanupThreads contains the maximum number of cleanup
                       threads(dd or blkdiscard) per init container.
                     type: integer
-                  deleteLocalStorageOnPodFailureRecovery:
+                  deleteLocalStorageOnPodRecovery:
                     description: |-
-                      DeleteLocalStorageOnPodFailureRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
+                      DeleteLocalStorageOnPodRecovery enables the deletion of local storage PVCs when AKO recovers a failed pod.
                       Defaults to false.
                       WARNING: enabling this will cause permanent data loss for local volumes on the failed pod.
                       Only enable this when the data on the local disk is known to be corrupted or unrecoverable.

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -321,11 +321,13 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 ) common.ReconcileResult {
 	failedPods, failedWithinGracePeriodPods, activePods := getFailedAndActivePods(podsToRestart, true)
 
-	// If already dead node (failed pod) then no need to check node safety, migration
+	// Failed pods are always restarted as failure recovery regardless of the outer operation
+	// (upgrade, k8sNodeBlockList, planned rolling restart) — they failed for an unknown reason
+	// and their local disk data must be protected.
 	if len(failedPods) != 0 {
 		r.Log.Info("Restart failed pods", "pods", getPodNames(failedPods))
 
-		if res := r.restartPods(rackState, failedPods, restartTypeMap); !res.IsSuccess {
+		if res := r.restartPods(rackState, failedPods, restartTypeMap, true); !res.IsSuccess {
 			return res
 		}
 	}
@@ -360,7 +362,8 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 			}
 		}
 
-		if res := r.restartPods(rackState, activePods, restartTypeMap); !res.IsSuccess {
+		// Active pods are healthy — any restart of them is a planned operation.
+		if res := r.restartPods(rackState, activePods, restartTypeMap, false); !res.IsSuccess {
 			return res
 		}
 
@@ -483,6 +486,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 
 func (r *SingleClusterReconciler) restartPods(
 	rackState *RackState, podsToRestart []*corev1.Pod, restartTypeMap map[string]RestartType,
+	isFailureRecovery bool,
 ) common.ReconcileResult {
 	// For each block volume removed from a namespace, pod status dirtyVolumes is appended with that volume name.
 	// For each file removed from a namespace, it is deleted right away.
@@ -509,10 +513,12 @@ func (r *SingleClusterReconciler) restartPods(
 
 			restartedASDPodNames = append(restartedASDPodNames, pod.Name)
 		case podRestart:
-			if r.isLocalPVCDeletionRequired(rackState, pod) {
+			if r.isLocalPVCDeletionRequired(rackState, pod, isFailureRecovery) {
 				if err := r.deleteLocalPVCs(rackState, pod); err != nil {
 					return common.ReconcileError(err)
 				}
+			} else if isFailureRecovery && len(rackState.Rack.Storage.LocalStorageClasses) != 0 {
+				r.Log.Info("Skipping local PVC deletion for failed pod", "podName", pod.Name)
 			}
 
 			if err := r.Delete(context.TODO(), pod); err != nil {
@@ -667,7 +673,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 	if len(failedPods) != 0 {
 		r.Log.Info("Restart failed pods with updated container image", "pods", getPodNames(failedPods))
 
-		if res := r.deletePodAndEnsureImageUpdated(rackState, failedPods); !res.IsSuccess {
+		if res := r.deletePodAndEnsureImageUpdated(rackState, failedPods, true); !res.IsSuccess {
 			return res
 		}
 	}
@@ -701,7 +707,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 			}
 		}
 
-		if res := r.deletePodAndEnsureImageUpdated(rackState, activePods); !res.IsSuccess {
+		if res := r.deletePodAndEnsureImageUpdated(rackState, activePods, false); !res.IsSuccess {
 			return res
 		}
 
@@ -730,7 +736,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 }
 
 func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
-	rackState *RackState, podsToUpdate []*corev1.Pod,
+	rackState *RackState, podsToUpdate []*corev1.Pod, isFailureRecovery bool,
 ) common.ReconcileResult {
 	// For each block volume removed from a namespace, pod status dirtyVolumes is appended with that volume name.
 	// For each file removed from a namespace, it is deleted right away.
@@ -740,7 +746,7 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 
 	// Delete pods
 	for _, pod := range podsToUpdate {
-		if r.isLocalPVCDeletionRequired(rackState, pod) {
+		if r.isLocalPVCDeletionRequired(rackState, pod, isFailureRecovery) {
 			if err := r.deleteLocalPVCs(rackState, pod); err != nil {
 				return common.ReconcileError(err)
 			}
@@ -760,8 +766,25 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 	return r.ensurePodsImageUpdated(podsToUpdate)
 }
 
-func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(rackState *RackState, pod *corev1.Pod) bool {
-	// Check if pod is being deleted due to eviction
+func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(
+	rackState *RackState, pod *corev1.Pod, isFailureRecovery bool,
+) bool {
+	if isFailureRecovery {
+		// During unplanned failure recovery the pod may have failed for any reason (OOM kill, Aerospike
+		// crash, container runtime error, etc.). The local disk data is almost certainly intact.
+		// Do not delete local PVCs unless the user has explicitly opted in via deleteLocalStorageOnPodFailure,
+		// regardless of the eviction-blocked annotation, node block-list, or deleteLocalStorageOnRestart.
+		if asdbv1.GetBool(rackState.Rack.Storage.DeleteLocalStorageOnPodFailureRecovery) {
+			r.Log.Info("deleteLocalStorageOnPodFailure is enabled, deleting local PVCs for failed pod",
+				"podName", pod.Name)
+
+			return true
+		}
+
+		return false
+	}
+
+	// Planned restart path — existing logic unchanged.
 	if _, hasEvictionBlocked := pod.Annotations[asdbv1.EvictionBlockedAnnotation]; hasEvictionBlocked {
 		r.Log.Info("Pod has eviction-blocked annotation, deleting corresponding local PVCs if any",
 			"podName", pod.Name)
@@ -1005,11 +1028,10 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(sts *appsv1.StatefulSe
 
 // getIgnorablePods returns pods:
 // 1. From racksToDelete that are currently not running and can be ignored in stability checks.
-// 2. Failed/pending pods from the configuredRacks identified using maxIgnorablePods field and
-// 3. Failed pods from old revisions of revision-changed racks that will be replaced anyway can be
-// ignored from stability checks.
+// 2. Failed/pending pods including old revisions pods from the configuredRacks identified using maxIgnorablePods field
+// are ignored from stability checks.
 func (r *SingleClusterReconciler) getIgnorablePods(
-	racksToDelete []asdbv1.Rack, configuredRacks []RackState, revisionChangedRacks map[int]revisionChangedRack,
+	racksToDelete []asdbv1.Rack, configuredRacks []RackState,
 ) (sets.Set[string], error) {
 	ignorablePodNames := sets.Set[string]{}
 	ignorableRackIDs := sets.Set[int]{}
@@ -1033,34 +1055,6 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 		ignorableRackIDs.Insert(ignorableRacks[rackIdx].ID)
 	}
 
-	// Handle failed pods from old revisions of revision-changed racks
-	for rackID, revisionChangedRackInfo := range revisionChangedRacks {
-		oldRackState := revisionChangedRackInfo.oldRack
-		r.Log.Info("Checking old revision failed pods for revision-changed rack",
-			"rackID", rackID, "oldRevision", oldRackState.Rack.Revision)
-
-		oldPodList, err := r.getRackPodList(oldRackState.Rack.ID, oldRackState.Rack.Revision)
-		if err != nil {
-			return nil, err
-		}
-
-		var oldFailedPods []string
-
-		for podIdx := range oldPodList.Items {
-			pod := oldPodList.Items[podIdx]
-			if !utils.IsPodRunningAndReady(&pod) {
-				oldFailedPods = append(oldFailedPods, pod.Name)
-				ignorablePodNames.Insert(pod.Name)
-			}
-		}
-
-		if len(oldFailedPods) > 0 {
-			r.Log.Info("Adding old revision failed pods to ignore list (will be replaced)",
-				"rackID", oldRackState.Rack.ID, "oldRevision", oldRackState.Rack.Revision,
-				"failedPods", oldFailedPods)
-		}
-	}
-
 	for idx := range configuredRacks {
 		rackState := &configuredRacks[idx]
 		if ignorableRackIDs.Has(rackState.Rack.ID) {
@@ -1072,7 +1066,7 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 			r.aeroCluster.Spec.RackConfig.MaxIgnorablePods, int(rackState.Size), false,
 		)
 
-		podList, err := r.getRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+		podList, err := r.getAllRevisionRackPodList(rackState.Rack.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -774,7 +774,7 @@ func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(
 		// crash, container runtime error, etc.). The local disk data is almost certainly intact.
 		// Do not delete local PVCs unless the user has explicitly opted in via deleteLocalStorageOnPodFailure,
 		// regardless of the eviction-blocked annotation, node block-list, or deleteLocalStorageOnRestart.
-		if asdbv1.GetBool(rackState.Rack.Storage.DeleteLocalStorageOnPodFailureRecovery) {
+		if asdbv1.GetBool(rackState.Rack.Storage.DeleteLocalStorageOnPodRecovery) {
 			r.Log.Info("deleteLocalStorageOnPodFailure is enabled, deleting local PVCs for failed pod",
 				"podName", pod.Name)
 
@@ -1071,7 +1071,9 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 			return nil, err
 		}
 
-		var failedPod, pendingPod []string
+		var oldRevisionFailed, currentRevisionFailed, failedPod, pendingPod []string
+
+		currentRevision := rackState.Rack.Revision
 
 		for podIdx := range podList.Items {
 			pod := &podList.Items[podIdx]
@@ -1082,12 +1084,25 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 					continue
 				}
 
-				failedPod = append(failedPod, pod.Name)
+				// Old-revision pods belong to an STS that is being replaced and cannot
+				// recover on their own. Prioritise them so they always consume the
+				// maxIgnorablePods budget first, leaving leftover capacity for
+				// current-revision pods which may still recover.
+				if pod.Labels[asdbv1.AerospikeRackRevisionLabel] != currentRevision {
+					oldRevisionFailed = append(oldRevisionFailed, pod.Name)
+				} else {
+					currentRevisionFailed = append(currentRevisionFailed, pod.Name)
+				}
 			}
 		}
 
-		// prepend pendingPod to failedPod
-		failedPod = append(pendingPod, failedPod...)
+		// Budget priority order:
+		// 1. Pending (unschedulable) — least likely to recover on their own
+		// 2. Old-revision failed — STS is being replaced, recovery is impossible
+		// 3. Current-revision failed — may recover; use remaining budget only
+		failedPod = append(failedPod, pendingPod...)
+		failedPod = append(failedPod, oldRevisionFailed...)
+		failedPod = append(failedPod, currentRevisionFailed...)
 
 		for podIdx := range failedPod {
 			if failedAllowed <= 0 {

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -1071,7 +1071,7 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 			return nil, err
 		}
 
-		var oldRevisionFailed, currentRevisionFailed, failedPod, pendingPod []string
+		var oldRevisionFailed, currentRevisionFailed, pendingPod []string
 
 		currentRevision := rackState.Rack.Revision
 
@@ -1100,6 +1100,8 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 		// 1. Pending (unschedulable) — least likely to recover on their own
 		// 2. Old-revision failed — STS is being replaced, recovery is impossible
 		// 3. Current-revision failed — may recover; use remaining budget only
+
+		failedPod := make([]string, 0, len(pendingPod)+len(oldRevisionFailed)+len(currentRevisionFailed))
 		failedPod = append(failedPod, pendingPod...)
 		failedPod = append(failedPod, oldRevisionFailed...)
 		failedPod = append(failedPod, currentRevisionFailed...)

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	ls "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,7 +46,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		return common.ReconcileError(err)
 	}
 
-	ignorablePodNames, err := r.getIgnorablePods(racksToDelete, configuredRacks, revisionChangedRacks)
+	ignorablePodNames, err := r.getIgnorablePods(racksToDelete, configuredRacks)
 	if err != nil {
 		return common.ReconcileError(err)
 	}
@@ -932,7 +933,19 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			continue
 		}
 
-		ignorablePodNames.Insert(podsBatch[idx].Name)
+		// If the pod is not already in the ignorable set (i.e. not covered
+		// by maxIgnorablePods), block the scale-down and wait for recovery.
+		// Scaling down a failed pod skips migration safety checks and can delete
+		// PVCs (cascadeDelete=true), causing data loss on any storage type.
+		// The user can override this by raising maxIgnorablePods.
+		if !ignorablePodNames.Has(podsBatch[idx].Name) {
+			return found, common.ReconcileError(
+				fmt.Errorf(
+					"pod %s is not ready; waiting for recovery before scale-down to prevent data loss",
+					podsBatch[idx].Name,
+				),
+			)
+		}
 	}
 
 	// Ignore safe stop check if all pods in the batch are not running.
@@ -952,18 +965,18 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		); !res.IsSuccess {
 			return found, res
 		}
+	}
 
-		// Wait for migration to complete before deleting the pods.
-		if res := r.waitForMigrationToComplete(policy,
-			ignorablePodNames,
-		); !res.IsSuccess {
-			r.Log.Error(
-				res.Err, "Failed to wait for migration to complete before deleting pods",
-				"rackID", rackState.Rack.ID,
-			)
+	// Wait for migration to complete before deleting the pods.
+	if res := r.waitForMigrationToComplete(policy,
+		ignorablePodNames,
+	); !res.IsSuccess {
+		r.Log.Error(
+			res.Err, "Failed to wait for migration to complete before deleting pods",
+			"rackID", rackState.Rack.ID,
+		)
 
-			return found, res
-		}
+		return found, res
 	}
 
 	// Update new object with new size
@@ -1716,6 +1729,24 @@ func (r *SingleClusterReconciler) getRackPodList(rackID int, rackRevision string
 	}
 
 	// TODO: Should we add check to get only non-terminating pod? What if it is rolling restart
+	if err := r.List(context.TODO(), podList, listOps); err != nil {
+		return nil, err
+	}
+
+	return podList, nil
+}
+
+func (r *SingleClusterReconciler) getAllRevisionRackPodList(rackID int) (
+	*corev1.PodList, error,
+) {
+	// List the pods for this aeroCluster's statefulset
+	podList := &corev1.PodList{}
+	listOps := &client.ListOptions{
+		Namespace: r.aeroCluster.Namespace,
+		LabelSelector: ls.SelectorFromSet(
+			utils.LabelsForAerospikeClusterRack(r.aeroCluster.Name, rackID, "")),
+	}
+
 	if err := r.List(context.TODO(), podList, listOps); err != nil {
 		return nil, err
 	}

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -173,7 +173,7 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 		return reconcile.Result{}, recErr
 	}
 
-	ignorablePodNames, err := r.getIgnorablePods(nil, getConfiguredRackStateList(r.aeroCluster), nil)
+	ignorablePodNames, err := r.getIgnorablePods(nil, getConfiguredRackStateList(r.aeroCluster))
 	if err != nil {
 		r.Log.Error(err, "Failed to determine pods to be ignored")
 

--- a/internal/webhook/v1/storage.go
+++ b/internal/webhook/v1/storage.go
@@ -250,6 +250,12 @@ func validateStorage(
 		)
 	}
 
+	if asdbv1.GetBool(storage.DeleteLocalStorageOnPodRecovery) && len(storage.LocalStorageClasses) == 0 {
+		return warnings, fmt.Errorf(
+			"localStorageClasses cannot be empty if deleteLocalStorageOnPodFailureRecovery is set",
+		)
+	}
+
 	reservedPaths := map[string]int{
 		// Reserved mount paths for the operator.
 		"/etc/aerospike": 1,

--- a/test/cluster/batch_scaledown_pods_test.go
+++ b/test/cluster/batch_scaledown_pods_test.go
@@ -97,6 +97,83 @@ var _ = Describe("BatchScaleDown", func() {
 		})
 	})
 
+	Context("When a pod in the scale-down batch is failed", func() {
+		BeforeEach(
+			func() {
+				aeroCluster := createNonSCDummyAerospikeCluster(clusterNamespacedName, 4)
+				Expect(DeployCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+			},
+		)
+
+		It("Should block scale-down when the last pod is failed and maxIgnorablePods is not set", func() {
+			aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Highest-ordinal pod is first in the scale-down batch.
+			failedPodName := clusterName + "-0-3"
+
+			By("Marking the pod as failed")
+			Expect(markPodAsFailed(ctx, k8sClient, failedPodName, namespace)).ToNot(HaveOccurred())
+
+			By("Triggering scale-down by 1 without maxIgnorablePods")
+
+			aeroCluster.Spec.Size--
+			Expect(k8sClient.Update(ctx, aeroCluster)).ToNot(HaveOccurred())
+
+			By("Asserting cluster does not complete (blocked waiting for pod recovery)")
+
+			err = waitForAerospikeCluster(
+				k8sClient, ctx, aeroCluster, int(aeroCluster.Spec.Size),
+				retryInterval, 2*time.Minute,
+				[]asdbv1.AerospikeClusterPhase{asdbv1.AerospikeClusterInProgress, asdbv1.AerospikeClusterError},
+			)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should allow scale-down when the failed pod is covered by maxIgnorablePods", func() {
+			aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+			Expect(err).ToNot(HaveOccurred())
+
+			failedPodName := clusterName + "-0-3"
+
+			By("Marking the pod as failed")
+			Expect(markPodAsFailed(ctx, k8sClient, failedPodName, namespace)).ToNot(HaveOccurred())
+
+			By("Setting maxIgnorablePods=1 and triggering scale-down")
+
+			maxIgnorable := intstr.FromInt32(1)
+			aeroCluster.Spec.RackConfig.MaxIgnorablePods = &maxIgnorable
+			aeroCluster.Spec.Size--
+
+			Expect(updateCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+		})
+
+		It("Should block scale-down when pod other than the pod to be scaled down is in failed and "+
+			"maxIgnorablePods is not set", func() {
+			aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+			Expect(err).ToNot(HaveOccurred())
+
+			failedPodName := clusterName + "-0-1"
+
+			By("Marking the pod as failed")
+			Expect(markPodAsFailed(ctx, k8sClient, failedPodName, namespace)).ToNot(HaveOccurred())
+
+			By("Triggering scale-down by 1 without maxIgnorablePods")
+
+			aeroCluster.Spec.Size--
+			Expect(k8sClient.Update(ctx, aeroCluster)).ToNot(HaveOccurred())
+
+			By("Asserting cluster does not complete (blocked waiting for pod recovery)")
+
+			err = waitForAerospikeCluster(
+				k8sClient, ctx, aeroCluster, int(aeroCluster.Spec.Size),
+				retryInterval, 2*time.Minute,
+				[]asdbv1.AerospikeClusterPhase{asdbv1.AerospikeClusterInProgress, asdbv1.AerospikeClusterError},
+			)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	// TODO: Do we need to add all the invalid operation test-cases here?
 	// Skipped for now as they are exactly same as RollingUpdateBatchSize invalid operation test-cases
 	Context("When doing invalid operations", func() {

--- a/test/cluster/eviction_webhook_test.go
+++ b/test/cluster/eviction_webhook_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/pkg/utils"
@@ -117,6 +118,98 @@ var _ = Describe(
 							validateClusterPVCDeletion(ctx, oldPvcInfoPerPod)
 						},
 					)
+
+					It("Should NOT delete local PVCs when an eviction-blocked annotation is set on a failed pod ",
+						func() {
+							aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+							Expect(err).ToNot(HaveOccurred())
+
+							podList, err := getClusterPodList(k8sClient, ctx, aeroCluster)
+							Expect(err).ToNot(HaveOccurred())
+
+							oldPvcInfoPerPod, err := extractClusterPVC(ctx, k8sClient, aeroCluster)
+							Expect(err).ToNot(HaveOccurred())
+
+							targetPod := &podList.Items[0]
+
+							By("Marking the target pod as failed")
+							Expect(markPodAsFailed(ctx, k8sClient, targetPod.Name, namespace)).ToNot(HaveOccurred())
+
+							By("Evicting the failed pod — webhook blocks it and sets the eviction-blocked annotation")
+
+							err = evictPod(ctx, targetPod)
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(ContainSubstring(
+								"Eviction of Aerospike pod %s/%s is blocked by admission webhook",
+								targetPod.Namespace, targetPod.Name))
+
+							By("Verifying the eviction-blocked annotation was set on the failed pod")
+							Eventually(func() string {
+								pod := &corev1.Pod{}
+								if err = k8sClient.Get(ctx, types.NamespacedName{
+									Name: targetPod.Name, Namespace: namespace,
+								}, pod); err != nil {
+									return ""
+								}
+
+								return pod.Annotations[asdbv1.EvictionBlockedAnnotation]
+							}, time.Minute, retryInterval).ShouldNot(BeEmpty())
+
+							By("Waiting for AKO to recover the failed pod")
+
+							err = waitForAerospikeCluster(
+								k8sClient, ctx, aeroCluster, int(aeroCluster.Spec.Size),
+								retryInterval, getTimeout(aeroCluster.Spec.Size),
+								[]asdbv1.AerospikeClusterPhase{asdbv1.AerospikeClusterCompleted},
+							)
+							Expect(err).ToNot(HaveOccurred())
+
+							By("Asserting PVC for the failed pod is preserved (eviction annotation ignored for isFailureRecovery=true)")
+							Expect(validatePVCDeletion(ctx, oldPvcInfoPerPod[targetPod.Name], false)).ToNot(HaveOccurred())
+						})
+
+					It("Should delete local PVCs when an eviction-blocked annotation is set on a failed pod "+
+						"and deleteLocalStorageOnPodRecovery is enabled", func() {
+						aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+						Expect(err).ToNot(HaveOccurred())
+
+						aeroCluster.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(true)
+						Expect(updateCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+						aeroCluster, err = getCluster(k8sClient, ctx, clusterNamespacedName)
+						Expect(err).ToNot(HaveOccurred())
+
+						podList, err := getClusterPodList(k8sClient, ctx, aeroCluster)
+						Expect(err).ToNot(HaveOccurred())
+
+						oldPvcInfoPerPod, err := extractClusterPVC(ctx, k8sClient, aeroCluster)
+						Expect(err).ToNot(HaveOccurred())
+
+						targetPod := &podList.Items[0]
+
+						By("Marking the target pod as failed")
+						Expect(markPodAsFailed(ctx, k8sClient, targetPod.Name, namespace)).ToNot(HaveOccurred())
+
+						By("Evicting the failed pod — webhook blocks it and sets the eviction-blocked annotation")
+
+						err = evictPod(ctx, targetPod)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring(
+							"Eviction of Aerospike pod %s/%s is blocked by admission webhook",
+							targetPod.Namespace, targetPod.Name))
+
+						By("Waiting for AKO to recover the failed pod (with PVC deletion)")
+
+						err = waitForAerospikeCluster(
+							k8sClient, ctx, aeroCluster, int(aeroCluster.Spec.Size),
+							retryInterval, getTimeout(aeroCluster.Spec.Size),
+							[]asdbv1.AerospikeClusterPhase{asdbv1.AerospikeClusterCompleted},
+						)
+						Expect(err).ToNot(HaveOccurred())
+
+						By("Asserting PVC for the failed pod is deleted")
+						Expect(validatePVCDeletion(ctx, oldPvcInfoPerPod[targetPod.Name], true)).ToNot(HaveOccurred())
+					})
 				})
 
 				Context("Non-Aerospike pods", func() {

--- a/test/cluster/local_pvc_delete_test.go
+++ b/test/cluster/local_pvc_delete_test.go
@@ -25,20 +25,20 @@ var _ = Describe(
 		migrateFillDelay := int64(300)
 		clusterNamespacedName := test.GetNamespacedName(clusterName, namespace)
 
-		Context("When doing valid operations", func() {
-			AfterEach(
-				func() {
-					aeroCluster := &asdbv1.AerospikeCluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      clusterName,
-							Namespace: namespace,
-						},
-					}
-					Expect(DeleteCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
-					Expect(CleanupPVC(k8sClient, aeroCluster.Namespace, aeroCluster.Name)).ToNot(HaveOccurred())
-				},
-			)
+		AfterEach(
+			func() {
+				aeroCluster := &asdbv1.AerospikeCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      clusterName,
+						Namespace: namespace,
+					},
+				}
+				Expect(DeleteCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+				Expect(CleanupPVC(k8sClient, aeroCluster.Namespace, aeroCluster.Name)).ToNot(HaveOccurred())
+			},
+		)
 
+		Context("When doing valid operations", func() {
 			Context("When doing rolling restart", func() {
 				It("Should delete the local PVCs when deleteLocalStorageOnRestart is set and set MFD dynamically",
 					func() {
@@ -161,6 +161,113 @@ var _ = Describe(
 					By("Validating PVCs deletion")
 					validateClusterPVCDeletion(ctx, oldPvcInfoPerPod, clusterName+"-2-0")
 				})
+			})
+		})
+
+		Context("When a pod is failed (failure recovery path)", func() {
+			It("Should NOT delete local PVCs for a failed pod during rolling restart even if "+
+				"deleteLocalStorageOnRestart is set", func() {
+				aeroCluster := createDummyAerospikeCluster(clusterNamespacedName, 3)
+				aeroCluster.Spec.Storage.DeleteLocalStorageOnRestart = ptr.To(true)
+				aeroCluster.Spec.Storage.LocalStorageClasses = []string{storageClass}
+				Expect(DeployCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+				oldPvcInfoPerPod, err := extractClusterPVC(ctx, k8sClient, aeroCluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				failedPodName := clusterName + "-0-0"
+
+				By("Marking pod as failed")
+				Expect(markPodAsFailed(ctx, k8sClient, failedPodName, namespace)).ToNot(HaveOccurred())
+
+				By("Triggering rolling restart via pod metadata update")
+
+				aeroCluster.Spec.PodSpec.AerospikeObjectMeta = asdbv1.AerospikeObjectMeta{
+					Labels: map[string]string{"test-label": "failure-recovery"},
+				}
+				Expect(updateCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+				By("Validating failed pod PVC is preserved; active pods PVCs are deleted")
+				// Failed pod PVC must survive (isFailureRecovery=true, no deleteLocalStorageOnPodFailureRecovery).
+				// All other pods are active restarts: their PVCs should be replaced.
+				validateClusterPVCDeletion(ctx, oldPvcInfoPerPod, failedPodName)
+			})
+
+			It("Should delete local PVCs for a failed pod during rolling restart when "+
+				"deleteLocalStorageOnPodFailureRecovery is set", func() {
+				aeroCluster := createDummyAerospikeCluster(clusterNamespacedName, 3)
+				aeroCluster.Spec.Storage.DeleteLocalStorageOnRestart = ptr.To(true)
+				aeroCluster.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(true)
+				aeroCluster.Spec.Storage.LocalStorageClasses = []string{storageClass}
+				Expect(DeployCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+				oldPvcInfoPerPod, err := extractClusterPVC(ctx, k8sClient, aeroCluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				failedPodName := clusterName + "-0-0"
+
+				By("Marking pod as failed")
+				Expect(markPodAsFailed(ctx, k8sClient, failedPodName, namespace)).ToNot(HaveOccurred())
+
+				By("Triggering rolling restart via pod metadata update")
+
+				aeroCluster, err = getCluster(k8sClient, ctx, clusterNamespacedName)
+				Expect(err).ToNot(HaveOccurred())
+
+				aeroCluster.Spec.PodSpec.AerospikeObjectMeta = asdbv1.AerospikeObjectMeta{
+					Labels: map[string]string{"test-label": "failure-recovery-delete"},
+				}
+				Expect(updateCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+				By("Validating all pods PVCs are deleted (including failed pod)")
+				validateClusterPVCDeletion(ctx, oldPvcInfoPerPod)
+			})
+
+			It("Should NOT delete local PVCs for a failed pod during image upgrade even if "+
+				"deleteLocalStorageOnRestart is set", func() {
+				aeroCluster := createDummyAerospikeCluster(clusterNamespacedName, 3)
+				aeroCluster.Spec.Storage.DeleteLocalStorageOnRestart = ptr.To(true)
+				aeroCluster.Spec.Storage.LocalStorageClasses = []string{storageClass}
+				Expect(DeployCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+				oldPvcInfoPerPod, err := extractClusterPVC(ctx, k8sClient, aeroCluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				failedPodName := clusterName + "-0-0"
+
+				By("Marking pod as failed")
+				Expect(markPodAsFailed(ctx, k8sClient, failedPodName, namespace)).ToNot(HaveOccurred())
+
+				By("Triggering image upgrade")
+				Expect(UpdateClusterImage(aeroCluster, nextImage)).ToNot(HaveOccurred())
+				Expect(updateCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+				By("Validating failed pod PVC is preserved; active pods PVCs are deleted")
+				validateClusterPVCDeletion(ctx, oldPvcInfoPerPod, failedPodName)
+			})
+
+			It("Should delete local PVCs for a failed pod during upgrade when "+
+				"deleteLocalStorageOnPodFailureRecovery is set", func() {
+				aeroCluster := createDummyAerospikeCluster(clusterNamespacedName, 3)
+				aeroCluster.Spec.Storage.DeleteLocalStorageOnRestart = ptr.To(true)
+				aeroCluster.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(true)
+				aeroCluster.Spec.Storage.LocalStorageClasses = []string{storageClass}
+				Expect(DeployCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+				oldPvcInfoPerPod, err := extractClusterPVC(ctx, k8sClient, aeroCluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				failedPodName := clusterName + "-0-0"
+
+				By("Marking pod as failed")
+				Expect(markPodAsFailed(ctx, k8sClient, failedPodName, namespace)).ToNot(HaveOccurred())
+
+				By("Triggering image upgrade")
+				Expect(UpdateClusterImage(aeroCluster, nextImage)).ToNot(HaveOccurred())
+				Expect(updateCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+				By("Validating all pods PVCs are deleted (including failed pod)")
+				validateClusterPVCDeletion(ctx, oldPvcInfoPerPod)
 			})
 		})
 

--- a/test/envtests/cluster/cluster_webhook_test.go
+++ b/test/envtests/cluster/cluster_webhook_test.go
@@ -160,9 +160,7 @@ var _ = Describe("AerospikeCluster validation", func() {
 					// Webhook response validation
 					envtests.NewStatusErrorMatcher().
 						WithMessageSubstrings("\"vaerospikecluster.kb.io\"",
-							"namespace storage device related devicePath /test/dev/xvdf not found in Storage config",
-							"<nil>", "deleteFiles deleteFiles false}",
-							"{<nil> <nil>", "none dd false} 1 [] <nil> []}").
+							"namespace storage device related devicePath /test/dev/xvdf not found in Storage config").
 						Validate(err)
 				})
 

--- a/test/envtests/cluster/storage_webhook_test.go
+++ b/test/envtests/cluster/storage_webhook_test.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/test/testutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,6 +79,47 @@ var _ = Describe("Storage webhook validation", func() {
 							{ID: 1, Revision: "v1", InputStorage: &fullRack},
 						},
 					}
+
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+				})
+			})
+		})
+
+		Context("spec.storage deleteLocalStorageOnPodFailureRecovery validation", func() {
+			Context("negative", func() {
+				It("rejects deploy when deleteLocalStorageOnPodFailureRecovery is true "+
+					"but localStorageClasses is empty", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 2)
+					aeroCluster.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(true)
+					aeroCluster.Spec.Storage.LocalStorageClasses = nil
+
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"\"vaerospikecluster.kb.io\"",
+							"localStorageClasses cannot be empty if deleteLocalStorageOnPodFailureRecovery is set",
+						).
+						Validate(err)
+				})
+			})
+
+			Context("positive", func() {
+				It("allows deploy when deleteLocalStorageOnPodFailureRecovery is true "+
+					"and localStorageClasses is set", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 2)
+					aeroCluster.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(true)
+					aeroCluster.Spec.Storage.LocalStorageClasses = []string{testutil.StorageClass}
+
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+				})
+
+				It("allows deploy when deleteLocalStorageOnPodFailureRecovery is false "+
+					"without localStorageClasses", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 2)
+					aeroCluster.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(false)
+					// no localStorageClasses required when the flag is false
 
 					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
 				})
@@ -251,6 +293,50 @@ var _ = Describe("Storage webhook validation", func() {
 					for i := range current.Spec.RackConfig.Racks {
 						current.Spec.RackConfig.Racks[i].InputStorage = nil
 					}
+
+					Expect(envtests.K8sClient.Update(ctx, current)).To(Succeed())
+				})
+			})
+		})
+
+		Context("spec.storage deleteLocalStorageOnPodFailureRecovery validation", func() {
+			Context("negative", func() {
+				It("rejects update that enables deleteLocalStorageOnPodFailureRecovery "+
+					"without localStorageClasses", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 2)
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, nsName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(true)
+					aeroCluster.Spec.Storage.LocalStorageClasses = nil
+
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							"\"vaerospikecluster.kb.io\"",
+							"localStorageClasses cannot be empty if deleteLocalStorageOnPodFailureRecovery is set",
+						).
+						Validate(err)
+				})
+			})
+
+			Context("positive", func() {
+				It("allows disabling deleteLocalStorageOnPodFailureRecovery via update"+
+					" without localStorageClasses", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 2)
+					aeroCluster.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(true)
+					aeroCluster.Spec.Storage.LocalStorageClasses = []string{testutil.StorageClass}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, nsName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.Storage.DeleteLocalStorageOnPodRecovery = ptr.To(false)
+					current.Spec.Storage.LocalStorageClasses = nil
 
 					Expect(envtests.K8sClient.Update(ctx, current)).To(Succeed())
 				})


### PR DESCRIPTION
- Add deleteLocalStorageOnPodFailure storage flag (default false) as an explicit opt-in for local PVC deletion during unplanned pod failure recovery; preserves PVCs by default since disk data is intact after aprocess crash
- Thread isFailureRecovery bool through restartPods and deletePodAndEnsureImageUpdated so deleteLocalStorageOnRestart and eviction/node-blocklist triggers are not applied to crashed pods
- Block scale-down of non-ignorable failed pods in scaleDownRack; the old unconditional Insert into ignorablePodNames skipped all safety checks (migration, safe-stop, cascade-delete PVC), causing data loss on any storage type; maxIgnorablePods is now the escape valve
- Use getAllRevisionRackPodList in getIgnorablePods so old-revision pods are included in the maxIgnorablePods budget, preventing premature scale-down of the old STS during rack revision migration

TODO:
- Automated test-cases
- lib quiesce check