### PR TITLE
refactor: KO-556 Standardize logging, error, and event formatting in AerospikeCluster controller

### DIFF
--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -4,6 +4,7 @@ package cluster
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -34,6 +36,7 @@ const (
 // Returns a tuple of admin username and password to use. If the cluster is not security
 // enabled both username and password will be zero strings.
 func AerospikeAdminCredentials(
+	ctx context.Context,
 	desiredState, currentState *asdbv1.AerospikeClusterSpec,
 	passwordProvider AerospikeUserPasswordProvider,
 ) (user, pass string, err error) {
@@ -49,15 +52,15 @@ func AerospikeAdminCredentials(
 
 	if currentState.AerospikeAccessControl == nil {
 		// We haven't yet set up access control. Use default password.
-		return asdbv1.AdminUsername, passwordProvider.GetDefaultPassword(desiredState), nil
+		return asdbv1.AdminUsername, passwordProvider.GetDefaultPassword(ctx, desiredState), nil
 	}
 
 	adminUserSpec, ok := asdbv1.GetUsersFromSpec(currentState)[asdbv1.AdminUsername]
 	if !ok {
 		// Should not happen on a validated spec.
-		return "", "", fmt.Errorf(
+		return "", "", reconcile.TerminalError(fmt.Errorf(
 			"%s user missing in access control", asdbv1.AdminUsername,
-		)
+		))
 	}
 
 	// If authMode PKIOnly is set for admin user in status, return empty user and empty password.
@@ -66,7 +69,7 @@ func AerospikeAdminCredentials(
 	}
 
 	password, err := passwordProvider.Get(
-		asdbv1.AdminUsername, &adminUserSpec,
+		ctx, asdbv1.AdminUsername, &adminUserSpec,
 	)
 	if err != nil {
 		return "", "", err
@@ -77,6 +80,7 @@ func AerospikeAdminCredentials(
 
 // reconcileAccessControl reconciles access control to ensure current state moves to the desired state.
 func (r *SingleClusterReconciler) reconcileAccessControl(
+	ctx context.Context,
 	client *as.Client,
 	passwordProvider AerospikeUserPasswordProvider,
 ) error {
@@ -84,7 +88,6 @@ func (r *SingleClusterReconciler) reconcileAccessControl(
 
 	currentState, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		r.Log.Error(err, "Failed to copy spec in status", "err", err)
 		return err
 	}
 
@@ -103,7 +106,7 @@ func (r *SingleClusterReconciler) reconcileAccessControl(
 	currentUsers := asdbv1.GetUsersFromSpec(currentState)
 
 	return r.reconcileUsers(
-		desiredUsers, currentUsers, passwordProvider, client, adminPolicy,
+		ctx, desiredUsers, currentUsers, passwordProvider, client, adminPolicy,
 	)
 }
 
@@ -171,6 +174,7 @@ func (r *SingleClusterReconciler) reconcileRoles(
 
 // reconcileUsers reconciles users to take them from current to desired.
 func (r *SingleClusterReconciler) reconcileUsers(
+	ctx context.Context,
 	desired map[string]asdbv1.AerospikeUserSpec,
 	current map[string]asdbv1.AerospikeUserSpec,
 	passwordProvider AerospikeUserPasswordProvider, client *as.Client,
@@ -230,7 +234,7 @@ func (r *SingleClusterReconciler) reconcileUsers(
 
 		case asdbv1.IsAuthModeInternal(userSpec.AuthMode):
 			// Enterprise with Internal auth: real password from provider
-			pwd, err := passwordProvider.Get(userName, &userSpec)
+			pwd, err := passwordProvider.Get(ctx, userName, &userSpec)
 			if err != nil {
 				return err
 			}
@@ -279,7 +283,7 @@ func privilegeStringToAerospikePrivilege(privilegeStrings []string) (
 		parts := strings.Split(privilege, ".")
 		if _, ok := asdbv1.Privileges[parts[0]]; !ok {
 			// First part of the privilege is not part of defined privileges.
-			return nil, fmt.Errorf("invalid privilege %s", privilege)
+			return nil, reconcile.TerminalError(fmt.Errorf("invalid privilege %q", privilege))
 		}
 
 		privilegeCode := parts[0]
@@ -339,7 +343,7 @@ func privilegeStringToAerospikePrivilege(privilegeStrings []string) (
 			code = as.WriteMasked
 
 		default:
-			return nil, fmt.Errorf("unknown privilege %s", privilegeCode)
+			return nil, reconcile.TerminalError(fmt.Errorf("unknown privilege %q", privilegeCode))
 		}
 
 		aerospikePrivilege := as.Privilege{
@@ -401,9 +405,9 @@ func AerospikePrivilegeToPrivilegeString(aerospikePrivileges []as.Privilege) (
 			buffer.WriteString("write-masked")
 
 		default:
-			return nil, fmt.Errorf(
-				"unknown privilege code %v", aerospikePrivilege.Code,
-			)
+			return nil, reconcile.TerminalError(fmt.Errorf(
+				"unknown privilege code %s", fmt.Sprint(aerospikePrivilege.Code),
+			))
 		}
 
 		if aerospikePrivilege.Namespace != "" {
@@ -425,12 +429,12 @@ func AerospikePrivilegeToPrivilegeString(aerospikePrivileges []as.Privilege) (
 // AerospikeUserPasswordProvider provides password for a give user..
 type AerospikeUserPasswordProvider interface {
 	// Get returns the password for username.
-	Get(username string, userSpec *asdbv1.AerospikeUserSpec) (
+	Get(ctx context.Context, username string, userSpec *asdbv1.AerospikeUserSpec) (
 		string, error,
 	)
 
 	// GetDefaultPassword returns the default password for cluster using AerospikeClusterSpec.
-	GetDefaultPassword(spec *asdbv1.AerospikeClusterSpec) string
+	GetDefaultPassword(ctx context.Context, spec *asdbv1.AerospikeClusterSpec) string
 }
 
 // aerospikeAccessControlReconcileCmd commands needed to Reconcile a single access control entry,
@@ -477,7 +481,7 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 		} else {
 			// Failure to query for the role.
 			return fmt.Errorf(
-				"error querying role %s: %v", roleCreate.name, err,
+				"querying role %q: %w", roleCreate.name, err,
 			)
 		}
 	}
@@ -517,14 +521,14 @@ func (roleCreate aerospikeRoleCreateUpdate) createRole(
 
 	aerospikePrivileges, err := privilegeStringToAerospikePrivilege(roleCreate.privileges)
 	if err != nil {
-		return fmt.Errorf("could not create role %s: %v", roleCreate.name, err)
+		return fmt.Errorf("converting privileges for role %q: %w", roleCreate.name, err)
 	}
 
 	if err = client.CreateRole(
 		adminPolicy, roleCreate.name, aerospikePrivileges, roleCreate.whitelist,
 		roleCreate.readQuota, roleCreate.writeQuota,
 	); err != nil {
-		return fmt.Errorf("could not create role %s: %v", roleCreate.name, err)
+		return fmt.Errorf("creating role %q: %w", roleCreate.name, err)
 	}
 
 	logger.Info("Created role", "role name", roleCreate.name)
@@ -548,7 +552,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 	// Find the privileges to drop.
 	currentPrivileges, err := AerospikePrivilegeToPrivilegeString(role.Privileges)
 	if err != nil {
-		return fmt.Errorf("could not update role %s: %v", roleCreate.name, err)
+		return fmt.Errorf("converting current privileges for role %q: %w", roleCreate.name, err)
 	}
 
 	desiredPrivileges := roleCreate.privileges
@@ -559,7 +563,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 		aerospikePrivileges, err := privilegeStringToAerospikePrivilege(privilegesToRevoke)
 		if err != nil {
 			return fmt.Errorf(
-				"could not update role %s: %v", roleCreate.name, err,
+				"converting privileges to revoke for role %q: %w", roleCreate.name, err,
 			)
 		}
 
@@ -567,7 +571,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, aerospikePrivileges,
 		); err != nil {
 			return fmt.Errorf(
-				"error revoking privileges for role %s: %v", roleCreate.name,
+				"revoking privileges for role %q: %w", roleCreate.name,
 				err,
 			)
 		}
@@ -582,7 +586,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 		aerospikePrivileges, err := privilegeStringToAerospikePrivilege(privilegesToGrant)
 		if err != nil {
 			return fmt.Errorf(
-				"could not update role %s: %v", roleCreate.name, err,
+				"converting privileges to grant for role %q: %w", roleCreate.name, err,
 			)
 		}
 
@@ -590,7 +594,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, aerospikePrivileges,
 		); err != nil {
 			return fmt.Errorf(
-				"error granting privileges for role %s: %v", roleCreate.name,
+				"granting privileges for role %q: %w", roleCreate.name,
 				err,
 			)
 		}
@@ -607,7 +611,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, roleCreate.whitelist,
 		); err != nil {
 			return fmt.Errorf(
-				"error setting whitelist for role %s: %v", roleCreate.name, err,
+				"setting whitelist for role %q: %w", roleCreate.name, err,
 			)
 		}
 	}
@@ -617,7 +621,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, roleCreate.readQuota, roleCreate.writeQuota,
 		); err != nil {
 			return fmt.Errorf(
-				"error setting quotas for role %s: %v", roleCreate.name, err,
+				"setting quotas for role %q: %w", roleCreate.name, err,
 			)
 		}
 	}
@@ -657,7 +661,7 @@ func (userCreate aerospikeUserCreateUpdate) execute(
 		} else {
 			// Failure to query for the user.
 			return fmt.Errorf(
-				"error querying user %s: %v", userCreate.name, err,
+				"querying user %q: %w", userCreate.name, err,
 			)
 		}
 	}
@@ -696,15 +700,15 @@ func (userCreate aerospikeUserCreateUpdate) createUser(
 	logger.Info("Creating user", "username", userCreate.name)
 
 	if userCreate.password == nil {
-		return fmt.Errorf(
-			"error creating user %s. Password not specified", userCreate.name,
-		)
+		return reconcile.TerminalError(fmt.Errorf(
+			"creating user %q: password not specified", userCreate.name,
+		))
 	}
 
 	if err := client.CreateUser(
 		adminPolicy, userCreate.name, *userCreate.password, userCreate.roles,
 	); err != nil {
-		return fmt.Errorf("could not create user %s: %v", userCreate.name, err)
+		return fmt.Errorf("creating user %q: %w", userCreate.name, err)
 	}
 
 	logger.Info("Created user", "username", userCreate.name)
@@ -731,7 +735,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 			adminPolicy, userCreate.name, *userCreate.password,
 		); err != nil {
 			return fmt.Errorf(
-				"error updating password for user %s: %v", userCreate.name, err,
+				"updating password for user %q: %w", userCreate.name, err,
 			)
 		}
 
@@ -747,7 +751,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 	if len(rolesToRevoke) > 0 {
 		if err := client.RevokeRoles(adminPolicy, userCreate.name, rolesToRevoke); err != nil {
 			return fmt.Errorf(
-				"error revoking roles for user %s: %v", userCreate.name, err,
+				"revoking roles for user %q: %w", userCreate.name, err,
 			)
 		}
 
@@ -760,7 +764,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 	if len(rolesToGrant) > 0 {
 		if err := client.GrantRoles(adminPolicy, userCreate.name, rolesToGrant); err != nil {
 			return fmt.Errorf(
-				"error granting roles for user %s: %v", userCreate.name, err,
+				"granting roles for user %q: %w", userCreate.name, err,
 			)
 		}
 
@@ -795,7 +799,7 @@ func (userDrop aerospikeUserDrop) execute(
 	if err := client.DropUser(adminPolicy, userDrop.name); err != nil {
 		if !strings.Contains(err.Error(), userNotFoundErr) {
 			// Failure to drop for the user.
-			return fmt.Errorf("error dropping user %s: %v", userDrop.name, err)
+			return fmt.Errorf("dropping user %q: %w", userDrop.name, err)
 		}
 	}
 
@@ -824,7 +828,7 @@ func (roleDrop aerospikeRoleDrop) execute(
 	if err := client.DropRole(adminPolicy, roleDrop.name); err != nil {
 		if !strings.Contains(err.Error(), roleNotFoundErr) {
 			// Failure to drop for the role.
-			return fmt.Errorf("error dropping role %s: %v", roleDrop.name, err)
+			return fmt.Errorf("dropping role %q: %w", roleDrop.name, err)
 		}
 	}
 

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -87,7 +87,7 @@ func (r *SingleClusterReconciler) reconcileAccessControl(
 
 	currentState, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		return fmt.Errorf("could not copy cluster status to spec: %w", err)
+		return fmt.Errorf("copy cluster status to spec: %w", err)
 	}
 
 	// Get admin policy based in desired state so that new timeout updates can be applied. It is safe.
@@ -520,14 +520,14 @@ func (roleCreate aerospikeRoleCreateUpdate) createRole(
 
 	aerospikePrivileges, err := privilegeStringToAerospikePrivilege(roleCreate.privileges)
 	if err != nil {
-		return fmt.Errorf("could not create role %s: %w", roleCreate.name, err)
+		return fmt.Errorf("create role %s: %w", roleCreate.name, err)
 	}
 
 	if err = client.CreateRole(
 		adminPolicy, roleCreate.name, aerospikePrivileges, roleCreate.whitelist,
 		roleCreate.readQuota, roleCreate.writeQuota,
 	); err != nil {
-		return fmt.Errorf("could not create role %s: %w", roleCreate.name, err)
+		return fmt.Errorf("create role %s: %w", roleCreate.name, err)
 	}
 
 	logger.Info("Created role", "role name", roleCreate.name)
@@ -551,7 +551,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 	// Find the privileges to drop.
 	currentPrivileges, err := AerospikePrivilegeToPrivilegeString(role.Privileges)
 	if err != nil {
-		return fmt.Errorf("could not update role %s: %w", roleCreate.name, err)
+		return fmt.Errorf("update role %s: %w", roleCreate.name, err)
 	}
 
 	desiredPrivileges := roleCreate.privileges
@@ -561,7 +561,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 	if len(privilegesToRevoke) > 0 {
 		aerospikePrivileges, err := privilegeStringToAerospikePrivilege(privilegesToRevoke)
 		if err != nil {
-			return fmt.Errorf("could not update role %s: %w", roleCreate.name, err)
+			return fmt.Errorf("update role %s: %w", roleCreate.name, err)
 		}
 
 		if err := client.RevokePrivileges(
@@ -582,7 +582,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 	if len(privilegesToGrant) > 0 {
 		aerospikePrivileges, err := privilegeStringToAerospikePrivilege(privilegesToGrant)
 		if err != nil {
-			return fmt.Errorf("could not update role %s: %w", roleCreate.name, err)
+			return fmt.Errorf("update role %s: %w", roleCreate.name, err)
 		}
 
 		if err := client.GrantPrivileges(
@@ -703,7 +703,7 @@ func (userCreate aerospikeUserCreateUpdate) createUser(
 	if err := client.CreateUser(
 		adminPolicy, userCreate.name, *userCreate.password, userCreate.roles,
 	); err != nil {
-		return fmt.Errorf("could not create user %s: %w", userCreate.name, err)
+		return fmt.Errorf("create user %s: %w", userCreate.name, err)
 	}
 
 	logger.Info("Created user", "username", userCreate.name)

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -58,9 +57,9 @@ func AerospikeAdminCredentials(
 	adminUserSpec, ok := asdbv1.GetUsersFromSpec(currentState)[asdbv1.AdminUsername]
 	if !ok {
 		// Should not happen on a validated spec.
-		return "", "", reconcile.TerminalError(fmt.Errorf(
+		return "", "", fmt.Errorf(
 			"%s user missing in access control", asdbv1.AdminUsername,
-		))
+		)
 	}
 
 	// If authMode PKIOnly is set for admin user in status, return empty user and empty password.
@@ -283,7 +282,7 @@ func privilegeStringToAerospikePrivilege(privilegeStrings []string) (
 		parts := strings.Split(privilege, ".")
 		if _, ok := asdbv1.Privileges[parts[0]]; !ok {
 			// First part of the privilege is not part of defined privileges.
-			return nil, reconcile.TerminalError(fmt.Errorf("invalid privilege %q", privilege))
+			return nil, fmt.Errorf("invalid privilege %s", privilege)
 		}
 
 		privilegeCode := parts[0]
@@ -343,7 +342,7 @@ func privilegeStringToAerospikePrivilege(privilegeStrings []string) (
 			code = as.WriteMasked
 
 		default:
-			return nil, reconcile.TerminalError(fmt.Errorf("unknown privilege %q", privilegeCode))
+			return nil, fmt.Errorf("unknown privilege %s", privilegeCode)
 		}
 
 		aerospikePrivilege := as.Privilege{
@@ -405,9 +404,9 @@ func AerospikePrivilegeToPrivilegeString(aerospikePrivileges []as.Privilege) (
 			buffer.WriteString("write-masked")
 
 		default:
-			return nil, reconcile.TerminalError(fmt.Errorf(
-				"unknown privilege code %s", fmt.Sprint(aerospikePrivilege.Code),
-			))
+		return nil, fmt.Errorf(
+			"unknown privilege code %v", aerospikePrivilege.Code,
+		)
 		}
 
 		if aerospikePrivilege.Namespace != "" {
@@ -700,9 +699,7 @@ func (userCreate aerospikeUserCreateUpdate) createUser(
 	logger.Info("Creating user", "username", userCreate.name)
 
 	if userCreate.password == nil {
-		return reconcile.TerminalError(fmt.Errorf(
-			"creating user %q: password not specified", userCreate.name,
-		))
+	return fmt.Errorf("creating user %q: password not specified", userCreate.name)
 	}
 
 	if err := client.CreateUser(

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -87,7 +87,7 @@ func (r *SingleClusterReconciler) reconcileAccessControl(
 
 	currentState, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		return fmt.Errorf("copy cluster status to spec: %w", err)
+		return fmt.Errorf("could not copy cluster status to spec: %w", err)
 	}
 
 	// Get admin policy based in desired state so that new timeout updates can be applied. It is safe.

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -87,7 +87,7 @@ func (r *SingleClusterReconciler) reconcileAccessControl(
 
 	currentState, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		return err
+		return fmt.Errorf("copy cluster status to spec: %w", err)
 	}
 
 	// Get admin policy based in desired state so that new timeout updates can be applied. It is safe.
@@ -404,9 +404,9 @@ func AerospikePrivilegeToPrivilegeString(aerospikePrivileges []as.Privilege) (
 			buffer.WriteString("write-masked")
 
 		default:
-		return nil, fmt.Errorf(
-			"unknown privilege code %v", aerospikePrivilege.Code,
-		)
+			return nil, fmt.Errorf(
+				"unknown privilege code %v", aerospikePrivilege.Code,
+			)
 		}
 
 		if aerospikePrivilege.Namespace != "" {

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -490,8 +490,8 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 		var errorCreate error
 		if errorCreate = roleCreate.createRole(client, adminPolicy, logger, recorder, aeroCluster); errorCreate != nil {
 			recorder.Eventf(
-				aeroCluster, corev1.EventTypeWarning, "RoleCreateFailed",
-				"Failed to Create Role %s", roleCreate.name,
+				aeroCluster, corev1.EventTypeWarning, EventReasonRoleCreateFailed,
+				"Failed to create Aerospike role %s", roleCreate.name,
 			)
 		}
 
@@ -502,8 +502,8 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 		client, adminPolicy, role, logger, recorder, aeroCluster,
 	); errorUpdate != nil {
 		recorder.Eventf(
-			aeroCluster, corev1.EventTypeWarning, "RoleUpdateFailed",
-			"Failed to Update Role %s", roleCreate.name,
+			aeroCluster, corev1.EventTypeWarning, EventReasonRoleUpdateFailed,
+			"Failed to update Aerospike role %s", roleCreate.name,
 		)
 
 		return errorUpdate
@@ -533,8 +533,8 @@ func (roleCreate aerospikeRoleCreateUpdate) createRole(
 
 	logger.Info("Created role", "role name", roleCreate.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, "RoleCreated",
-		"Created Role %s", roleCreate.name,
+		aeroCluster, corev1.EventTypeNormal, EventReasonRoleCreated,
+		"Created Aerospike role %s", roleCreate.name,
 	)
 
 	return nil
@@ -628,8 +628,8 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 
 	logger.Info("Updated role", "role name", roleCreate.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, "RoleUpdated",
-		"Updated Role %s", roleCreate.name,
+		aeroCluster, corev1.EventTypeNormal, EventReasonRoleUpdated,
+		"Updated Aerospike role %s", roleCreate.name,
 	)
 
 	return nil
@@ -670,8 +670,8 @@ func (userCreate aerospikeUserCreateUpdate) execute(
 		err := userCreate.createUser(client, adminPolicy, logger, recorder, aeroCluster)
 		if err != nil {
 			recorder.Eventf(
-				aeroCluster, corev1.EventTypeWarning, "UserCreateFailed",
-				"Failed to Create User %s", userCreate.name,
+				aeroCluster, corev1.EventTypeWarning, EventReasonUserCreateFailed,
+				"Failed to create Aerospike user %s", userCreate.name,
 			)
 		}
 
@@ -682,8 +682,8 @@ func (userCreate aerospikeUserCreateUpdate) execute(
 		client, adminPolicy, user, logger, recorder, aeroCluster,
 	); errorUpdate != nil {
 		recorder.Eventf(
-			aeroCluster, corev1.EventTypeWarning, "UserUpdateFailed",
-			"Failed to Update User %s", userCreate.name,
+			aeroCluster, corev1.EventTypeWarning, EventReasonUserUpdateFailed,
+			"Failed to update Aerospike user %s", userCreate.name,
 		)
 
 		return errorUpdate
@@ -713,8 +713,8 @@ func (userCreate aerospikeUserCreateUpdate) createUser(
 
 	logger.Info("Created user", "username", userCreate.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, "UserCreated",
-		"Created User %s", userCreate.name,
+		aeroCluster, corev1.EventTypeNormal, EventReasonUserCreated,
+		"Created Aerospike user %s", userCreate.name,
 	)
 
 	return nil
@@ -776,8 +776,8 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 
 	logger.Info("Updated user", "username", userCreate.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, "UserUpdated",
-		"Updated User %s", userCreate.name,
+		aeroCluster, corev1.EventTypeNormal, EventReasonUserUpdated,
+		"Updated Aerospike user %s", userCreate.name,
 	)
 
 	return nil
@@ -805,8 +805,8 @@ func (userDrop aerospikeUserDrop) execute(
 
 	logger.Info("Dropped user", "username", userDrop.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, "UserDeleted",
-		"Dropped User %s", userDrop.name,
+		aeroCluster, corev1.EventTypeNormal, EventReasonUserDeleted,
+		"Deleted Aerospike user %s", userDrop.name,
 	)
 
 	return nil
@@ -834,8 +834,8 @@ func (roleDrop aerospikeRoleDrop) execute(
 
 	logger.Info("Dropped role", "role", roleDrop.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, "RoleDeleted",
-		"Dropped Role %s", roleDrop.name,
+		aeroCluster, corev1.EventTypeNormal, EventReasonRoleDeleted,
+		"Deleted Aerospike role %s", roleDrop.name,
 	)
 
 	return nil

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -480,7 +480,7 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 		} else {
 			// Failure to query for the role.
 			return fmt.Errorf(
-				"querying role %q: %w", roleCreate.name, err,
+				"error querying role %s: %w", roleCreate.name, err,
 			)
 		}
 	}
@@ -520,14 +520,14 @@ func (roleCreate aerospikeRoleCreateUpdate) createRole(
 
 	aerospikePrivileges, err := privilegeStringToAerospikePrivilege(roleCreate.privileges)
 	if err != nil {
-		return fmt.Errorf("converting privileges for role %q: %w", roleCreate.name, err)
+		return fmt.Errorf("could not create role %s: %w", roleCreate.name, err)
 	}
 
 	if err = client.CreateRole(
 		adminPolicy, roleCreate.name, aerospikePrivileges, roleCreate.whitelist,
 		roleCreate.readQuota, roleCreate.writeQuota,
 	); err != nil {
-		return fmt.Errorf("creating role %q: %w", roleCreate.name, err)
+		return fmt.Errorf("could not create role %s: %w", roleCreate.name, err)
 	}
 
 	logger.Info("Created role", "role name", roleCreate.name)
@@ -551,7 +551,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 	// Find the privileges to drop.
 	currentPrivileges, err := AerospikePrivilegeToPrivilegeString(role.Privileges)
 	if err != nil {
-		return fmt.Errorf("converting current privileges for role %q: %w", roleCreate.name, err)
+		return fmt.Errorf("could not update role %s: %w", roleCreate.name, err)
 	}
 
 	desiredPrivileges := roleCreate.privileges
@@ -561,16 +561,14 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 	if len(privilegesToRevoke) > 0 {
 		aerospikePrivileges, err := privilegeStringToAerospikePrivilege(privilegesToRevoke)
 		if err != nil {
-			return fmt.Errorf(
-				"converting privileges to revoke for role %q: %w", roleCreate.name, err,
-			)
+			return fmt.Errorf("could not update role %s: %w", roleCreate.name, err)
 		}
 
 		if err := client.RevokePrivileges(
 			adminPolicy, roleCreate.name, aerospikePrivileges,
 		); err != nil {
 			return fmt.Errorf(
-				"revoking privileges for role %q: %w", roleCreate.name,
+				"error revoking privileges for role %s: %w", roleCreate.name,
 				err,
 			)
 		}
@@ -584,16 +582,14 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 	if len(privilegesToGrant) > 0 {
 		aerospikePrivileges, err := privilegeStringToAerospikePrivilege(privilegesToGrant)
 		if err != nil {
-			return fmt.Errorf(
-				"converting privileges to grant for role %q: %w", roleCreate.name, err,
-			)
+			return fmt.Errorf("could not update role %s: %w", roleCreate.name, err)
 		}
 
 		if err := client.GrantPrivileges(
 			adminPolicy, roleCreate.name, aerospikePrivileges,
 		); err != nil {
 			return fmt.Errorf(
-				"granting privileges for role %q: %w", roleCreate.name,
+				"error granting privileges for role %s: %w", roleCreate.name,
 				err,
 			)
 		}
@@ -610,7 +606,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, roleCreate.whitelist,
 		); err != nil {
 			return fmt.Errorf(
-				"setting whitelist for role %q: %w", roleCreate.name, err,
+				"error setting whitelist for role %s: %w", roleCreate.name, err,
 			)
 		}
 	}
@@ -620,7 +616,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, roleCreate.readQuota, roleCreate.writeQuota,
 		); err != nil {
 			return fmt.Errorf(
-				"setting quotas for role %q: %w", roleCreate.name, err,
+				"error setting quotas for role %s: %w", roleCreate.name, err,
 			)
 		}
 	}
@@ -660,7 +656,7 @@ func (userCreate aerospikeUserCreateUpdate) execute(
 		} else {
 			// Failure to query for the user.
 			return fmt.Errorf(
-				"querying user %q: %w", userCreate.name, err,
+				"error querying user %s: %w", userCreate.name, err,
 			)
 		}
 	}
@@ -699,13 +695,15 @@ func (userCreate aerospikeUserCreateUpdate) createUser(
 	logger.Info("Creating user", "username", userCreate.name)
 
 	if userCreate.password == nil {
-	return fmt.Errorf("creating user %q: password not specified", userCreate.name)
+		return fmt.Errorf(
+			"error creating user %s. Password not specified", userCreate.name,
+		)
 	}
 
 	if err := client.CreateUser(
 		adminPolicy, userCreate.name, *userCreate.password, userCreate.roles,
 	); err != nil {
-		return fmt.Errorf("creating user %q: %w", userCreate.name, err)
+		return fmt.Errorf("could not create user %s: %w", userCreate.name, err)
 	}
 
 	logger.Info("Created user", "username", userCreate.name)
@@ -732,7 +730,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 			adminPolicy, userCreate.name, *userCreate.password,
 		); err != nil {
 			return fmt.Errorf(
-				"updating password for user %q: %w", userCreate.name, err,
+				"error updating password for user %s: %w", userCreate.name, err,
 			)
 		}
 
@@ -748,7 +746,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 	if len(rolesToRevoke) > 0 {
 		if err := client.RevokeRoles(adminPolicy, userCreate.name, rolesToRevoke); err != nil {
 			return fmt.Errorf(
-				"revoking roles for user %q: %w", userCreate.name, err,
+				"error revoking roles for user %s: %w", userCreate.name, err,
 			)
 		}
 
@@ -761,7 +759,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 	if len(rolesToGrant) > 0 {
 		if err := client.GrantRoles(adminPolicy, userCreate.name, rolesToGrant); err != nil {
 			return fmt.Errorf(
-				"granting roles for user %q: %w", userCreate.name, err,
+				"error granting roles for user %s: %w", userCreate.name, err,
 			)
 		}
 
@@ -796,7 +794,7 @@ func (userDrop aerospikeUserDrop) execute(
 	if err := client.DropUser(adminPolicy, userDrop.name); err != nil {
 		if !strings.Contains(err.Error(), userNotFoundErr) {
 			// Failure to drop for the user.
-			return fmt.Errorf("dropping user %q: %w", userDrop.name, err)
+			return fmt.Errorf("error dropping user %s: %w", userDrop.name, err)
 		}
 	}
 
@@ -825,7 +823,7 @@ func (roleDrop aerospikeRoleDrop) execute(
 	if err := client.DropRole(adminPolicy, roleDrop.name); err != nil {
 		if !strings.Contains(err.Error(), roleNotFoundErr) {
 			// Failure to drop for the role.
-			return fmt.Errorf("dropping role %q: %w", roleDrop.name, err)
+			return fmt.Errorf("error dropping role %s: %w", roleDrop.name, err)
 		}
 	}
 

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -489,7 +489,7 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 		var errorCreate error
 		if errorCreate = roleCreate.createRole(client, adminPolicy, logger, recorder, aeroCluster); errorCreate != nil {
 			recorder.Eventf(
-				aeroCluster, corev1.EventTypeWarning, EventReasonRoleCreateFailed,
+				aeroCluster, corev1.EventTypeWarning, "RoleCreateFailed",
 				"Failed to create Aerospike role %s", roleCreate.name,
 			)
 		}
@@ -501,7 +501,7 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 		client, adminPolicy, role, logger, recorder, aeroCluster,
 	); errorUpdate != nil {
 		recorder.Eventf(
-			aeroCluster, corev1.EventTypeWarning, EventReasonRoleUpdateFailed,
+			aeroCluster, corev1.EventTypeWarning, "RoleUpdateFailed",
 			"Failed to update Aerospike role %s", roleCreate.name,
 		)
 
@@ -532,7 +532,7 @@ func (roleCreate aerospikeRoleCreateUpdate) createRole(
 
 	logger.Info("Created role", "role name", roleCreate.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, EventReasonRoleCreated,
+		aeroCluster, corev1.EventTypeNormal, "RoleCreated",
 		"Created Aerospike role %s", roleCreate.name,
 	)
 
@@ -623,7 +623,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 
 	logger.Info("Updated role", "role name", roleCreate.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, EventReasonRoleUpdated,
+		aeroCluster, corev1.EventTypeNormal, "RoleUpdated",
 		"Updated Aerospike role %s", roleCreate.name,
 	)
 
@@ -665,7 +665,7 @@ func (userCreate aerospikeUserCreateUpdate) execute(
 		err := userCreate.createUser(client, adminPolicy, logger, recorder, aeroCluster)
 		if err != nil {
 			recorder.Eventf(
-				aeroCluster, corev1.EventTypeWarning, EventReasonUserCreateFailed,
+				aeroCluster, corev1.EventTypeWarning, "UserCreateFailed",
 				"Failed to create Aerospike user %s", userCreate.name,
 			)
 		}
@@ -677,7 +677,7 @@ func (userCreate aerospikeUserCreateUpdate) execute(
 		client, adminPolicy, user, logger, recorder, aeroCluster,
 	); errorUpdate != nil {
 		recorder.Eventf(
-			aeroCluster, corev1.EventTypeWarning, EventReasonUserUpdateFailed,
+			aeroCluster, corev1.EventTypeWarning, "UserUpdateFailed",
 			"Failed to update Aerospike user %s", userCreate.name,
 		)
 
@@ -708,7 +708,7 @@ func (userCreate aerospikeUserCreateUpdate) createUser(
 
 	logger.Info("Created user", "username", userCreate.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, EventReasonUserCreated,
+		aeroCluster, corev1.EventTypeNormal, "UserCreated",
 		"Created Aerospike user %s", userCreate.name,
 	)
 
@@ -771,7 +771,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 
 	logger.Info("Updated user", "username", userCreate.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, EventReasonUserUpdated,
+		aeroCluster, corev1.EventTypeNormal, "UserUpdated",
 		"Updated Aerospike user %s", userCreate.name,
 	)
 
@@ -800,7 +800,7 @@ func (userDrop aerospikeUserDrop) execute(
 
 	logger.Info("Dropped user", "username", userDrop.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, EventReasonUserDeleted,
+		aeroCluster, corev1.EventTypeNormal, "UserDeleted",
 		"Deleted Aerospike user %s", userDrop.name,
 	)
 
@@ -829,7 +829,7 @@ func (roleDrop aerospikeRoleDrop) execute(
 
 	logger.Info("Dropped role", "role", roleDrop.name)
 	recorder.Eventf(
-		aeroCluster, corev1.EventTypeNormal, EventReasonRoleDeleted,
+		aeroCluster, corev1.EventTypeNormal, "RoleDeleted",
 		"Deleted Aerospike role %s", roleDrop.name,
 	)
 

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -696,7 +696,7 @@ func (userCreate aerospikeUserCreateUpdate) createUser(
 
 	if userCreate.password == nil {
 		return fmt.Errorf(
-			"create user %s: password not specified", userCreate.name,
+			"user %s: password not specified", userCreate.name,
 		)
 	}
 

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -480,7 +480,7 @@ func (roleCreate aerospikeRoleCreateUpdate) execute(
 		} else {
 			// Failure to query for the role.
 			return fmt.Errorf(
-				"error querying role %s: %w", roleCreate.name, err,
+				"query role %s: %w", roleCreate.name, err,
 			)
 		}
 	}
@@ -516,7 +516,7 @@ func (roleCreate aerospikeRoleCreateUpdate) createRole(
 	client *as.Client, adminPolicy *as.AdminPolicy, logger logger,
 	recorder record.EventRecorder, aeroCluster *asdbv1.AerospikeCluster,
 ) error {
-	logger.Info("Creating role", "role name", roleCreate.name)
+	logger.Info("Creating role", "roleName", roleCreate.name)
 
 	aerospikePrivileges, err := privilegeStringToAerospikePrivilege(roleCreate.privileges)
 	if err != nil {
@@ -530,7 +530,7 @@ func (roleCreate aerospikeRoleCreateUpdate) createRole(
 		return fmt.Errorf("create role %s: %w", roleCreate.name, err)
 	}
 
-	logger.Info("Created role", "role name", roleCreate.name)
+	logger.Info("Created role", "roleName", roleCreate.name)
 	recorder.Eventf(
 		aeroCluster, corev1.EventTypeNormal, "RoleCreated",
 		"Created Aerospike role %s", roleCreate.name,
@@ -546,7 +546,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 	aeroCluster *asdbv1.AerospikeCluster,
 ) error {
 	// Update the role.
-	logger.Info("Updating role", "role name", roleCreate.name)
+	logger.Info("Updating role", "roleName", roleCreate.name)
 
 	// Find the privileges to drop.
 	currentPrivileges, err := AerospikePrivilegeToPrivilegeString(role.Privileges)
@@ -568,13 +568,13 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, aerospikePrivileges,
 		); err != nil {
 			return fmt.Errorf(
-				"error revoking privileges for role %s: %w", roleCreate.name,
+				"revoke privileges for role %s: %w", roleCreate.name,
 				err,
 			)
 		}
 
 		logger.Info(
-			"Revoked privileges for role", "role name", roleCreate.name,
+			"Revoked privileges for role", "roleName", roleCreate.name,
 			"privileges", privilegesToRevoke,
 		)
 	}
@@ -589,13 +589,13 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, aerospikePrivileges,
 		); err != nil {
 			return fmt.Errorf(
-				"error granting privileges for role %s: %w", roleCreate.name,
+				"grant privileges for role %s: %w", roleCreate.name,
 				err,
 			)
 		}
 
 		logger.Info(
-			"Granted privileges to role", "role name", roleCreate.name,
+			"Granted privileges to role", "roleName", roleCreate.name,
 			"privileges", privilegesToGrant,
 		)
 	}
@@ -606,7 +606,7 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, roleCreate.whitelist,
 		); err != nil {
 			return fmt.Errorf(
-				"error setting whitelist for role %s: %w", roleCreate.name, err,
+				"set whitelist for role %s: %w", roleCreate.name, err,
 			)
 		}
 	}
@@ -616,12 +616,12 @@ func (roleCreate aerospikeRoleCreateUpdate) updateRole(
 			adminPolicy, roleCreate.name, roleCreate.readQuota, roleCreate.writeQuota,
 		); err != nil {
 			return fmt.Errorf(
-				"error setting quotas for role %s: %w", roleCreate.name, err,
+				"set quotas for role %s: %w", roleCreate.name, err,
 			)
 		}
 	}
 
-	logger.Info("Updated role", "role name", roleCreate.name)
+	logger.Info("Updated role", "roleName", roleCreate.name)
 	recorder.Eventf(
 		aeroCluster, corev1.EventTypeNormal, "RoleUpdated",
 		"Updated Aerospike role %s", roleCreate.name,
@@ -656,7 +656,7 @@ func (userCreate aerospikeUserCreateUpdate) execute(
 		} else {
 			// Failure to query for the user.
 			return fmt.Errorf(
-				"error querying user %s: %w", userCreate.name, err,
+				"query user %s: %w", userCreate.name, err,
 			)
 		}
 	}
@@ -696,7 +696,7 @@ func (userCreate aerospikeUserCreateUpdate) createUser(
 
 	if userCreate.password == nil {
 		return fmt.Errorf(
-			"error creating user %s. Password not specified", userCreate.name,
+			"create user %s: password not specified", userCreate.name,
 		)
 	}
 
@@ -730,7 +730,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 			adminPolicy, userCreate.name, *userCreate.password,
 		); err != nil {
 			return fmt.Errorf(
-				"error updating password for user %s: %w", userCreate.name, err,
+				"update password for user %s: %w", userCreate.name, err,
 			)
 		}
 
@@ -746,7 +746,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 	if len(rolesToRevoke) > 0 {
 		if err := client.RevokeRoles(adminPolicy, userCreate.name, rolesToRevoke); err != nil {
 			return fmt.Errorf(
-				"error revoking roles for user %s: %w", userCreate.name, err,
+				"revoke roles for user %s: %w", userCreate.name, err,
 			)
 		}
 
@@ -759,7 +759,7 @@ func (userCreate aerospikeUserCreateUpdate) updateUser(
 	if len(rolesToGrant) > 0 {
 		if err := client.GrantRoles(adminPolicy, userCreate.name, rolesToGrant); err != nil {
 			return fmt.Errorf(
-				"error granting roles for user %s: %w", userCreate.name, err,
+				"grant roles for user %s: %w", userCreate.name, err,
 			)
 		}
 

--- a/internal/controller/cluster/access_control.go
+++ b/internal/controller/cluster/access_control.go
@@ -794,7 +794,7 @@ func (userDrop aerospikeUserDrop) execute(
 	if err := client.DropUser(adminPolicy, userDrop.name); err != nil {
 		if !strings.Contains(err.Error(), userNotFoundErr) {
 			// Failure to drop for the user.
-			return fmt.Errorf("error dropping user %s: %w", userDrop.name, err)
+			return fmt.Errorf("drop user %s: %w", userDrop.name, err)
 		}
 	}
 
@@ -823,7 +823,7 @@ func (roleDrop aerospikeRoleDrop) execute(
 	if err := client.DropRole(adminPolicy, roleDrop.name); err != nil {
 		if !strings.Contains(err.Error(), roleNotFoundErr) {
 			// Failure to drop for the role.
-			return fmt.Errorf("error dropping role %s: %w", roleDrop.name, err)
+			return fmt.Errorf("drop role %s: %w", roleDrop.name, err)
 		}
 	}
 

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -49,14 +49,14 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	// Remove a node only if the cluster is stable
 	if err := r.waitForAllSTSToBeReady(ctx, ignorablePodNames); err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"waiting for cluster %s statefulsets to be ready: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"could not wait until cluster %s StatefulSets are ready: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	// This doesn't make actual connection, only objects having connection info are created
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	// Safety guard: if the cluster is degraded (some pods are failed/ignorable) and
@@ -108,7 +108,7 @@ func (r *SingleClusterReconciler) waitForMigrationToComplete(ctx context.Context
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	r.Log.Info("Waiting for migration to complete")
@@ -325,7 +325,7 @@ func (r *SingleClusterReconciler) setMigrateFillDelay(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -348,7 +348,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -365,7 +365,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -15,6 +15,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -40,21 +41,23 @@ import (
 // 1. going to be deleted eventually and are safe to ignore in stability checks
 // 2. given in ignorePodList by the user and are safe to ignore in stability checks
 func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
-	pods []*corev1.Pod, ignorablePodNames sets.Set[string],
+	ctx context.Context, pods []*corev1.Pod, ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
 	if len(pods) == 0 {
 		return common.ReconcileSuccess()
 	}
 
 	// Remove a node only if the cluster is stable
-	if err := r.waitForAllSTSToBeReady(ignorablePodNames); err != nil {
-		return common.ReconcileError(fmt.Errorf("failed to wait for cluster to be ready: %v", err))
+	if err := r.waitForAllSTSToBeReady(ctx, ignorablePodNames); err != nil {
+		return common.ReconcileError(fmt.Errorf(
+			"waiting for cluster %s statefulsets to be ready: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	// This doesn't make actual connection, only objects having connection info are created
-	allHostConns, err := r.newAllHostConnWithOption(ignorablePodNames)
+	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
-		return common.ReconcileError(fmt.Errorf("failed to get hostConn for aerospike cluster nodes: %v", err))
+		return common.ReconcileError(fmt.Errorf(
+			"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	// Safety guard: if the cluster is degraded (some pods are failed/ignorable) and
@@ -73,7 +76,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 		))
 	}
 
-	policy := r.getClientPolicy()
+	policy := r.getClientPolicy(ctx)
 
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, "WaitMigration",
@@ -86,12 +89,12 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	}
 
 	// Setup roster after migration.
-	if err = r.getAndSetRoster(policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
+	if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
 		r.Log.Error(err, "Failed to set roster for cluster")
 		return common.ReconcileRequeueAfter(1)
 	}
 
-	if err := r.quiescePods(policy, allHostConns, pods, ignorablePodNames); err != nil {
+	if err := r.quiescePods(ctx, policy, allHostConns, pods, ignorablePodNames); err != nil {
 		return common.ReconcileError(err)
 	}
 
@@ -99,13 +102,14 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 }
 
 // waitForMigrationToComplete waits for the migration to complete on all the nodes in the cluster.
-func (r *SingleClusterReconciler) waitForMigrationToComplete(policy *as.ClientPolicy,
+func (r *SingleClusterReconciler) waitForMigrationToComplete(ctx context.Context, policy *as.ClientPolicy,
 	ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
 	// This doesn't make actual connection, only objects having connection info are created
-	allHostConns, err := r.newAllHostConnWithOption(ignorablePodNames)
+	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
-		return common.ReconcileError(fmt.Errorf("failed to get hostConn for aerospike cluster nodes: %v", err))
+		return common.ReconcileError(fmt.Errorf(
+			"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	r.Log.Info("Waiting for migration to complete")
@@ -114,6 +118,7 @@ func (r *SingleClusterReconciler) waitForMigrationToComplete(policy *as.ClientPo
 }
 
 func (r *SingleClusterReconciler) quiescePods(
+	ctx context.Context,
 	policy *as.ClientPolicy, allHostConns []*deployment.HostConn, pods []*corev1.Pod, ignorablePodNames sets.Set[string],
 ) error {
 	podList := make([]corev1.Pod, 0, len(pods))
@@ -127,7 +132,7 @@ func (r *SingleClusterReconciler) quiescePods(
 		return err
 	}
 
-	nodesNamespaces, err := deployment.GetClusterNamespaces(r.Log, r.getClientPolicy(), allHostConns)
+	nodesNamespaces, err := deployment.GetClusterNamespaces(r.Log, r.getClientPolicy(ctx), allHostConns)
 	if err != nil {
 		return err
 	}
@@ -178,14 +183,14 @@ func (r *SingleClusterReconciler) waitForClusterStability(
 }
 
 func (r *SingleClusterReconciler) tipClearHostname(
-	pod *corev1.Pod, clearPodName string,
+	ctx context.Context, pod *corev1.Pod, clearPodName string,
 ) error {
 	asConn := r.newAsConn(pod)
 
 	_, heartbeatTLSPort := asdbv1.GetHeartbeatTLSNameAndPort(r.aeroCluster.Spec.AerospikeConfig)
 	if heartbeatTLSPort != nil {
 		if err := asConn.TipClearHostname(
-			r.getClientPolicy(), getFQDNForPod(r.aeroCluster, clearPodName),
+			r.getClientPolicy(ctx), getFQDNForPod(r.aeroCluster, clearPodName),
 			int(*heartbeatTLSPort),
 		); err != nil {
 			return err
@@ -195,7 +200,7 @@ func (r *SingleClusterReconciler) tipClearHostname(
 	heartbeatPort := asdbv1.GetHeartbeatPort(r.aeroCluster.Spec.AerospikeConfig)
 	if heartbeatPort != nil {
 		if err := asConn.TipClearHostname(
-			r.getClientPolicy(), getFQDNForPod(r.aeroCluster, clearPodName),
+			r.getClientPolicy(ctx), getFQDNForPod(r.aeroCluster, clearPodName),
 			int(*heartbeatPort),
 		); err != nil {
 			return err
@@ -205,23 +210,23 @@ func (r *SingleClusterReconciler) tipClearHostname(
 	return nil
 }
 
-func (r *SingleClusterReconciler) alumniReset(pod *corev1.Pod) error {
+func (r *SingleClusterReconciler) alumniReset(ctx context.Context, pod *corev1.Pod) error {
 	asConn := r.newAsConn(pod)
-	return asConn.AlumniReset(r.getClientPolicy())
+	return asConn.AlumniReset(r.getClientPolicy(ctx))
 }
 
 // newAllHostConnWithOption returns connections to all pods in the cluster skipping pods that are not running and
 // present in ignorablePods.
-func (r *SingleClusterReconciler) newAllHostConnWithOption(ignorablePodNames sets.Set[string]) (
+func (r *SingleClusterReconciler) newAllHostConnWithOption(ctx context.Context, ignorablePodNames sets.Set[string]) (
 	[]*deployment.HostConn, error,
 ) {
-	podList, err := r.getClusterPodList()
+	podList, err := r.getClusterPodList(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("pod list empty")
+		return nil, fmt.Errorf("no pods found for cluster %s", utils.ClusterNamespacedName(r.aeroCluster))
 	}
 
 	return r.newPodsHostConnWithOption(podList.Items, ignorablePodNames)
@@ -251,7 +256,7 @@ func (r *SingleClusterReconciler) newPodsHostConnWithOption(pods []corev1.Pod, i
 				continue
 			}
 
-			return nil, fmt.Errorf("pod %v is not ready", pod.Name)
+			return nil, fmt.Errorf("pod %s is not ready", utils.GetNamespacedNameString(pod))
 		}
 
 		asConn := r.newAsConn(pod)
@@ -288,6 +293,7 @@ func hostID(hostName string, hostPort int) string {
 }
 
 func (r *SingleClusterReconciler) setMigrateFillDelay(
+	ctx context.Context,
 	policy *as.ClientPolicy,
 	asConfig *asdbv1.AerospikeConfigSpec, setToZero bool, ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
@@ -316,11 +322,11 @@ func (r *SingleClusterReconciler) setMigrateFillDelay(
 	}
 
 	// This doesn't make actual connection, only objects having connection info are created
-	allHostConns, err := r.newAllHostConnWithOption(ignorablePodNames)
+	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"failed to get hostConn for aerospike cluster nodes: %v", err,
+				"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -335,14 +341,15 @@ func (r *SingleClusterReconciler) setMigrateFillDelay(
 }
 
 func (r *SingleClusterReconciler) setDynamicConfig(
+	ctx context.Context,
 	dynamicConfDiffPerPod map[string]asconfig.DynamicConfigMap, pods []*corev1.Pod, ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
 	// This doesn't make actual connection, only objects having connection info are created
-	allHostConns, err := r.newAllHostConnWithOption(ignorablePodNames)
+	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"failed to get hostConn for aerospike cluster nodes: %v", err,
+				"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -359,7 +366,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"failed to get hostConn for aerospike cluster nodes: %v", err,
+				"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -374,7 +381,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 		podName := podIPNameMap[host.ASConn.AerospikeHostName]
 
 		asConfCmds, err := asconfig.CreateSetConfigCmdList(r.Log, dynamicConfDiffPerPod[podName],
-			host.ASConn, r.getClientPolicy())
+			host.ASConn, r.getClientPolicy(ctx))
 		if err != nil {
 			// Assuming error returned here will not be a server error.
 			return common.ReconcileError(err)
@@ -382,7 +389,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 
 		r.Log.Info("Generated dynamic config commands", "commands", fmt.Sprintf("%v", asConfCmds), "pod", podName)
 
-		if succeededCmds, err := deployment.SetConfigCommandsOnHosts(r.Log, r.getClientPolicy(), allHostConns,
+		if succeededCmds, err := deployment.SetConfigCommandsOnHosts(r.Log, r.getClientPolicy(ctx), allHostConns,
 			[]*deployment.HostConn{host}, asConfCmds); err != nil {
 			errorStatus := asdbv1.Failed
 
@@ -401,10 +408,11 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 			patches = append(patches, patch)
 
 			if patchErr := r.patchPodStatus(
-				context.TODO(), patches,
+				ctx, patches,
 			); patchErr != nil {
 				return common.ReconcileError(
-					fmt.Errorf("error updating status: %v, dynamic config command error: %v", patchErr, err))
+					fmt.Errorf("patching status for pod %s after dynamic config command error: %w",
+						utils.NamespacedName(r.aeroCluster.Namespace, podName), errors.Join(patchErr, err)))
 			}
 
 			return common.ReconcileError(err)

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -15,6 +15,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -50,14 +51,14 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	// Remove a node only if the cluster is stable
 	if err := r.waitForAllSTSToBeReady(ctx, ignorablePodNames); err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"wait for cluster %s StatefulSets to be ready: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"wait for cluster %s StatefulSets to be ready: %w", utils.GetNamespacedNameString(r.aeroCluster), err))
 	}
 
 	// This doesn't make actual connection, only objects having connection info are created
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err))
 	}
 
 	// Safety guard: if the cluster is degraded (some pods are failed/ignorable) and
@@ -90,7 +91,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 
 	// Setup roster after migration.
 	if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
-		r.Log.V(1).Info("Failed to set roster for cluster, will requeue", "err", err)
+		r.Log.Info("Failed to set roster for cluster, will requeue", "err", err)
 		return common.ReconcileRequeueAfter(1)
 	}
 
@@ -109,7 +110,7 @@ func (r *SingleClusterReconciler) waitForMigrationToComplete(ctx context.Context
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err))
 	}
 
 	r.Log.Info("Waiting for migration to complete")
@@ -282,7 +283,7 @@ func (r *SingleClusterReconciler) newAsConn(pod *corev1.Pod) *deployment.ASConn 
 		AerospikeHostName: host,
 		AerospikePort:     int(*port),
 		AerospikeTLSName:  tlsName,
-		Log:               r.Log.WithValues("pod", klog.KObj(pod)),
+		Log:               klog.LoggerWithValues(r.Log, "pod", klog.KObj(pod)),
 	}
 
 	return asConn
@@ -326,7 +327,7 @@ func (r *SingleClusterReconciler) setMigrateFillDelay(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err,
 			),
 		)
 	}
@@ -349,7 +350,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err,
 			),
 		)
 	}
@@ -366,7 +367,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err,
 			),
 		)
 	}
@@ -387,7 +388,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 			return common.ReconcileError(err)
 		}
 
-		r.Log.V(2).Info("Generated dynamic config commands",
+		r.Log.Info("Generated dynamic config commands",
 			"commands", asConfCmds, "pod", klog.KRef(r.aeroCluster.Namespace, podName))
 
 		if succeededCmds, err := deployment.SetConfigCommandsOnHosts(r.Log, r.getClientPolicy(ctx), allHostConns,
@@ -412,7 +413,10 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 				ctx, patches,
 			); patchErr != nil {
 				return common.ReconcileError(
-					fmt.Errorf("update status (patch error: %v, dynamic config error: %v)", patchErr, err),
+					errors.Join(
+						fmt.Errorf("update status: %w", patchErr),
+						fmt.Errorf("apply dynamic config: %w", err),
+					),
 				)
 			}
 

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -50,14 +50,14 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	// Remove a node only if the cluster is stable
 	if err := r.waitForAllSTSToBeReady(ctx, ignorablePodNames); err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"could not wait until cluster %s StatefulSets are ready: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"wait for cluster %s StatefulSets to be ready: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	// This doesn't make actual connection, only objects having connection info are created
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	// Safety guard: if the cluster is degraded (some pods are failed/ignorable) and
@@ -109,7 +109,7 @@ func (r *SingleClusterReconciler) waitForMigrationToComplete(ctx context.Context
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	r.Log.Info("Waiting for migration to complete")
@@ -326,7 +326,7 @@ func (r *SingleClusterReconciler) setMigrateFillDelay(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -349,7 +349,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -366,7 +366,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+				"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -412,7 +412,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 				ctx, patches,
 			); patchErr != nil {
 				return common.ReconcileError(
-					fmt.Errorf("error updating status: %v, dynamic config command error: %v", patchErr, err),
+					fmt.Errorf("update status (patch error: %v, dynamic config error: %v)", patchErr, err),
 				)
 			}
 

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -15,7 +15,6 @@ package cluster
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -226,7 +225,7 @@ func (r *SingleClusterReconciler) newAllHostConnWithOption(ctx context.Context, 
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("no pods found for cluster %s", utils.ClusterNamespacedName(r.aeroCluster))
+		return nil, fmt.Errorf("pod list empty")
 	}
 
 	return r.newPodsHostConnWithOption(podList.Items, ignorablePodNames)
@@ -411,8 +410,8 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 				ctx, patches,
 			); patchErr != nil {
 				return common.ReconcileError(
-					fmt.Errorf("patching status for pod %s after dynamic config command error: %w",
-						utils.NamespacedName(r.aeroCluster.Namespace, podName), errors.Join(patchErr, err)))
+					fmt.Errorf("error updating status: %v, dynamic config command error: %v", patchErr, err),
+				)
 			}
 
 			return common.ReconcileError(err)

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -79,7 +79,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	policy := r.getClientPolicy(ctx)
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonWaitMigration,
+		r.aeroCluster, corev1.EventTypeNormal, "WaitMigration",
 		"[rack-%s] Waiting for migrations to complete", pods[0].Labels[asdbv1.AerospikeRackIDLabel],
 	)
 

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -89,7 +90,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 
 	// Setup roster after migration.
 	if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
-		r.Log.Error(err, "Failed to set roster for cluster")
+		r.Log.V(1).Info("Failed to set roster for cluster, will requeue", "err", err)
 		return common.ReconcileRequeueAfter(1)
 	}
 
@@ -249,7 +250,7 @@ func (r *SingleClusterReconciler) newPodsHostConnWithOption(pods []corev1.Pod, i
 			if ignorablePodNames.Has(pod.Name) {
 				// This pod is not running and ignorable.
 				r.Log.Info(
-					"Ignoring info call on non-running pod ", "pod", pod.Name,
+					"Ignoring info call on non-running pod", "pod", klog.KObj(pod),
 				)
 
 				continue
@@ -281,7 +282,7 @@ func (r *SingleClusterReconciler) newAsConn(pod *corev1.Pod) *deployment.ASConn 
 		AerospikeHostName: host,
 		AerospikePort:     int(*port),
 		AerospikeTLSName:  tlsName,
-		Log:               r.Log.WithValues("host", pod.Name),
+		Log:               r.Log.WithValues("pod", klog.KObj(pod)),
 	}
 
 	return asConn
@@ -386,7 +387,8 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 			return common.ReconcileError(err)
 		}
 
-		r.Log.Info("Generated dynamic config commands", "commands", fmt.Sprintf("%v", asConfCmds), "pod", podName)
+		r.Log.V(2).Info("Generated dynamic config commands",
+			"commands", asConfCmds, "pod", klog.KRef(r.aeroCluster.Namespace, podName))
 
 		if succeededCmds, err := deployment.SetConfigCommandsOnHosts(r.Log, r.getClientPolicy(ctx), allHostConns,
 			[]*deployment.HostConn{host}, asConfCmds); err != nil {

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -21,7 +21,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -51,14 +50,14 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	// Remove a node only if the cluster is stable
 	if err := r.waitForAllSTSToBeReady(ctx, ignorablePodNames); err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"wait for cluster %s StatefulSets to be ready: %w", utils.GetNamespacedNameString(r.aeroCluster), err))
+			"wait for cluster to be ready: %w", err))
 	}
 
 	// This doesn't make actual connection, only objects having connection info are created
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err))
+			"get host connections for cluster nodes: %w", err))
 	}
 
 	// Safety guard: if the cluster is degraded (some pods are failed/ignorable) and
@@ -72,7 +71,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	if len(allHostConns) < 2 && ignorablePodNames.Len() > 0 {
 		return common.ReconcileError(fmt.Errorf(
 			"cluster is degraded: %d failed/ignorable pod(s) excluded, only %d reachable node(s) remain; "+
-				"refusing to proceed to prevent data loss — recover the failed pods first",
+				"refusing to proceed to prevent data loss — recover the failed Pods first",
 			ignorablePodNames.Len(), len(allHostConns),
 		))
 	}
@@ -91,7 +90,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 
 	// Setup roster after migration.
 	if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
-		r.Log.Info("Failed to set roster for cluster, will requeue", "err", err)
+		r.Log.Error(err, "Failed to set roster for cluster, will requeue")
 		return common.ReconcileRequeueAfter(1)
 	}
 
@@ -110,7 +109,7 @@ func (r *SingleClusterReconciler) waitForMigrationToComplete(ctx context.Context
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err))
+			"get host connections for cluster nodes: %w", err))
 	}
 
 	r.Log.Info("Waiting for migration to complete")
@@ -227,7 +226,7 @@ func (r *SingleClusterReconciler) newAllHostConnWithOption(ctx context.Context, 
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("pod list empty")
+		return nil, fmt.Errorf("get Pod list: empty")
 	}
 
 	return r.newPodsHostConnWithOption(podList.Items, ignorablePodNames)
@@ -251,13 +250,13 @@ func (r *SingleClusterReconciler) newPodsHostConnWithOption(pods []corev1.Pod, i
 			if ignorablePodNames.Has(pod.Name) {
 				// This pod is not running and ignorable.
 				r.Log.Info(
-					"Ignoring info call on non-running pod", "pod", klog.KObj(pod),
+					"Ignoring info call on non-running Pod", "pod", utils.GetNamespacedName(pod),
 				)
 
 				continue
 			}
 
-			return nil, fmt.Errorf("pod %s is not ready", utils.GetNamespacedNameString(pod))
+			return nil, fmt.Errorf("check Pod %s: not ready", utils.GetNamespacedNameString(pod))
 		}
 
 		asConn := r.newAsConn(pod)
@@ -283,7 +282,7 @@ func (r *SingleClusterReconciler) newAsConn(pod *corev1.Pod) *deployment.ASConn 
 		AerospikeHostName: host,
 		AerospikePort:     int(*port),
 		AerospikeTLSName:  tlsName,
-		Log:               klog.LoggerWithValues(r.Log, "pod", klog.KObj(pod)),
+		Log:               r.Log.WithValues("pod", utils.GetNamespacedName(pod)),
 	}
 
 	return asConn
@@ -327,7 +326,7 @@ func (r *SingleClusterReconciler) setMigrateFillDelay(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err,
+				"get host connections for cluster nodes: %w", err,
 			),
 		)
 	}
@@ -350,7 +349,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err,
+				"get host connections for cluster nodes: %w", err,
 			),
 		)
 	}
@@ -367,13 +366,13 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf(
-				"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err,
+				"get host connections for cluster nodes: %w", err,
 			),
 		)
 	}
 
 	if len(selectedHostConns) == 0 {
-		r.Log.Info("No pods selected for dynamic config change")
+		r.Log.Info("No Pods selected for dynamic config change")
 
 		return common.ReconcileSuccess()
 	}
@@ -389,7 +388,7 @@ func (r *SingleClusterReconciler) setDynamicConfig(
 		}
 
 		r.Log.Info("Generated dynamic config commands",
-			"commands", asConfCmds, "pod", klog.KRef(r.aeroCluster.Namespace, podName))
+			"commands", asConfCmds, "pod", utils.NewNamespacedName(r.aeroCluster.Namespace, podName))
 
 		if succeededCmds, err := deployment.SetConfigCommandsOnHosts(r.Log, r.getClientPolicy(ctx), allHostConns,
 			[]*deployment.HostConn{host}, asConfCmds); err != nil {

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -79,7 +79,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	policy := r.getClientPolicy(ctx)
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "WaitMigration",
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonWaitMigration,
 		"[rack-%s] Waiting for migrations to complete", pods[0].Labels[asdbv1.AerospikeRackIDLabel],
 	)
 

--- a/internal/controller/cluster/aero_info_calls.go
+++ b/internal/controller/cluster/aero_info_calls.go
@@ -50,7 +50,7 @@ func (r *SingleClusterReconciler) waitForMultipleNodesSafeStopReady(
 	// Remove a node only if the cluster is stable
 	if err := r.waitForAllSTSToBeReady(ctx, ignorablePodNames); err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"wait for cluster to be ready: %w", err))
+			"wait for cluster StatefulSets to be ready: %w", err))
 	}
 
 	// This doesn't make actual connection, only objects having connection info are created
@@ -226,7 +226,7 @@ func (r *SingleClusterReconciler) newAllHostConnWithOption(ctx context.Context, 
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("get Pod list: empty")
+		return nil, fmt.Errorf("cluster Pod list is empty")
 	}
 
 	return r.newPodsHostConnWithOption(podList.Items, ignorablePodNames)
@@ -256,7 +256,7 @@ func (r *SingleClusterReconciler) newPodsHostConnWithOption(pods []corev1.Pod, i
 				continue
 			}
 
-			return nil, fmt.Errorf("check Pod %s: not ready", utils.GetNamespacedNameString(pod))
+			return nil, fmt.Errorf("status for Pod %s: not ready", utils.GetNamespacedNameString(pod))
 		}
 
 		asConn := r.newAsConn(pod)

--- a/internal/controller/cluster/aerospikecluster_controller.go
+++ b/internal/controller/cluster/aerospikecluster_controller.go
@@ -145,7 +145,7 @@ type RackState struct {
 
 // Reconcile AerospikeCluster object
 func (r *AerospikeClusterReconciler) Reconcile(
-	_ context.Context, request reconcile.Request,
+	ctx context.Context, request reconcile.Request,
 ) (ctrl.Result, error) {
 	log := r.Log.WithValues("aerospikecluster", request.NamespacedName)
 
@@ -153,7 +153,7 @@ func (r *AerospikeClusterReconciler) Reconcile(
 
 	// Fetch the AerospikeCluster instance
 	aeroCluster := &asdbv1.AerospikeCluster{}
-	if err := r.Get(context.TODO(), request.NamespacedName, aeroCluster); err != nil {
+	if err := r.Get(ctx, request.NamespacedName, aeroCluster); err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after Reconcile request.
 			return reconcile.Result{}, nil
@@ -172,5 +172,5 @@ func (r *AerospikeClusterReconciler) Reconcile(
 		Recorder:    r.Recorder,
 	}
 
-	return cr.Reconcile()
+	return cr.Reconcile(ctx)
 }

--- a/internal/controller/cluster/aerospikecluster_controller.go
+++ b/internal/controller/cluster/aerospikecluster_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -147,7 +148,7 @@ type RackState struct {
 func (r *AerospikeClusterReconciler) Reconcile(
 	ctx context.Context, request reconcile.Request,
 ) (ctrl.Result, error) {
-	log := r.Log.WithValues("aerospikecluster", request.NamespacedName)
+	log := r.Log.WithValues("aerospikeCluster", klog.KRef(request.Namespace, request.Name))
 
 	log.Info("Reconciling AerospikeCluster")
 

--- a/internal/controller/cluster/aerospikecluster_controller.go
+++ b/internal/controller/cluster/aerospikecluster_controller.go
@@ -148,7 +148,7 @@ type RackState struct {
 func (r *AerospikeClusterReconciler) Reconcile(
 	ctx context.Context, request reconcile.Request,
 ) (ctrl.Result, error) {
-	log := r.Log.WithValues("aerospikeCluster", klog.KRef(request.Namespace, request.Name))
+	log := klog.LoggerWithValues(r.Log, "aerospikeCluster", klog.KRef(request.Namespace, request.Name))
 
 	log.Info("Reconciling AerospikeCluster")
 

--- a/internal/controller/cluster/aerospikecluster_controller.go
+++ b/internal/controller/cluster/aerospikecluster_controller.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -148,7 +147,7 @@ type RackState struct {
 func (r *AerospikeClusterReconciler) Reconcile(
 	ctx context.Context, request reconcile.Request,
 ) (ctrl.Result, error) {
-	log := klog.LoggerWithValues(r.Log, "aerospikeCluster", klog.KRef(request.Namespace, request.Name))
+	log := r.Log.WithValues("aerospikecluster", request.NamespacedName)
 
 	log.Info("Reconciling AerospikeCluster")
 

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -13,9 +13,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/pkg/utils"
 )
 
 // fromSecretPasswordProvider provides user password from the secret provided in AerospikeUserSpec.
@@ -29,32 +31,32 @@ type fromSecretPasswordProvider struct {
 
 // Get returns the password for the username using userSpec.
 func (pp fromSecretPasswordProvider) Get(
-	_ string, userSpec *asdbv1.AerospikeUserSpec,
+	ctx context.Context, _ string, userSpec *asdbv1.AerospikeUserSpec,
 ) (string, error) {
 	secret := &corev1.Secret{}
 	secretName := userSpec.SecretName
 	// Assuming secret is in same namespace
 	err := (*pp.k8sClient).Get(
-		context.TODO(),
+		ctx,
 		types.NamespacedName{Name: secretName, Namespace: pp.namespace}, secret,
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to get secret %s: %v", secretName, err)
+		return "", fmt.Errorf("getting secret %s: %w", utils.NamespacedName(pp.namespace, secretName), err)
 	}
 
 	passBytes, ok := secret.Data["password"]
 	if !ok {
-		return "", fmt.Errorf(
-			"failed to get password from secret. Please check your secret %s",
-			secretName,
-		)
+		return "", reconcile.TerminalError(fmt.Errorf(
+			"missing %q key in secret %s",
+			"password", utils.NamespacedName(pp.namespace, secretName),
+		))
 	}
 
 	return string(passBytes), nil
 }
 
 // GetDefaultPassword returns the default password for cluster using AerospikeClusterSpec.
-func (pp fromSecretPasswordProvider) GetDefaultPassword(spec *asdbv1.AerospikeClusterSpec) string {
+func (pp fromSecretPasswordProvider) GetDefaultPassword(ctx context.Context, spec *asdbv1.AerospikeClusterSpec) string {
 	defaultPasswordFilePath := asdbv1.GetDefaultPasswordFilePath(spec.AerospikeConfig)
 
 	// No default password file specified. Give default password.
@@ -69,7 +71,7 @@ func (pp fromSecretPasswordProvider) GetDefaultPassword(spec *asdbv1.AerospikeCl
 	// Get the password from the secret.
 	passwordFileName := filepath.Base(*defaultPasswordFilePath)
 
-	password, err := pp.getPasswordFromSecret(secretName, passwordFileName)
+	password, err := pp.getPasswordFromSecret(ctx, secretName, passwordFileName)
 	if err != nil {
 		pkgLog.Error(err, "Failed to get password from secret")
 
@@ -81,22 +83,22 @@ func (pp fromSecretPasswordProvider) GetDefaultPassword(spec *asdbv1.AerospikeCl
 
 // GetPasswordFromSecret returns the password from the secret.
 func (pp fromSecretPasswordProvider) getPasswordFromSecret(
-	secretName string, passFileName string,
+	ctx context.Context, secretName string, passFileName string,
 ) (string, error) {
 	secretNamespcedName := types.NamespacedName{Name: secretName, Namespace: pp.namespace}
 	secret := &corev1.Secret{}
 
-	err := (*pp.k8sClient).Get(context.TODO(), secretNamespcedName, secret)
+	err := (*pp.k8sClient).Get(ctx, secretNamespcedName, secret)
 	if err != nil {
-		return "", fmt.Errorf("failed to get secret %s: %v", secretNamespcedName, err)
+		return "", fmt.Errorf("getting secret %s: %w", secretNamespcedName, err)
 	}
 
 	passBytes, ok := secret.Data[passFileName]
 	if !ok {
-		return "", fmt.Errorf(
-			"failed to get password file in secret %s, fileName %s",
-			secretNamespcedName, passFileName,
-		)
+		return "", reconcile.TerminalError(fmt.Errorf(
+			"missing password file %q in secret %s",
+			passFileName, secretNamespcedName,
+		))
 	}
 
 	return string(passBytes), nil
@@ -108,7 +110,7 @@ func (r *SingleClusterReconciler) getPasswordProvider() fromSecretPasswordProvid
 	}
 }
 
-func (r *SingleClusterReconciler) getClientPolicy() *as.ClientPolicy {
+func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.ClientPolicy {
 	policy := as.NewClientPolicy()
 
 	policy.SeedOnlyCluster = true
@@ -123,7 +125,7 @@ func (r *SingleClusterReconciler) getClientPolicy() *as.ClientPolicy {
 
 		tlsConf := tls.Config{
 			RootCAs: r.getClusterServerCAPool(
-				clientCertSpec, r.aeroCluster.Namespace,
+				ctx, clientCertSpec, r.aeroCluster.Namespace,
 			),
 			Certificates: []tls.Certificate{},
 			// used only in testing
@@ -137,7 +139,7 @@ func (r *SingleClusterReconciler) getClientPolicy() *as.ClientPolicy {
 				"clientCertSpec", clientCertSpec,
 			)
 		} else if cert, err := r.getClientCertificate(
-			clientCertSpec, r.aeroCluster.Namespace,
+			ctx, clientCertSpec, r.aeroCluster.Namespace,
 		); err == nil {
 			tlsConf.Certificates = append(tlsConf.Certificates, *cert)
 		} else {
@@ -161,14 +163,14 @@ func (r *SingleClusterReconciler) getClientPolicy() *as.ClientPolicy {
 
 	statusToSpec, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		r.Log.Error(err, "Failed to copy status in spec", "err", err)
+		r.Log.Error(err, "Failed to copy status in spec")
 	}
 
 	user, pass, err := AerospikeAdminCredentials(
-		&r.aeroCluster.Spec, statusToSpec, r.getPasswordProvider(),
+		ctx, &r.aeroCluster.Spec, statusToSpec, r.getPasswordProvider(),
 	)
 	if err != nil {
-		r.Log.Error(err, "Failed to get cluster auth info", "err", err)
+		r.Log.Error(err, "Failed to get cluster auth info")
 	}
 	// TODO: What should be the timeout, should make it configurable or just keep it default
 	policy.Timeout = time.Minute * 1
@@ -190,6 +192,7 @@ func (r *SingleClusterReconciler) getClientPolicy() *as.ClientPolicy {
 }
 
 func (r *SingleClusterReconciler) getClusterServerCAPool(
+	ctx context.Context,
 	clientCertSpec *asdbv1.AerospikeOperatorClientCertSpec,
 	clusterNamespace string,
 ) *x509.CertPool {
@@ -215,7 +218,7 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 		)
 	case clientCertSpec.SecretCertSource != nil:
 		return r.appendCACertFromSecret(
-			clientCertSpec.SecretCertSource, clusterNamespace, serverPool,
+			ctx, clientCertSpec.SecretCertSource, clusterNamespace, serverPool,
 		)
 	default:
 		r.Log.Error(
@@ -267,6 +270,7 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 }
 
 func (r *SingleClusterReconciler) appendCACertFromSecret(
+	ctx context.Context,
 	secretSource *asdbv1.AerospikeSecretCertSource,
 	defaultNamespace string, serverPool *x509.CertPool,
 ) *x509.CertPool {
@@ -290,7 +294,7 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 		//nolint:staticcheck // SA1019: must read deprecated SecretNamespace to resolve secret until field is removed
 		secretName := namespacedSecret(secretSource.CaCertsSource.SecretNamespace,
 			secretSource.CaCertsSource.SecretName, defaultNamespace)
-		if err := r.Get(context.TODO(), secretName, found); err != nil {
+		if err := r.Get(ctx, secretName, found); err != nil {
 			r.Log.Error(
 				err,
 				"Failed to get CA certificates secret, returning empty certPool",
@@ -310,7 +314,7 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 	} else {
 		//nolint:staticcheck // SA1019: must read deprecated SecretNamespace to resolve secret until field is removed
 		secretName := namespacedSecret(secretSource.SecretNamespace, secretSource.SecretName, defaultNamespace)
-		if err := r.Get(context.TODO(), secretName, found); err != nil {
+		if err := r.Get(ctx, secretName, found); err != nil {
 			r.Log.Error(
 				err,
 				"Failed to get secret certificates to the pool, returning empty certPool",
@@ -338,6 +342,7 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 }
 
 func (r *SingleClusterReconciler) getClientCertificate(
+	ctx context.Context,
 	clientCertSpec *asdbv1.AerospikeOperatorClientCertSpec,
 	clusterNamespace string,
 ) (*tls.Certificate, error) {
@@ -349,14 +354,17 @@ func (r *SingleClusterReconciler) getClientCertificate(
 		)
 	case clientCertSpec.SecretCertSource != nil:
 		return r.loadCertAndKeyFromSecret(
-			clientCertSpec.SecretCertSource, clusterNamespace,
+			ctx, clientCertSpec.SecretCertSource, clusterNamespace,
 		)
 	default:
-		return nil, fmt.Errorf("both `secretName` and `certPathInOperator` are not set")
+		return nil, reconcile.TerminalError(fmt.Errorf(
+			"invalid aerospike operator client cert spec: neither secretName nor certPathInOperator is set",
+		))
 	}
 }
 
 func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
+	ctx context.Context,
 	secretSource *asdbv1.AerospikeSecretCertSource,
 	defaultNamespace string,
 ) (*tls.Certificate, error) {
@@ -365,34 +373,34 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 
 	//nolint:staticcheck // SA1019: must read deprecated SecretNamespace to resolve secret until field is removed
 	secretName := namespacedSecret(secretSource.SecretNamespace, secretSource.SecretName, defaultNamespace)
-	if err := r.Get(context.TODO(), secretName, found); err != nil {
+	if err := r.Get(ctx, secretName, found); err != nil {
 		r.Log.Info(
 			"Warn: Failed to get secret certificates to the pool", "err", err,
 		)
 
-		return nil, err
+		return nil, fmt.Errorf("getting secret %s: %w", secretName, err)
 	}
 
 	crtData, crtExists := found.Data[secretSource.ClientCertFilename]
 	if !crtExists {
-		return nil, fmt.Errorf(
-			"can't find certificate `%s` in secret %+v",
+		return nil, reconcile.TerminalError(fmt.Errorf(
+			"certificate %q not found in secret %s",
 			secretSource.ClientCertFilename, secretName,
-		)
+		))
 	}
 
 	keyData, keyExists := found.Data[secretSource.ClientKeyFilename]
 	if !keyExists {
-		return nil, fmt.Errorf(
-			"can't find client key `%s` in secret %+v",
+		return nil, reconcile.TerminalError(fmt.Errorf(
+			"client key %q not found in secret %s",
 			secretSource.ClientKeyFilename, secretName,
-		)
+		))
 	}
 
 	cert, err := tls.X509KeyPair(crtData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to load X509 key pair for cluster from secret %+v: %w",
+			"loading X509 key pair from secret %s: %w",
 			secretName, err,
 		)
 	}
@@ -426,18 +434,18 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromFiles(
 ) (*tls.Certificate, error) {
 	certData, certErr := os.ReadFile(certPath)
 	if certErr != nil {
-		return nil, certErr
+		return nil, fmt.Errorf("reading certificate file %s: %w", certPath, certErr)
 	}
 
 	keyData, keyErr := os.ReadFile(keyPath)
 	if keyErr != nil {
-		return nil, keyErr
+		return nil, fmt.Errorf("reading client key file %s: %w", keyPath, keyErr)
 	}
 
 	cert, err := tls.X509KeyPair(certData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"failed to load X509 key pair for cluster (cert=%s,key=%s): %w",
+			"loading X509 key pair (cert=%s, key=%s): %w",
 			certPath, keyPath, err,
 		)
 	}

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -46,10 +45,7 @@ func (pp fromSecretPasswordProvider) Get(
 
 	passBytes, ok := secret.Data["password"]
 	if !ok {
-		return "", reconcile.TerminalError(fmt.Errorf(
-			"missing %q key in secret %s",
-			"password", utils.NamespacedName(pp.namespace, secretName),
-		))
+		return "", fmt.Errorf("missing %q key in secret %s", "password", utils.NamespacedName(pp.namespace, secretName))
 	}
 
 	return string(passBytes), nil
@@ -95,10 +91,7 @@ func (pp fromSecretPasswordProvider) getPasswordFromSecret(
 
 	passBytes, ok := secret.Data[passFileName]
 	if !ok {
-		return "", reconcile.TerminalError(fmt.Errorf(
-			"missing password file %q in secret %s",
-			passFileName, secretNamespcedName,
-		))
+		return "", fmt.Errorf("missing password file %q in secret %s", passFileName, secretNamespcedName)
 	}
 
 	return string(passBytes), nil
@@ -357,9 +350,7 @@ func (r *SingleClusterReconciler) getClientCertificate(
 			ctx, clientCertSpec.SecretCertSource, clusterNamespace,
 		)
 	default:
-		return nil, reconcile.TerminalError(fmt.Errorf(
-			"invalid aerospike operator client cert spec: neither secretName nor certPathInOperator is set",
-		))
+		return nil, fmt.Errorf("neither secretName nor certPathInOperator is set in operatorClientCertSpec")
 	}
 }
 
@@ -383,18 +374,12 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 
 	crtData, crtExists := found.Data[secretSource.ClientCertFilename]
 	if !crtExists {
-		return nil, reconcile.TerminalError(fmt.Errorf(
-			"certificate %q not found in secret %s",
-			secretSource.ClientCertFilename, secretName,
-		))
+		return nil, fmt.Errorf("certificate %q not found in secret %s", secretSource.ClientCertFilename, secretName)
 	}
 
 	keyData, keyExists := found.Data[secretSource.ClientKeyFilename]
 	if !keyExists {
-		return nil, reconcile.TerminalError(fmt.Errorf(
-			"client key %q not found in secret %s",
-			secretSource.ClientKeyFilename, secretName,
-		))
+		return nil, fmt.Errorf("client key %q not found in secret %s", secretSource.ClientKeyFilename, secretName)
 	}
 
 	cert, err := tls.X509KeyPair(crtData, keyData)

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -350,7 +350,7 @@ func (r *SingleClusterReconciler) getClientCertificate(
 			ctx, clientCertSpec.SecretCertSource, clusterNamespace,
 		)
 	default:
-		return nil, fmt.Errorf("both secretName and certPathInOperator are not set in operatorClientCertSpec")
+		return nil, fmt.Errorf("both `secretName` and `certPathInOperator` are not set")
 	}
 }
 
@@ -369,23 +369,29 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 			"Warn: Failed to get secret certificates to the pool", "err", err,
 		)
 
-		return nil, fmt.Errorf("could not get secret %s: %w", secretName, err)
+		return nil, fmt.Errorf("could not get secret %+v: %w", secretName, err)
 	}
 
 	crtData, crtExists := found.Data[secretSource.ClientCertFilename]
 	if !crtExists {
-		return nil, fmt.Errorf("certificate %q not found in secret %s", secretSource.ClientCertFilename, secretName)
+		return nil, fmt.Errorf(
+			"can't find certificate `%q` in secret %+v",
+			secretSource.ClientCertFilename, secretName,
+		)
 	}
 
 	keyData, keyExists := found.Data[secretSource.ClientKeyFilename]
 	if !keyExists {
-		return nil, fmt.Errorf("client key %q not found in secret %s", secretSource.ClientKeyFilename, secretName)
+		return nil, fmt.Errorf(
+			"can't find client key `%q` in secret %+v",
+			secretSource.ClientKeyFilename, secretName,
+		)
 	}
 
 	cert, err := tls.X509KeyPair(crtData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"could not load X509 key pair from secret %s: %w",
+			"could not load X509 key pair for cluster from secret %+v: %w",
 			secretName, err,
 		)
 	}
@@ -430,7 +436,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromFiles(
 	cert, err := tls.X509KeyPair(certData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"could not load X509 key pair (cert=%s, key=%s): %w",
+			"could not load X509 key pair for cluster (cert=%s, key=%s): %w",
 			certPath, keyPath, err,
 		)
 	}

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -40,7 +40,7 @@ func (pp fromSecretPasswordProvider) Get(
 		types.NamespacedName{Name: secretName, Namespace: pp.namespace}, secret,
 	)
 	if err != nil {
-		return "", fmt.Errorf("getting secret %s: %w", utils.NamespacedName(pp.namespace, secretName), err)
+		return "", fmt.Errorf("could not get secret %s: %w", utils.NamespacedName(pp.namespace, secretName), err)
 	}
 
 	passBytes, ok := secret.Data["password"]
@@ -86,7 +86,7 @@ func (pp fromSecretPasswordProvider) getPasswordFromSecret(
 
 	err := (*pp.k8sClient).Get(ctx, secretNamespcedName, secret)
 	if err != nil {
-		return "", fmt.Errorf("getting secret %s: %w", secretNamespcedName, err)
+		return "", fmt.Errorf("could not get secret %s: %w", secretNamespcedName, err)
 	}
 
 	passBytes, ok := secret.Data[passFileName]
@@ -369,7 +369,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 			"Warn: Failed to get secret certificates to the pool", "err", err,
 		)
 
-		return nil, fmt.Errorf("getting secret %s: %w", secretName, err)
+		return nil, fmt.Errorf("could not get secret %s: %w", secretName, err)
 	}
 
 	crtData, crtExists := found.Data[secretSource.ClientCertFilename]
@@ -385,7 +385,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	cert, err := tls.X509KeyPair(crtData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"loading X509 key pair from secret %s: %w",
+			"could not load X509 key pair from secret %s: %w",
 			secretName, err,
 		)
 	}
@@ -419,18 +419,18 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromFiles(
 ) (*tls.Certificate, error) {
 	certData, certErr := os.ReadFile(certPath)
 	if certErr != nil {
-		return nil, fmt.Errorf("reading certificate file %s: %w", certPath, certErr)
+		return nil, fmt.Errorf("could not read certificate file %s: %w", certPath, certErr)
 	}
 
 	keyData, keyErr := os.ReadFile(keyPath)
 	if keyErr != nil {
-		return nil, fmt.Errorf("reading client key file %s: %w", keyPath, keyErr)
+		return nil, fmt.Errorf("could not read client key file %s: %w", keyPath, keyErr)
 	}
 
 	cert, err := tls.X509KeyPair(certData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"loading X509 key pair (cert=%s, key=%s): %w",
+			"could not load X509 key pair (cert=%s, key=%s): %w",
 			certPath, keyPath, err,
 		)
 	}

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -12,6 +12,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
@@ -69,7 +70,9 @@ func (pp fromSecretPasswordProvider) GetDefaultPassword(ctx context.Context, spe
 
 	password, err := pp.getPasswordFromSecret(ctx, secretName, passwordFileName)
 	if err != nil {
-		pkgLog.Error(err, "Failed to get password from secret")
+		pkgLog.Error(err, "Failed to get password from secret",
+			"secret", klog.KRef(pp.namespace, secretName),
+		)
 
 		return asdbv1.DefaultAdminPassword
 	}
@@ -129,6 +132,7 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 			// This is possible when tls-authenticate-client = false
 			r.Log.Info(
 				"Operator's client cert is not configured. Skip using client certs.",
+				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 				"clientCertSpec", clientCertSpec,
 			)
 		} else if cert, err := r.getClientCertificate(
@@ -138,7 +142,8 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 		} else {
 			r.Log.Error(
 				err,
-				"Failed to get client certificate. Using basic clientPolicy",
+				"Failed to get client certificate, using basic clientPolicy",
+				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			)
 		}
 
@@ -156,14 +161,18 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 
 	statusToSpec, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		r.Log.Error(err, "Failed to copy status in spec")
+		r.Log.Error(err, "Failed to copy status in spec",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		)
 	}
 
 	user, pass, err := AerospikeAdminCredentials(
 		ctx, &r.aeroCluster.Spec, statusToSpec, r.getPasswordProvider(),
 	)
 	if err != nil {
-		r.Log.Error(err, "Failed to get cluster auth info")
+		r.Log.Error(err, "Failed to get cluster auth info",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		)
 	}
 	// TODO: What should be the timeout, should make it configurable or just keep it default
 	policy.Timeout = time.Minute * 1
@@ -193,14 +202,19 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 	serverPool, err := x509.SystemCertPool()
 	if err != nil {
 		r.Log.Info(
-			"Warn: Failed to add system certificates to the pool", "err", err,
+			"Warn: Failed to add system certificates to the pool, using empty pool",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+			"err", err,
 		)
 
 		serverPool = x509.NewCertPool()
 	}
 
 	if clientCertSpec == nil {
-		r.Log.Info("`operatorClientCertSpec` is not configured. Using default system CA certs...")
+		r.Log.Info("`operatorClientCertSpec` is not configured. Using default system CA certs",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		)
+
 		return serverPool
 	}
 
@@ -216,7 +230,8 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 	default:
 		r.Log.Error(
 			fmt.Errorf("both `secretName` and `certPathInOperator` are not set"),
-			"Returning empty certPool.",
+			"Returning empty certPool",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		)
 
 		return serverPool
@@ -227,7 +242,10 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 	caPath string, serverPool *x509.CertPool,
 ) *x509.CertPool {
 	if caPath == "" {
-		r.Log.Info("CA path is not provided in `operatorClientCertSpec`. Using default system CA certs...")
+		r.Log.Info("CA path is not provided in `operatorClientCertSpec`. Using default system CA certs",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		)
+
 		return serverPool
 	}
 
@@ -246,8 +264,11 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 				}
 
 				serverPool.AppendCertsFromPEM(caData)
-				r.Log.Info("Loaded CA certs from file.", "ca-path", caPath,
-					"file", path)
+				r.Log.Info("Loaded CA certs from file",
+					"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+					"caPath", caPath,
+					"file", path,
+				)
 			}
 
 			return nil
@@ -255,7 +276,9 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 	)
 	if err != nil {
 		r.Log.Error(
-			err, "Failed to load CA certs from dir.", "ca-path", caPath,
+			err, "Failed to load CA certs from dir",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+			"caPath", caPath,
 		)
 	}
 
@@ -268,17 +291,19 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 	defaultNamespace string, serverPool *x509.CertPool,
 ) *x509.CertPool {
 	if secretSource.CaCertsFilename == "" && secretSource.CaCertsSource == nil {
-		r.Log.Info(
-			"Neither `caCertsFilename` nor `caCertSource` is specified. Using default CA certs...",
-			"secret", secretSource,
+		r.Log.V(2).Info(
+			"Neither caCertsFilename nor caCertSource is specified, using default CA certs",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+			"secretSource", secretSource,
 		)
 
 		return serverPool
 	}
 	// get the tls info from secret
-	r.Log.Info(
-		"Trying to find an appropriate CA cert from the secret...", "secret",
-		secretSource,
+	r.Log.V(2).Info(
+		"Trying to find an appropriate CA cert from the secret",
+		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		"secretSource", secretSource,
 	)
 
 	found := &corev1.Secret{}
@@ -291,7 +316,8 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 			r.Log.Error(
 				err,
 				"Failed to get CA certificates secret, returning empty certPool",
-				"secret", secretName,
+				"secret", klog.KRef(secretName.Namespace, secretName.Name),
+				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			)
 
 			return serverPool
@@ -299,8 +325,10 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 
 		for file, caData := range found.Data {
 			r.Log.V(1).Info(
-				"Adding cert to tls server-pool from the secret.", "secret",
-				secretName, "file", file,
+				"Adding cert to tls server-pool from the secret",
+				"secret", klog.KRef(secretName.Namespace, secretName.Name),
+				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+				"file", file,
 			)
 			serverPool.AppendCertsFromPEM(caData)
 		}
@@ -311,7 +339,8 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 			r.Log.Error(
 				err,
 				"Failed to get secret certificates to the pool, returning empty certPool",
-				"secret", secretName,
+				"secret", klog.KRef(secretName.Namespace, secretName.Name),
+				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			)
 
 			return serverPool
@@ -319,14 +348,17 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 
 		if caData, ok := found.Data[secretSource.CaCertsFilename]; ok {
 			r.Log.V(1).Info(
-				"Adding cert to tls server-pool from the secret.", "secret",
-				secretName,
+				"Adding cert to tls server-pool from the secret",
+				"secret", klog.KRef(secretName.Namespace, secretName.Name),
+				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			)
 			serverPool.AppendCertsFromPEM(caData)
 		} else {
 			r.Log.V(1).Info(
-				"WARN: Can't find ca-file in the secret. using default certPool.",
-				"secret", secretName, "ca-file", secretSource.CaCertsFilename,
+				"CA file not found in secret, using default certPool",
+				"secret", klog.KRef(secretName.Namespace, secretName.Name),
+				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+				"caFile", secretSource.CaCertsFilename,
 			)
 		}
 	}
@@ -366,7 +398,10 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	secretName := namespacedSecret(secretSource.SecretNamespace, secretSource.SecretName, defaultNamespace)
 	if err := r.Get(ctx, secretName, found); err != nil {
 		r.Log.Info(
-			"Warn: Failed to get secret certificates to the pool", "err", err,
+			"Failed to get secret for client certificate, continuing with error",
+			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+			"secret", klog.KRef(secretName.Namespace, secretName.Name),
+			"err", err,
 		)
 
 		return nil, fmt.Errorf("could not get secret %+v: %w", secretName, err)
@@ -397,8 +432,9 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	}
 
 	r.Log.Info(
-		"Loading Aerospike Cluster client cert from secret", "secret",
-		secretName,
+		"Loading Aerospike Cluster client cert from secret",
+		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		"secret", klog.KRef(secretName.Namespace, secretName.Name),
 	)
 
 	return &cert, nil
@@ -442,8 +478,10 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromFiles(
 	}
 
 	r.Log.Info(
-		"Loading Aerospike Cluster client cert from files.", "cert-path",
-		certPath, "key-path", keyPath,
+		"Loading Aerospike Cluster client cert from files",
+		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		"certPath", certPath,
+		"keyPath", keyPath,
 	)
 
 	return &cert, nil

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -350,7 +350,7 @@ func (r *SingleClusterReconciler) getClientCertificate(
 			ctx, clientCertSpec.SecretCertSource, clusterNamespace,
 		)
 	default:
-		return nil, fmt.Errorf("neither secretName nor certPathInOperator is set in operatorClientCertSpec")
+		return nil, fmt.Errorf("both secretName and certPathInOperator are not set in operatorClientCertSpec")
 	}
 }
 

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -41,7 +41,7 @@ func (pp fromSecretPasswordProvider) Get(
 		types.NamespacedName{Name: secretName, Namespace: pp.namespace}, secret,
 	)
 	if err != nil {
-		return "", fmt.Errorf("could not get secret %s: %w", utils.NamespacedName(pp.namespace, secretName), err)
+		return "", fmt.Errorf("get secret %s: %w", utils.NamespacedName(pp.namespace, secretName), err)
 	}
 
 	passBytes, ok := secret.Data["password"]
@@ -89,7 +89,7 @@ func (pp fromSecretPasswordProvider) getPasswordFromSecret(
 
 	err := (*pp.k8sClient).Get(ctx, secretNamespcedName, secret)
 	if err != nil {
-		return "", fmt.Errorf("could not get secret %s: %w", secretNamespcedName, err)
+		return "", fmt.Errorf("get secret %s: %w", secretNamespcedName, err)
 	}
 
 	passBytes, ok := secret.Data[passFileName]
@@ -404,7 +404,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 			"err", err,
 		)
 
-		return nil, fmt.Errorf("could not get secret %+v: %w", secretName, err)
+		return nil, fmt.Errorf("get secret %+v: %w", secretName, err)
 	}
 
 	crtData, crtExists := found.Data[secretSource.ClientCertFilename]
@@ -461,12 +461,12 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromFiles(
 ) (*tls.Certificate, error) {
 	certData, certErr := os.ReadFile(certPath)
 	if certErr != nil {
-		return nil, fmt.Errorf("could not read certificate file %s: %w", certPath, certErr)
+		return nil, fmt.Errorf("read certificate file %s: %w", certPath, certErr)
 	}
 
 	keyData, keyErr := os.ReadFile(keyPath)
 	if keyErr != nil {
-		return nil, fmt.Errorf("could not read client key file %s: %w", keyPath, keyErr)
+		return nil, fmt.Errorf("read client key file %s: %w", keyPath, keyErr)
 	}
 
 	cert, err := tls.X509KeyPair(certData, keyData)

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -10,9 +10,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
@@ -27,6 +27,8 @@ type fromSecretPasswordProvider struct {
 
 	// The secret namespace.
 	namespace string
+
+	log logr.Logger
 }
 
 // Get returns the password for the username using userSpec.
@@ -41,12 +43,12 @@ func (pp fromSecretPasswordProvider) Get(
 		types.NamespacedName{Name: secretName, Namespace: pp.namespace}, secret,
 	)
 	if err != nil {
-		return "", fmt.Errorf("get secret %s: %w", utils.NamespacedName(pp.namespace, secretName), err)
+		return "", fmt.Errorf("get Secret %s: %w", utils.NamespacedName(pp.namespace, secretName), err)
 	}
 
 	passBytes, ok := secret.Data["password"]
 	if !ok {
-		return "", fmt.Errorf("missing %q key in secret %s", "password", utils.NamespacedName(pp.namespace, secretName))
+		return "", fmt.Errorf("missing %q key in Secret %s", "password", utils.NamespacedName(pp.namespace, secretName))
 	}
 
 	return string(passBytes), nil
@@ -70,10 +72,8 @@ func (pp fromSecretPasswordProvider) GetDefaultPassword(ctx context.Context, spe
 
 	password, err := pp.getPasswordFromSecret(ctx, secretName, passwordFileName)
 	if err != nil {
-		pkgLog.Info(
-			"Failed to get password from secret, using default password",
-			"secret", klog.KRef(pp.namespace, secretName),
-			"err", err,
+		pp.log.Error(err, "Failed to get password from Secret",
+			"secret", utils.NewNamespacedName(pp.namespace, secretName),
 		)
 
 		return asdbv1.DefaultAdminPassword
@@ -91,12 +91,12 @@ func (pp fromSecretPasswordProvider) getPasswordFromSecret(
 
 	err := (*pp.k8sClient).Get(ctx, secretNamespcedName, secret)
 	if err != nil {
-		return "", fmt.Errorf("get secret %s: %w", secretNamespcedName, err)
+		return "", fmt.Errorf("get Secret %s: %w", secretNamespcedName, err)
 	}
 
 	passBytes, ok := secret.Data[passFileName]
 	if !ok {
-		return "", fmt.Errorf("get password file %q from secret %s: not found in secret data",
+		return "", fmt.Errorf("get password file %q from Secret %s: not found in Secret data",
 			passFileName, secretNamespcedName)
 	}
 
@@ -105,7 +105,7 @@ func (pp fromSecretPasswordProvider) getPasswordFromSecret(
 
 func (r *SingleClusterReconciler) getPasswordProvider() fromSecretPasswordProvider {
 	return fromSecretPasswordProvider{
-		k8sClient: &r.Client, namespace: r.aeroCluster.Namespace,
+		k8sClient: &r.Client, namespace: r.aeroCluster.Namespace, log: r.asConfigLog(),
 	}
 }
 
@@ -135,7 +135,6 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 			// This is possible when tls-authenticate-client = false
 			r.Log.Info(
 				"Operator's client cert is not configured. Skip using client certs.",
-				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 				"clientCertSpec", clientCertSpec,
 			)
 		} else if cert, err := r.getClientCertificate(
@@ -143,10 +142,9 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 		); err == nil {
 			tlsConf.Certificates = append(tlsConf.Certificates, *cert)
 		} else {
-			r.Log.Info(
-				"Failed to get client certificate, using basic clientPolicy",
-				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-				"err", err,
+			r.Log.Error(
+				err,
+				"Failed to get client certificate. Using basic clientPolicy",
 			)
 		}
 
@@ -164,22 +162,14 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 
 	statusToSpec, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		r.Log.Info(
-			"Failed to copy status to spec, continuing with partial client policy",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-			"err", err,
-		)
+		r.Log.Error(err, "Failed to copy status in spec", "err", err)
 	}
 
 	user, pass, err := AerospikeAdminCredentials(
 		ctx, &r.aeroCluster.Spec, statusToSpec, r.getPasswordProvider(),
 	)
 	if err != nil {
-		r.Log.Info(
-			"Failed to get cluster auth info, using empty credentials",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-			"err", err,
-		)
+		r.Log.Error(err, "Failed to get cluster auth info", "err", err)
 	}
 	// TODO: What should be the timeout, should make it configurable or just keep it default
 	policy.Timeout = time.Minute * 1
@@ -210,7 +200,6 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 	if err != nil {
 		r.Log.Info(
 			"Failed to load system certificates into pool, using empty pool",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			"err", err,
 		)
 
@@ -220,7 +209,6 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 	if clientCertSpec == nil {
 		r.Log.Info(
 			"operatorClientCertSpec is not configured, using default system CA certs",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		)
 
 		return serverPool
@@ -236,9 +224,9 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 			ctx, clientCertSpec.SecretCertSource, clusterNamespace, serverPool,
 		)
 	default:
-		r.Log.Info(
-			"Neither secretName nor certPathInOperator is set in operatorClientCertSpec, using existing cert pool",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		r.Log.Error(
+			fmt.Errorf("both secretName and certPathInOperator are not set"),
+			"Returning empty certPool.",
 		)
 
 		return serverPool
@@ -251,7 +239,6 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 	if caPath == "" {
 		r.Log.Info(
 			"CA path is not provided in operatorClientCertSpec, using default system CA certs",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		)
 
 		return serverPool
@@ -273,7 +260,6 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 
 				serverPool.AppendCertsFromPEM(caData)
 				r.Log.Info("Loaded CA certs from file",
-					"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 					"caPath", caPath,
 					"file", path,
 				)
@@ -283,11 +269,8 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 		},
 	)
 	if err != nil {
-		r.Log.Info(
-			"Failed to load CA certs from dir, using cert pool without those CAs",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-			"caPath", caPath,
-			"err", err,
+		r.Log.Error(
+			err, "Failed to load CA certs from dir.", "caPath", caPath,
 		)
 	}
 
@@ -302,7 +285,6 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 	if secretSource.CaCertsFilename == "" && secretSource.CaCertsSource == nil {
 		r.Log.Info(
 			"Neither caCertsFilename nor caCertSource is specified, using default CA certs",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			"secretSource", secretSource,
 		)
 
@@ -310,8 +292,7 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 	}
 	// get the tls info from secret
 	r.Log.Info(
-		"Trying to find an appropriate CA cert from the secret",
-		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		"Trying to find an appropriate CA cert from the Secret",
 		"secretSource", secretSource,
 	)
 
@@ -322,11 +303,10 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 		secretName := namespacedSecret(secretSource.CaCertsSource.SecretNamespace,
 			secretSource.CaCertsSource.SecretName, defaultNamespace)
 		if err := r.Get(ctx, secretName, found); err != nil {
-			r.Log.Info(
-				"Failed to get CA certificates secret, using cert pool without secret CAs",
-				"secret", klog.KRef(secretName.Namespace, secretName.Name),
-				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-				"err", err,
+			r.Log.Error(
+				err,
+				"Failed to get CA certificates Secret, returning empty certPool",
+				"secret", utils.NewNamespacedName(secretName.Namespace, secretName.Name),
 			)
 
 			return serverPool
@@ -334,9 +314,8 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 
 		for file, caData := range found.Data {
 			r.Log.V(1).Info(
-				"Adding cert to tls server-pool from the secret",
-				"secret", klog.KRef(secretName.Namespace, secretName.Name),
-				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+				"Adding cert to tls server-pool from the Secret",
+				"secret", utils.NewNamespacedName(secretName.Namespace, secretName.Name),
 				"file", file,
 			)
 			serverPool.AppendCertsFromPEM(caData)
@@ -345,11 +324,10 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 		//nolint:staticcheck // SA1019: must read deprecated SecretNamespace to resolve secret until field is removed
 		secretName := namespacedSecret(secretSource.SecretNamespace, secretSource.SecretName, defaultNamespace)
 		if err := r.Get(ctx, secretName, found); err != nil {
-			r.Log.Info(
-				"Failed to get CA certificates secret, using cert pool without secret CAs",
-				"secret", klog.KRef(secretName.Namespace, secretName.Name),
-				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-				"err", err,
+			r.Log.Error(
+				err,
+				"Failed to get Secret certificates to the pool, returning empty certPool",
+				"secret", utils.NewNamespacedName(secretName.Namespace, secretName.Name),
 			)
 
 			return serverPool
@@ -357,16 +335,14 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 
 		if caData, ok := found.Data[secretSource.CaCertsFilename]; ok {
 			r.Log.V(1).Info(
-				"Adding cert to tls server-pool from the secret",
-				"secret", klog.KRef(secretName.Namespace, secretName.Name),
-				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+				"Adding cert to tls server-pool from the Secret",
+				"secret", utils.NewNamespacedName(secretName.Namespace, secretName.Name),
 			)
 			serverPool.AppendCertsFromPEM(caData)
 		} else {
 			r.Log.V(1).Info(
-				"CA file not found in secret, using cert pool without that CA",
-				"secret", klog.KRef(secretName.Namespace, secretName.Name),
-				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+				"CA file not found in Secret, using cert pool without that CA",
+				"secret", utils.NewNamespacedName(secretName.Namespace, secretName.Name),
 				"caFile", secretSource.CaCertsFilename,
 			)
 		}
@@ -406,20 +382,13 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	//nolint:staticcheck // SA1019: must read deprecated SecretNamespace to resolve secret until field is removed
 	secretName := namespacedSecret(secretSource.SecretNamespace, secretSource.SecretName, defaultNamespace)
 	if err := r.Get(ctx, secretName, found); err != nil {
-		r.Log.Info(
-			"Failed to get secret for client certificate, continuing with error",
-			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-			"secret", klog.KRef(secretName.Namespace, secretName.Name),
-			"err", err,
-		)
-
-		return nil, fmt.Errorf("get secret %+v: %w", secretName, err)
+		return nil, fmt.Errorf("get Secret %s: %w", secretName, err)
 	}
 
 	crtData, crtExists := found.Data[secretSource.ClientCertFilename]
 	if !crtExists {
 		return nil, fmt.Errorf(
-			"find certificate %q in secret %+v",
+			"certificate %q not found in Secret %+v",
 			secretSource.ClientCertFilename, secretName,
 		)
 	}
@@ -427,7 +396,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	keyData, keyExists := found.Data[secretSource.ClientKeyFilename]
 	if !keyExists {
 		return nil, fmt.Errorf(
-			"find client key %q in secret %+v",
+			"client key %q not found in Secret %+v",
 			secretSource.ClientKeyFilename, secretName,
 		)
 	}
@@ -435,15 +404,14 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	cert, err := tls.X509KeyPair(crtData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"load X509 key pair for cluster from secret %+v: %w",
+			"load X509 key pair for cluster from Secret %+v: %w",
 			secretName, err,
 		)
 	}
 
 	r.Log.Info(
-		"Loading Aerospike Cluster client cert from secret",
-		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-		"secret", klog.KRef(secretName.Namespace, secretName.Name),
+		"Loading AerospikeCluster client cert from Secret",
+		"secret", utils.NewNamespacedName(secretName.Namespace, secretName.Name),
 	)
 
 	return &cert, nil
@@ -487,8 +455,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromFiles(
 	}
 
 	r.Log.Info(
-		"Loading Aerospike Cluster client cert from files",
-		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		"Loading AerospikeCluster client cert from files",
 		"certPath", certPath,
 		"keyPath", keyPath,
 	)

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -70,6 +70,8 @@ func (pp fromSecretPasswordProvider) GetDefaultPassword(ctx context.Context, spe
 
 	password, err := pp.getPasswordFromSecret(ctx, secretName, passwordFileName)
 	if err != nil {
+		// TODO: Refactor per KO-379 §2.5 — return wrapped error instead of log-and-continue;
+		// let reconcile defer log once (separate ticket).
 		pkgLog.Error(err, "Failed to get password from secret",
 			"secret", klog.KRef(pp.namespace, secretName),
 		)
@@ -106,6 +108,8 @@ func (r *SingleClusterReconciler) getPasswordProvider() fromSecretPasswordProvid
 	}
 }
 
+// TODO: Refactor per KO-379 §2.5 — return (*as.ClientPolicy, error), build/cache once per
+// reconcile, and remove log.Error here so defer logs each failure once (separate ticket).
 func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.ClientPolicy {
 	policy := as.NewClientPolicy()
 
@@ -193,6 +197,8 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 	return policy
 }
 
+// TODO: Refactor per KO-379 §2.5 — return wrapped errors instead of log-and-continue
+// (separate ticket; called from getClientPolicy on every reconcile pass).
 func (r *SingleClusterReconciler) getClusterServerCAPool(
 	ctx context.Context,
 	clientCertSpec *asdbv1.AerospikeOperatorClientCertSpec,
@@ -238,6 +244,8 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 	}
 }
 
+// TODO: Refactor per KO-379 §2.5 — return wrapped errors instead of log-and-continue
+// (separate ticket; called from getClientPolicy on every reconcile pass).
 func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 	caPath string, serverPool *x509.CertPool,
 ) *x509.CertPool {
@@ -285,6 +293,8 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 	return serverPool
 }
 
+// TODO: Refactor per KO-379 §2.5 — return wrapped errors instead of log-and-continue
+// (separate ticket; called from getClientPolicy on every reconcile pass).
 func (r *SingleClusterReconciler) appendCACertFromSecret(
 	ctx context.Context,
 	secretSource *asdbv1.AerospikeSecretCertSource,

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -96,7 +96,7 @@ func (pp fromSecretPasswordProvider) getPasswordFromSecret(
 
 	passBytes, ok := secret.Data[passFileName]
 	if !ok {
-		return "", fmt.Errorf("get password file %q from Secret %s: not found in Secret data",
+		return "", fmt.Errorf("password file %q not found in Secret %s",
 			passFileName, secretNamespcedName)
 	}
 
@@ -162,14 +162,14 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 
 	statusToSpec, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		r.Log.Error(err, "Failed to copy status in spec", "err", err)
+		r.Log.Error(err, "Failed to copy status in spec")
 	}
 
 	user, pass, err := AerospikeAdminCredentials(
 		ctx, &r.aeroCluster.Spec, statusToSpec, r.getPasswordProvider(),
 	)
 	if err != nil {
-		r.Log.Error(err, "Failed to get cluster auth info", "err", err)
+		r.Log.Error(err, "Failed to get cluster auth info")
 	}
 	// TODO: What should be the timeout, should make it configurable or just keep it default
 	policy.Timeout = time.Minute * 1
@@ -283,18 +283,12 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 	defaultNamespace string, serverPool *x509.CertPool,
 ) *x509.CertPool {
 	if secretSource.CaCertsFilename == "" && secretSource.CaCertsSource == nil {
-		r.Log.Info(
-			"Neither caCertsFilename nor caCertSource is specified, using default CA certs",
-			"secretSource", secretSource,
-		)
+		r.Log.Info("Neither caCertsFilename nor caCertSource is specified, using default CA certs")
 
 		return serverPool
 	}
 	// get the tls info from secret
-	r.Log.Info(
-		"Trying to find an appropriate CA cert from the Secret",
-		"secretSource", secretSource,
-	)
+	r.Log.Info("Trying to find an appropriate CA cert from the Secret")
 
 	found := &corev1.Secret{}
 

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -70,10 +70,10 @@ func (pp fromSecretPasswordProvider) GetDefaultPassword(ctx context.Context, spe
 
 	password, err := pp.getPasswordFromSecret(ctx, secretName, passwordFileName)
 	if err != nil {
-		// TODO: Refactor per KO-379 §2.5 — return wrapped error instead of log-and-continue;
-		// let reconcile defer log once (separate ticket).
-		pkgLog.Error(err, "Failed to get password from secret",
+		pkgLog.Info(
+			"Failed to get password from secret, using default password",
 			"secret", klog.KRef(pp.namespace, secretName),
+			"err", err,
 		)
 
 		return asdbv1.DefaultAdminPassword
@@ -96,7 +96,8 @@ func (pp fromSecretPasswordProvider) getPasswordFromSecret(
 
 	passBytes, ok := secret.Data[passFileName]
 	if !ok {
-		return "", fmt.Errorf("missing password file %q in secret %s", passFileName, secretNamespcedName)
+		return "", fmt.Errorf("get password file %q from secret %s: not found in secret data",
+			passFileName, secretNamespcedName)
 	}
 
 	return string(passBytes), nil
@@ -108,8 +109,6 @@ func (r *SingleClusterReconciler) getPasswordProvider() fromSecretPasswordProvid
 	}
 }
 
-// TODO: Refactor per KO-379 §2.5 — return (*as.ClientPolicy, error), build/cache once per
-// reconcile, and remove log.Error here so defer logs each failure once (separate ticket).
 func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.ClientPolicy {
 	policy := as.NewClientPolicy()
 
@@ -144,10 +143,10 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 		); err == nil {
 			tlsConf.Certificates = append(tlsConf.Certificates, *cert)
 		} else {
-			r.Log.Error(
-				err,
+			r.Log.Info(
 				"Failed to get client certificate, using basic clientPolicy",
 				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+				"err", err,
 			)
 		}
 
@@ -165,8 +164,10 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 
 	statusToSpec, err := asdbv1.CopyStatusToSpec(&r.aeroCluster.Status.AerospikeClusterStatusSpec)
 	if err != nil {
-		r.Log.Error(err, "Failed to copy status in spec",
+		r.Log.Info(
+			"Failed to copy status to spec, continuing with partial client policy",
 			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+			"err", err,
 		)
 	}
 
@@ -174,8 +175,10 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 		ctx, &r.aeroCluster.Spec, statusToSpec, r.getPasswordProvider(),
 	)
 	if err != nil {
-		r.Log.Error(err, "Failed to get cluster auth info",
+		r.Log.Info(
+			"Failed to get cluster auth info, using empty credentials",
 			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+			"err", err,
 		)
 	}
 	// TODO: What should be the timeout, should make it configurable or just keep it default
@@ -197,8 +200,6 @@ func (r *SingleClusterReconciler) getClientPolicy(ctx context.Context) *as.Clien
 	return policy
 }
 
-// TODO: Refactor per KO-379 §2.5 — return wrapped errors instead of log-and-continue
-// (separate ticket; called from getClientPolicy on every reconcile pass).
 func (r *SingleClusterReconciler) getClusterServerCAPool(
 	ctx context.Context,
 	clientCertSpec *asdbv1.AerospikeOperatorClientCertSpec,
@@ -208,7 +209,7 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 	serverPool, err := x509.SystemCertPool()
 	if err != nil {
 		r.Log.Info(
-			"Warn: Failed to add system certificates to the pool, using empty pool",
+			"Failed to load system certificates into pool, using empty pool",
 			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			"err", err,
 		)
@@ -217,7 +218,8 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 	}
 
 	if clientCertSpec == nil {
-		r.Log.Info("`operatorClientCertSpec` is not configured. Using default system CA certs",
+		r.Log.Info(
+			"operatorClientCertSpec is not configured, using default system CA certs",
 			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		)
 
@@ -234,9 +236,8 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 			ctx, clientCertSpec.SecretCertSource, clusterNamespace, serverPool,
 		)
 	default:
-		r.Log.Error(
-			fmt.Errorf("both `secretName` and `certPathInOperator` are not set"),
-			"Returning empty certPool",
+		r.Log.Info(
+			"Neither secretName nor certPathInOperator is set in operatorClientCertSpec, using existing cert pool",
 			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		)
 
@@ -244,13 +245,12 @@ func (r *SingleClusterReconciler) getClusterServerCAPool(
 	}
 }
 
-// TODO: Refactor per KO-379 §2.5 — return wrapped errors instead of log-and-continue
-// (separate ticket; called from getClientPolicy on every reconcile pass).
 func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 	caPath string, serverPool *x509.CertPool,
 ) *x509.CertPool {
 	if caPath == "" {
-		r.Log.Info("CA path is not provided in `operatorClientCertSpec`. Using default system CA certs",
+		r.Log.Info(
+			"CA path is not provided in operatorClientCertSpec, using default system CA certs",
 			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		)
 
@@ -283,25 +283,24 @@ func (r *SingleClusterReconciler) appendCACertFromFileOrPath(
 		},
 	)
 	if err != nil {
-		r.Log.Error(
-			err, "Failed to load CA certs from dir",
+		r.Log.Info(
+			"Failed to load CA certs from dir, using cert pool without those CAs",
 			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			"caPath", caPath,
+			"err", err,
 		)
 	}
 
 	return serverPool
 }
 
-// TODO: Refactor per KO-379 §2.5 — return wrapped errors instead of log-and-continue
-// (separate ticket; called from getClientPolicy on every reconcile pass).
 func (r *SingleClusterReconciler) appendCACertFromSecret(
 	ctx context.Context,
 	secretSource *asdbv1.AerospikeSecretCertSource,
 	defaultNamespace string, serverPool *x509.CertPool,
 ) *x509.CertPool {
 	if secretSource.CaCertsFilename == "" && secretSource.CaCertsSource == nil {
-		r.Log.V(2).Info(
+		r.Log.Info(
 			"Neither caCertsFilename nor caCertSource is specified, using default CA certs",
 			"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 			"secretSource", secretSource,
@@ -310,7 +309,7 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 		return serverPool
 	}
 	// get the tls info from secret
-	r.Log.V(2).Info(
+	r.Log.Info(
 		"Trying to find an appropriate CA cert from the secret",
 		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		"secretSource", secretSource,
@@ -323,11 +322,11 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 		secretName := namespacedSecret(secretSource.CaCertsSource.SecretNamespace,
 			secretSource.CaCertsSource.SecretName, defaultNamespace)
 		if err := r.Get(ctx, secretName, found); err != nil {
-			r.Log.Error(
-				err,
-				"Failed to get CA certificates secret, returning empty certPool",
+			r.Log.Info(
+				"Failed to get CA certificates secret, using cert pool without secret CAs",
 				"secret", klog.KRef(secretName.Namespace, secretName.Name),
 				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+				"err", err,
 			)
 
 			return serverPool
@@ -346,11 +345,11 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 		//nolint:staticcheck // SA1019: must read deprecated SecretNamespace to resolve secret until field is removed
 		secretName := namespacedSecret(secretSource.SecretNamespace, secretSource.SecretName, defaultNamespace)
 		if err := r.Get(ctx, secretName, found); err != nil {
-			r.Log.Error(
-				err,
-				"Failed to get secret certificates to the pool, returning empty certPool",
+			r.Log.Info(
+				"Failed to get CA certificates secret, using cert pool without secret CAs",
 				"secret", klog.KRef(secretName.Namespace, secretName.Name),
 				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+				"err", err,
 			)
 
 			return serverPool
@@ -365,7 +364,7 @@ func (r *SingleClusterReconciler) appendCACertFromSecret(
 			serverPool.AppendCertsFromPEM(caData)
 		} else {
 			r.Log.V(1).Info(
-				"CA file not found in secret, using default certPool",
+				"CA file not found in secret, using cert pool without that CA",
 				"secret", klog.KRef(secretName.Namespace, secretName.Name),
 				"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 				"caFile", secretSource.CaCertsFilename,
@@ -392,7 +391,7 @@ func (r *SingleClusterReconciler) getClientCertificate(
 			ctx, clientCertSpec.SecretCertSource, clusterNamespace,
 		)
 	default:
-		return nil, fmt.Errorf("both `secretName` and `certPathInOperator` are not set")
+		return nil, fmt.Errorf("both secretName and certPathInOperator are not set")
 	}
 }
 
@@ -420,7 +419,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	crtData, crtExists := found.Data[secretSource.ClientCertFilename]
 	if !crtExists {
 		return nil, fmt.Errorf(
-			"can't find certificate `%q` in secret %+v",
+			"find certificate %q in secret %+v",
 			secretSource.ClientCertFilename, secretName,
 		)
 	}
@@ -428,7 +427,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	keyData, keyExists := found.Data[secretSource.ClientKeyFilename]
 	if !keyExists {
 		return nil, fmt.Errorf(
-			"can't find client key `%q` in secret %+v",
+			"find client key %q in secret %+v",
 			secretSource.ClientKeyFilename, secretName,
 		)
 	}

--- a/internal/controller/cluster/client_policy.go
+++ b/internal/controller/cluster/client_policy.go
@@ -426,7 +426,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromSecret(
 	cert, err := tls.X509KeyPair(crtData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"could not load X509 key pair for cluster from secret %+v: %w",
+			"load X509 key pair for cluster from secret %+v: %w",
 			secretName, err,
 		)
 	}
@@ -472,7 +472,7 @@ func (r *SingleClusterReconciler) loadCertAndKeyFromFiles(
 	cert, err := tls.X509KeyPair(certData, keyData)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"could not load X509 key pair for cluster (cert=%s, key=%s): %w",
+			"load X509 key pair for cluster (cert=%s, key=%s): %w",
 			certPath, keyPath, err,
 		)
 	}

--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -92,19 +92,25 @@ func init() {
 }
 
 // createConfigMapData create configMap data
-func (r *SingleClusterReconciler) createConfigMapData(rack *asdbv1.Rack) (
+func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack *asdbv1.Rack) (
 	map[string]string, error,
 ) {
 	// Add config template
 	confTemp, err := r.buildConfigTemplate(rack)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build config template: %v", err)
+		return nil, fmt.Errorf(
+			"building config template for rack %d in cluster %s: %w",
+			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	// Add conf file
-	confData, err := r.getBaseConfData(rack)
+	confData, err := r.getBaseConfData(ctx, rack)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build config template: %v", err)
+		return nil, fmt.Errorf(
+			"building base config data for rack %d in cluster %s: %w",
+			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	confData[aerospikeTemplateConfFileName] = confTemp
@@ -220,7 +226,10 @@ func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 
 	asConf, err := asconfig.NewMapAsConfig(r.Log, configMap)
 	if err != nil {
-		return "", fmt.Errorf("failed to load config map by lib: %v", err)
+		return "", fmt.Errorf(
+			"loading aerospike config via management lib for rack %d in cluster %s: %w",
+			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	// No need for asConf version validation, it's already validated in admission webhook
@@ -232,7 +241,7 @@ func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 }
 
 // getBaseConfData returns the basic data to be used in the config map for input aeroCluster spec.
-func (r *SingleClusterReconciler) getBaseConfData(rack *asdbv1.Rack) (map[string]string, error) {
+func (r *SingleClusterReconciler) getBaseConfData(ctx context.Context, rack *asdbv1.Rack) (map[string]string, error) {
 	workDir := asdbv1.GetWorkDirectory(rack.AerospikeConfig)
 	volume := asdbv1.GetVolumeForAerospikePath(&rack.Storage, workDir)
 
@@ -306,7 +315,7 @@ func (r *SingleClusterReconciler) getBaseConfData(rack *asdbv1.Rack) (map[string
 	}
 
 	// Include peer list.
-	peers, err := r.getFQDNsForCluster()
+	peers, err := r.getFQDNsForCluster(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -316,12 +325,12 @@ func (r *SingleClusterReconciler) getBaseConfData(rack *asdbv1.Rack) (map[string
 	return baseConfData, nil
 }
 
-func (r *SingleClusterReconciler) getFQDNsForCluster() ([]string, error) {
+func (r *SingleClusterReconciler) getFQDNsForCluster(ctx context.Context) ([]string, error) {
 	podNameSet := sets.NewString()
 
 	// The default rack is not listed in config during switchover to rack aware state.
 	// Use current pod names as well.
-	pods, err := r.getClusterPodList()
+	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +358,7 @@ func (r *SingleClusterReconciler) getFQDNsForCluster() ([]string, error) {
 	return podNameSet.List(), nil
 }
 
-func (r *SingleClusterReconciler) deleteRackConfigMap(namespacedName types.NamespacedName) error {
+func (r *SingleClusterReconciler) deleteRackConfigMap(ctx context.Context, namespacedName types.NamespacedName) error {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      namespacedName.Name,
@@ -357,7 +366,7 @@ func (r *SingleClusterReconciler) deleteRackConfigMap(namespacedName types.Names
 		},
 	}
 
-	if err := r.Delete(context.TODO(), configMap); err != nil {
+	if err := r.Delete(ctx, configMap); err != nil {
 		if errors.IsNotFound(err) {
 			r.Log.Info(
 				"Can't find rack configmap while trying to delete it. Skipping...",
@@ -367,7 +376,7 @@ func (r *SingleClusterReconciler) deleteRackConfigMap(namespacedName types.Names
 			return nil
 		}
 
-		return fmt.Errorf("failed to delete rack configmap for pod %s: %v", namespacedName.Name, err)
+		return fmt.Errorf("deleting rack configmap %s: %w", namespacedName, err)
 	}
 
 	return nil

--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -377,7 +377,7 @@ func (r *SingleClusterReconciler) deleteRackConfigMap(ctx context.Context, names
 			return nil
 		}
 
-		return fmt.Errorf("could not delete rack ConfigMap %s: %w", namespacedName, err)
+		return fmt.Errorf("delete rack ConfigMap %s: %w", namespacedName, err)
 	}
 
 	return nil

--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -215,7 +216,7 @@ func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 	string, error,
 ) {
 	log := pkgLog.WithValues(
-		"aerospikecluster", utils.ClusterNamespacedName(r.aeroCluster),
+		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 	)
 
 	configMap := rack.AerospikeConfig.Value

--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -99,7 +99,7 @@ func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack 
 	confTemp, err := r.buildConfigTemplate(rack)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"building config template for rack %d in cluster %s: %w",
+			"could not build config template for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -108,7 +108,7 @@ func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack 
 	confData, err := r.getBaseConfData(ctx, rack)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"building base config data for rack %d in cluster %s: %w",
+			"could not build base config data for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -227,7 +227,7 @@ func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 	asConf, err := asconfig.NewMapAsConfig(r.Log, configMap)
 	if err != nil {
 		return "", fmt.Errorf(
-			"loading aerospike config via management lib for rack %d in cluster %s: %w",
+			"could not load Aerospike configuration via management library for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -376,7 +376,7 @@ func (r *SingleClusterReconciler) deleteRackConfigMap(ctx context.Context, names
 			return nil
 		}
 
-		return fmt.Errorf("deleting rack configmap %s: %w", namespacedName, err)
+		return fmt.Errorf("could not delete rack ConfigMap %s: %w", namespacedName, err)
 	}
 
 	return nil

--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -227,7 +227,7 @@ func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 	asConf, err := asconfig.NewMapAsConfig(r.Log, configMap)
 	if err != nil {
 		return "", fmt.Errorf(
-			"could not load Aerospike configuration via management library for rack %d in cluster %s: %w",
+			"could not load Aerospike config map via management library for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}

--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -17,16 +17,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/pkg/utils"
 	lib "github.com/aerospike/aerospike-management-lib"
 	"github.com/aerospike/aerospike-management-lib/asconfig"
 )
-
-var pkgLog = klog.LoggerWithName(ctrl.Log, "lib.asconfig")
 
 const (
 	// aerospikeTemplateConfFileName is the name of the aerospike conf template
@@ -100,8 +96,8 @@ func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack 
 	confTemp, err := r.buildConfigTemplate(rack)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"build config template for rack %d in cluster %s: %w",
-			rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"build config template for rack %d: %w",
+			rack.ID, err,
 		)
 	}
 
@@ -109,8 +105,8 @@ func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack 
 	confData, err := r.getBaseConfData(ctx, rack)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"build base config data for rack %d in cluster %s: %w",
-			rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"build base config data for rack %d: %w",
+			rack.ID, err,
 		)
 	}
 
@@ -215,10 +211,7 @@ func createPodSpecForRack(
 func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 	string, error,
 ) {
-	log := klog.LoggerWithValues(
-		pkgLog,
-		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
-	)
+	log := r.asConfigLog()
 
 	configMap := rack.AerospikeConfig.Value
 	log.V(1).Info(
@@ -229,8 +222,8 @@ func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 	asConf, err := asconfig.NewMapAsConfig(r.Log, configMap)
 	if err != nil {
 		return "", fmt.Errorf(
-			"load Aerospike config map for rack %d in cluster %s: %w",
-			rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"load Aerospike config map for rack %d: %w",
+			rack.ID, err,
 		)
 	}
 
@@ -372,7 +365,7 @@ func (r *SingleClusterReconciler) deleteRackConfigMap(ctx context.Context, names
 		if errors.IsNotFound(err) {
 			r.Log.Info(
 				"Rack ConfigMap not found while deleting, skipping",
-				"configMap", klog.KRef(namespacedName.Namespace, namespacedName.Name),
+				"configMap", utils.NewNamespacedName(namespacedName.Namespace, namespacedName.Name),
 			)
 
 			return nil

--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aerospike/aerospike-management-lib/asconfig"
 )
 
-var pkgLog = ctrl.Log.WithName("lib.asconfig")
+var pkgLog = klog.LoggerWithName(ctrl.Log, "lib.asconfig")
 
 const (
 	// aerospikeTemplateConfFileName is the name of the aerospike conf template
@@ -101,7 +101,7 @@ func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack 
 	if err != nil {
 		return nil, fmt.Errorf(
 			"build config template for rack %d in cluster %s: %w",
-			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -110,7 +110,7 @@ func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack 
 	if err != nil {
 		return nil, fmt.Errorf(
 			"build base config data for rack %d in cluster %s: %w",
-			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -215,7 +215,8 @@ func createPodSpecForRack(
 func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 	string, error,
 ) {
-	log := pkgLog.WithValues(
+	log := klog.LoggerWithValues(
+		pkgLog,
 		"aerospikeCluster", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 	)
 
@@ -229,7 +230,7 @@ func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 	if err != nil {
 		return "", fmt.Errorf(
 			"load Aerospike config map for rack %d in cluster %s: %w",
-			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -370,8 +371,8 @@ func (r *SingleClusterReconciler) deleteRackConfigMap(ctx context.Context, names
 	if err := r.Delete(ctx, configMap); err != nil {
 		if errors.IsNotFound(err) {
 			r.Log.Info(
-				"Can't find rack configmap while trying to delete it. Skipping...",
-				"configmap", namespacedName.Name,
+				"Rack ConfigMap not found while deleting, skipping",
+				"configMap", klog.KRef(namespacedName.Namespace, namespacedName.Name),
 			)
 
 			return nil

--- a/internal/controller/cluster/configmap.go
+++ b/internal/controller/cluster/configmap.go
@@ -100,7 +100,7 @@ func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack 
 	confTemp, err := r.buildConfigTemplate(rack)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"could not build config template for rack %d in cluster %s: %w",
+			"build config template for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -109,7 +109,7 @@ func (r *SingleClusterReconciler) createConfigMapData(ctx context.Context, rack 
 	confData, err := r.getBaseConfData(ctx, rack)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"could not build base config data for rack %d in cluster %s: %w",
+			"build base config data for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -228,7 +228,7 @@ func (r *SingleClusterReconciler) buildConfigTemplate(rack *asdbv1.Rack) (
 	asConf, err := asconfig.NewMapAsConfig(r.Log, configMap)
 	if err != nil {
 		return "", fmt.Errorf(
-			"could not load Aerospike config map via management library for rack %d in cluster %s: %w",
+			"load Aerospike config map for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}

--- a/internal/controller/cluster/events.go
+++ b/internal/controller/cluster/events.go
@@ -1,0 +1,75 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/pkg/utils"
+)
+
+const (
+	EventReasonDeleteFailed = "DeleteFailed"
+	EventReasonDeleted      = "Deleted"
+
+	EventReasonServiceCreateFailed                = "ServiceCreateFailed"
+	EventReasonRackReconcileFailed                = "UpdateFailed"
+	EventReasonPodDisruptionBudgetReconcileFailed = "PodDisruptionBudgetReconcileFailed"
+	EventReasonAccessControlUpdateFailed          = "ACLUpdateFailed"
+	EventReasonStatusUpdateFailed                 = "StatusUpdateFailed"
+	EventReasonAccessControlUpdated               = "ACLUpdated"
+
+	EventReasonRoleCreateFailed = "RoleCreateFailed"
+	EventReasonRoleUpdateFailed = "RoleUpdateFailed"
+	EventReasonRoleCreated      = "RoleCreated"
+	EventReasonRoleUpdated      = "RoleUpdated"
+	EventReasonRoleDeleted      = "RoleDeleted"
+	EventReasonUserCreateFailed = "UserCreateFailed"
+	EventReasonUserUpdateFailed = "UserUpdateFailed"
+	EventReasonUserCreated      = "UserCreated"
+	EventReasonUserUpdated      = "UserUpdated"
+	EventReasonUserDeleted      = "UserDeleted"
+
+	EventReasonRackCreated              = "RackCreated"
+	EventReasonRackDeleted              = "RackDeleted"
+	EventReasonStatefulSetDeleteFailed  = "STSDeleteFailed"
+	EventReasonRackImageUpdateFailed    = "RackImageUpdateFailed"
+	EventReasonRackRollingRestartFailed = "RackRollingRestartFailed"
+	EventReasonRackDynamicConfigFailed  = "RackDynamicConfigUpdateFailed"
+	EventReasonDynamicConfigUpdate      = "DynamicConfigUpdate"
+	EventReasonDynamicConfigUpdated     = "DynamicConfigUpdated"
+	EventReasonRackScaleDownFailed      = "RackScaleDownFailed"
+	EventReasonRackScaleUpFailed        = "RackScaleUpFailed"
+	EventReasonRackScaleUp              = "RackScaleUp"
+	EventReasonRackScaledUp             = "RackScaledUp"
+	EventReasonPodImageUpdate           = "PodImageUpdate"
+	EventReasonPodImageUpdated          = "PodImageUpdated"
+	EventReasonPodWarmRestarted         = "PodWarmRestarted"
+	EventReasonPodConfUpdated           = "PodConfUpdated"
+	EventReasonPodRestarted             = "PodRestarted"
+	EventReasonPodWaitUpdate            = "PodWaitUpdate"
+	EventReasonRackImageUpdated         = "RackImageUpdated"
+	EventReasonRackScaleDown            = "RackScaleDown"
+	EventReasonPodDeleted               = "PodDeleted"
+	EventReasonRackScaledDown           = "RackScaledDown"
+	EventReasonRackRollingRestart       = "RackRollingRestart"
+	EventReasonRackRollingRestarted     = "RackRollingRestarted"
+	EventReasonWaitMigration            = "WaitMigration"
+)
+
+func eventNamespacedNames(namespace string, names []string) string {
+	return strings.Join(utils.NamespacedNames(namespace, names), ", ")
+}
+
+func eventRackScaleMessage(action string, rackID int, objectKind, objectName string, current, desired int32) string {
+	return fmt.Sprintf(
+		"[rack-%d] %s %s %s from %d to %d replicas",
+		rackID, action, objectKind, objectName, current, desired,
+	)
+}
+
+func eventRackScaleFailureMessage(action string, rackID int, objectKind, objectName string, current, desired int32) string {
+	return fmt.Sprintf(
+		"[rack-%d] Failed to %s %s %s from %d to %d replicas",
+		rackID, action, objectKind, objectName, current, desired,
+	)
+}

--- a/internal/controller/cluster/events.go
+++ b/internal/controller/cluster/events.go
@@ -60,16 +60,33 @@ func eventNamespacedNames(namespace string, names []string) string {
 	return strings.Join(utils.NamespacedNames(namespace, names), ", ")
 }
 
-func eventRackScaleMessage(action string, rackID int, objectKind, objectName string, current, desired int32) string {
+func eventRackScaleMessage(
+	action string, rackID int, objectName string, current, desired int32,
+) string {
 	return fmt.Sprintf(
-		"[rack-%d] %s %s %s from %d to %d replicas",
-		rackID, action, objectKind, objectName, current, desired,
+		"[rack-%d] %s StatefulSet %s from %d to %d replicas",
+		rackID, action, objectName, current, desired,
 	)
 }
 
-func eventRackScaleFailureMessage(action string, rackID int, objectKind, objectName string, current, desired int32) string {
+func eventRackScaleFailureMessage(
+	action string, rackID int, objectName string, current, desired int32,
+) string {
 	return fmt.Sprintf(
-		"[rack-%d] Failed to %s %s %s from %d to %d replicas",
-		rackID, action, objectKind, objectName, current, desired,
+		"[rack-%d] Failed to %s StatefulSet %s from %d to %d replicas",
+		rackID, action, objectName, current, desired,
 	)
+}
+
+// eventRackScaleFailureMessageWithCause appends a non-nil error to the rack scale failure message
+// (matches legacy Eventf text that ended with the reconcile error string).
+func eventRackScaleFailureMessageWithCause(
+	action string, rackID int, objectName string, current, desired int32, cause error,
+) string {
+	msg := eventRackScaleFailureMessage(action, rackID, objectName, current, desired)
+	if cause != nil {
+		return fmt.Sprintf("%s: %s", msg, cause.Error())
+	}
+
+	return msg
 }

--- a/internal/controller/cluster/events.go
+++ b/internal/controller/cluster/events.go
@@ -7,53 +7,12 @@ import (
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/pkg/utils"
 )
 
+// Shared Event Reason constants: used in two or more places across the cluster controller.
+// Single-use reasons are inlined as PascalCase string literals at their call sites.
 const (
-	EventReasonDeleteFailed = "DeleteFailed"
-	EventReasonDeleted      = "Deleted"
-
-	EventReasonServiceCreateFailed                = "ServiceCreateFailed"
-	EventReasonRackReconcileFailed                = "UpdateFailed"
-	EventReasonPodDisruptionBudgetReconcileFailed = "PodDisruptionBudgetReconcileFailed"
-	EventReasonAccessControlUpdateFailed          = "ACLUpdateFailed"
-	EventReasonStatusUpdateFailed                 = "StatusUpdateFailed"
-	EventReasonAccessControlUpdated               = "ACLUpdated"
-
-	EventReasonRoleCreateFailed = "RoleCreateFailed"
-	EventReasonRoleUpdateFailed = "RoleUpdateFailed"
-	EventReasonRoleCreated      = "RoleCreated"
-	EventReasonRoleUpdated      = "RoleUpdated"
-	EventReasonRoleDeleted      = "RoleDeleted"
-	EventReasonUserCreateFailed = "UserCreateFailed"
-	EventReasonUserUpdateFailed = "UserUpdateFailed"
-	EventReasonUserCreated      = "UserCreated"
-	EventReasonUserUpdated      = "UserUpdated"
-	EventReasonUserDeleted      = "UserDeleted"
-
-	EventReasonRackCreated              = "RackCreated"
-	EventReasonRackDeleted              = "RackDeleted"
-	EventReasonStatefulSetDeleteFailed  = "STSDeleteFailed"
-	EventReasonRackImageUpdateFailed    = "RackImageUpdateFailed"
-	EventReasonRackRollingRestartFailed = "RackRollingRestartFailed"
-	EventReasonRackDynamicConfigFailed  = "RackDynamicConfigUpdateFailed"
-	EventReasonDynamicConfigUpdate      = "DynamicConfigUpdate"
-	EventReasonDynamicConfigUpdated     = "DynamicConfigUpdated"
-	EventReasonRackScaleDownFailed      = "RackScaleDownFailed"
-	EventReasonRackScaleUpFailed        = "RackScaleUpFailed"
-	EventReasonRackScaleUp              = "RackScaleUp"
-	EventReasonRackScaledUp             = "RackScaledUp"
-	EventReasonPodImageUpdate           = "PodImageUpdate"
-	EventReasonPodImageUpdated          = "PodImageUpdated"
-	EventReasonPodWarmRestarted         = "PodWarmRestarted"
-	EventReasonPodConfUpdated           = "PodConfUpdated"
-	EventReasonPodRestarted             = "PodRestarted"
-	EventReasonPodWaitUpdate            = "PodWaitUpdate"
-	EventReasonRackImageUpdated         = "RackImageUpdated"
-	EventReasonRackScaleDown            = "RackScaleDown"
-	EventReasonPodDeleted               = "PodDeleted"
-	EventReasonRackScaledDown           = "RackScaledDown"
-	EventReasonRackRollingRestart       = "RackRollingRestart"
-	EventReasonRackRollingRestarted     = "RackRollingRestarted"
-	EventReasonWaitMigration            = "WaitMigration"
+	ReasonServiceCreateFailed = "ServiceCreateFailed"
+	ReasonStatusUpdateFailed  = "StatusUpdateFailed"
+	ReasonACLUpdateFailed     = "ACLUpdateFailed"
 )
 
 func eventNamespacedNames(namespace string, names []string) string {

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -78,7 +78,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(
 	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
-			"listing pods for rack %d in cluster %s: %w",
+			"could not list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -244,7 +244,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 
 	podSpecUpdated, err := r.isAnyPodSpecUpdated(ctx, rackState, pod)
 	if err != nil {
-		return restartType, fmt.Errorf("checking whether pod %s spec is updated: %w", utils.GetNamespacedNameString(pod), err)
+		return restartType, fmt.Errorf("could not check whether pod %s spec is up to date: %w", utils.GetNamespacedNameString(pod), err)
 	}
 
 	if podSpecUpdated {
@@ -361,7 +361,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("could not revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -380,7 +380,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("could not set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -520,7 +520,7 @@ func (r *SingleClusterReconciler) restartPods(
 			// We assume that the pod server image supports pod warm restart.
 			if err := r.restartASDOrUpdateAerospikeConf(pod.Name, quickRestart); err != nil {
 				return common.ReconcileError(fmt.Errorf(
-					"warm restart pod %s: %w",
+					"could not warm restart pod %s: %w",
 					utils.NamespacedName(r.aeroCluster.Namespace, pod.Name), err,
 				))
 			}
@@ -534,7 +534,7 @@ func (r *SingleClusterReconciler) restartPods(
 			}
 
 			if err := r.Delete(ctx, pod); err != nil {
-				return common.ReconcileError(fmt.Errorf("delete pod %s: %w", utils.GetNamespacedNameString(pod), err))
+				return common.ReconcileError(fmt.Errorf("could not delete pod %s: %w", utils.GetNamespacedNameString(pod), err))
 			}
 
 			restartedPods = append(restartedPods, pod)
@@ -715,7 +715,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("could not revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -733,7 +733,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("could not set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -1066,7 +1066,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 	if len(danglingPods) > 0 {
 		if err := r.cleanupPods(ctx, danglingPods, rackState); err != nil {
 			return fmt.Errorf(
-				"failed dangling pod cleanup for pods %s in rack %d for cluster %s: %w",
+				"could not complete dangling pod cleanup for pods %s in rack %d for cluster %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, danglingPods), ", "),
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
@@ -1709,7 +1709,7 @@ func isAllDynamicConfig(log logger, specToStatusDiffs asconfig.DynamicConfigMap,
 func getFlatConfig(log logger, confStr string) (*asconfig.Conf, error) {
 	asConf, err := asconfig.NewASConfigFromBytes(log, []byte(confStr), asconfig.AeroConfig)
 	if err != nil {
-		return nil, fmt.Errorf("loading config map by lib: %w", err)
+		return nil, fmt.Errorf("could not parse Aerospike configuration from text with management library: %w", err)
 	}
 
 	return asConf.GetFlatMap(), nil
@@ -1726,12 +1726,12 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfStatus, err := getFlatConfig(log, statusFromAnnotation)
 	if err != nil {
-		return nil, fmt.Errorf("loading config map by lib: %w", err)
+		return nil, fmt.Errorf("could not flatten Aerospike configuration from pod status annotation: %w", err)
 	}
 
 	asConf, err := asconfig.NewMapAsConfig(log, specConfig)
 	if err != nil {
-		return nil, fmt.Errorf("loading config map by lib: %w", err)
+		return nil, fmt.Errorf("could not build Aerospike configuration from spec map with management library: %w", err)
 	}
 
 	// special handling for DNE in ldap configurations
@@ -1741,7 +1741,7 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfSpec, err := getFlatConfig(log, specConfFile)
 	if err != nil {
-		return nil, fmt.Errorf("loading config map by lib: %w", err)
+		return nil, fmt.Errorf("could not normalize Aerospike configuration from spec for diff with management library: %w", err)
 	}
 
 	specToStatusDiffs, err := asconfig.ConfDiff(log, *asConfSpec, *asConfStatus,
@@ -1997,7 +1997,7 @@ func (r *SingleClusterReconciler) getEvictionBlockedPods(ctx context.Context) (s
 	// List all pods in the cluster namespace
 	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return evictionBlockedPods, fmt.Errorf("list pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return evictionBlockedPods, fmt.Errorf("could not list pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	for idx := range pods.Items {

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
@@ -104,7 +105,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(
 
 		if blockedK8sNodes.Has(pods[idx].Spec.NodeName) {
 			r.Log.Info("Pod found in blocked nodes list, will be migrated to a different node",
-				"podName", pods[idx].Name)
+				"pod", klog.KObj(pods[idx]))
 
 			restartTypeMap[pods[idx].Name] = podRestart
 
@@ -313,7 +314,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 
 		r.Log.Info(
 			"DynamicConfigUpdateStatus is PartiallyFailed. Need quick restart",
-			"pod", pod.Name,
+			"pod", klog.KObj(pod),
 		)
 	}
 
@@ -463,20 +464,20 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 				r.KubeConfig,
 			)
 			if err != nil {
-				r.Log.V(1).Info(
-					"Failed warm restart", "err", err, "podName", podNamespacedName.Name, "stdout",
-					stdout, "stderr", stderr,
+				return fmt.Errorf(
+					"pod %s: warm restart via /etc/aerospike/refresh-cmap-restart-asd.sh failed "+
+						"stdout=%q stderr=%q: %w",
+					utils.NamespacedName(podNamespacedName.Namespace, podNamespacedName.Name),
+					stdout, stderr, err,
 				)
-
-				return err
 			}
 		} else {
-			r.Log.V(1).Info(
-				"Failed to perform", "operation", subCommand, "err", err, "podName", podNamespacedName.Name, "stdout",
-				stdout, "stderr", stderr,
+			return fmt.Errorf(
+				"pod %s: %s %s failed: stdout=%q stderr=%q: %w",
+				utils.NamespacedName(podNamespacedName.Namespace, podNamespacedName.Name),
+				initBinary, subCommand,
+				stdout, stderr, err,
 			)
-
-			return err
 		}
 	}
 
@@ -486,14 +487,14 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 			"[rack-%d] Warm restarted Pod %s",
 			rackID, podNamespacedName.String(),
 		)
-		r.Log.V(1).Info("Pod warm restarted", "podName", podNamespacedName.Name)
+		r.Log.V(1).Info("Pod warm restarted", "pod", klog.KRef(podNamespacedName.Namespace, podNamespacedName.Name))
 	} else {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodConfUpdated,
 			"[rack-%d] Updated config for Pod %s",
 			rackID, podNamespacedName.String(),
 		)
-		r.Log.V(1).Info("Pod conf updated", "podName", podNamespacedName.Name)
+		r.Log.V(1).Info("Pod conf updated", "pod", klog.KRef(podNamespacedName.Namespace, podNamespacedName.Name))
 	}
 
 	return nil
@@ -544,7 +545,7 @@ func (r *SingleClusterReconciler) restartPods(
 			restartedPods = append(restartedPods, pod)
 			restartedPodNames = append(restartedPodNames, pod.Name)
 
-			r.Log.V(1).Info("Pod deleted", "podName", pod.Name)
+			r.Log.V(1).Info("Pod deleted", "pod", klog.KObj(pod))
 		case noRestart, noRestartUpdateConf:
 			// No action needed for these restart types
 		}
@@ -564,13 +565,13 @@ func (r *SingleClusterReconciler) restartPods(
 }
 
 func (r *SingleClusterReconciler) updateAerospikeConfInPod(podName string) error {
-	r.Log.Info("Updating aerospike config file in pod", "pod", podName)
+	r.Log.Info("Updating aerospike config file in pod", "pod", klog.KRef(r.aeroCluster.Namespace, podName))
 
 	if err := r.restartASDOrUpdateAerospikeConf(podName, noRestartUpdateConf); err != nil {
 		return err
 	}
 
-	r.Log.V(1).Info("Updated aerospike config file in pod", "podName", podName)
+	r.Log.V(1).Info("Updated aerospike config file in pod", "pod", klog.KRef(r.aeroCluster.Namespace, podName))
 
 	return nil
 }
@@ -594,7 +595,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 			}
 
 			r.Log.V(1).Info(
-				"Waiting for pod to be ready", "podName", pod.Name,
+				"Waiting for pod to be ready", "pod", klog.KObj(pod),
 				"status", pod.Status.Phase, "DeletionTimestamp",
 				pod.DeletionTimestamp,
 			)
@@ -616,7 +617,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 
 			readyPods[pod.Name] = true
 
-			r.Log.Info("Pod is restarted", "podName", updatedPod.Name)
+			r.Log.Info("Pod is restarted", "pod", klog.KObj(updatedPod))
 			r.Recorder.Eventf(
 				r.aeroCluster, corev1.EventTypeNormal, EventReasonPodRestarted,
 				"[rack-%s] Restarted Pod %s",
@@ -779,7 +780,7 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 			return common.ReconcileError(err)
 		}
 
-		r.Log.V(1).Info("Pod deleted", "podName", pod.Name)
+		r.Log.V(1).Info("Pod deleted", "pod", klog.KObj(pod))
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodWaitUpdate,
 			"[rack-%d] Waiting to update Pod %s",
@@ -816,21 +817,21 @@ func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(
 	// Planned restart path — existing logic unchanged.
 	if _, hasEvictionBlocked := pod.Annotations[asdbv1.EvictionBlockedAnnotation]; hasEvictionBlocked {
 		r.Log.Info("Pod has eviction-blocked annotation, deleting corresponding local PVCs if any",
-			"podName", pod.Name)
+			"pod", klog.KObj(pod))
 
 		return true
 	}
 
 	if utils.ContainsString(r.aeroCluster.Spec.K8sNodeBlockList, pod.Spec.NodeName) {
 		r.Log.Info("Pod found in blocked nodes list, deleting corresponding local PVCs if any",
-			"podName", pod.Name)
+			"pod", klog.KObj(pod))
 
 		return true
 	}
 
 	if asdbv1.GetBool(rackState.Rack.Storage.DeleteLocalStorageOnRestart) {
 		r.Log.Info("deleteLocalStorageOnRestart flag is enabled, deleting corresponding local PVCs if any",
-			"podName", pod.Name)
+			"pod", klog.KObj(pod))
 
 		return true
 	}
@@ -859,7 +860,7 @@ func (r *SingleClusterReconciler) ensurePodsImageUpdated(
 			}
 
 			r.Log.V(1).Info(
-				"Waiting for pod to be ready", "podName", pod.Name,
+				"Waiting for pod to be ready", "pod", klog.KObj(pod),
 			)
 
 			updatedPod := &corev1.Pod{}
@@ -880,11 +881,11 @@ func (r *SingleClusterReconciler) ensurePodsImageUpdated(
 
 			updatedPods.Insert(pod.Name)
 
-			r.Log.Info("Pod is upgraded/downgraded", "podName", pod.Name)
+			r.Log.Info("Pod is upgraded/downgraded", "pod", klog.KObj(updatedPod))
 		}
 
 		if len(updatedPods) == len(podsToCheck) {
-			r.Log.Info("Pods are upgraded/downgraded", "pod", podNames)
+			r.Log.Info("Pods are upgraded/downgraded", "pods", podNames)
 			return common.ReconcileSuccess()
 		}
 
@@ -951,7 +952,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 			if !utils.IsPodRunningAndReady(np) {
 				r.Log.Info(
 					"Pod is not running and ready. Skip clearing from tipHostnames.",
-					"pod", np.Name, "host to clear", podNames,
+					"pod", klog.KObj(np), "hostsToRemove", podNames,
 				)
 
 				continue
@@ -980,7 +981,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 			}
 
 			if err := r.alumniReset(ctx, np); err != nil {
-				r.Log.V(2).Info(fmt.Sprintf("Failed to reset alumni for the pod %s", np.Name))
+				r.Log.V(2).Info("Failed to reset alumni for pod", "pod", klog.KObj(np))
 			}
 		}
 
@@ -1260,7 +1261,7 @@ func (r *SingleClusterReconciler) isAnyPodInImageFailedState(podList []*corev1.P
 		// If node was crashed due to wrong config then only rollingRestart can bring it back.
 		if err := utils.CheckPodImageFailed(pod); err != nil {
 			r.Log.Info(
-				"AerospikeCluster Pod is in failed state", "podName", pod.Name, "err", err,
+				"AerospikeCluster Pod is in failed state", "pod", klog.KObj(pod), "err", err,
 			)
 
 			return true
@@ -1673,8 +1674,8 @@ func (r *SingleClusterReconciler) deleteFileStorage(podName, fileName string) er
 		cmd, r.KubeClient, r.KubeConfig)
 	if err != nil {
 		r.Log.V(1).Info(
-			"File deletion failed", "err", err, "podName", podName, "stdout",
-			stdout, "stderr", stderr,
+			"File deletion failed", "pod", klog.KRef(r.aeroCluster.Namespace, podName),
+			"stdout", stdout, "stderr", stderr,
 		)
 
 		return fmt.Errorf("error deleting file %w", err)
@@ -2116,7 +2117,7 @@ func (r *SingleClusterReconciler) checkForPortsUpdate(sts *appsv1.StatefulSet, p
 			(desiredPort.HostPort != 0 && currentPort.HostPort == 0) {
 			r.Log.Info(
 				"Pod spec is updated, container port changed",
-				"podName", pod.Name, "desiredPort", desiredPort, "currentPort", currentPort,
+				"pod", klog.KObj(pod), "desiredPort", desiredPort, "currentPort", currentPort,
 			)
 
 			return true, nil

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -471,14 +471,16 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 
 	if subCommand == "quick-restart" {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, "PodWarmRestarted",
-			"[rack-%d] Restarted Pod %s", rackID, podNamespacedName.Name,
+			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodWarmRestarted,
+			"[rack-%d] Warm restarted Pod %s",
+			rackID, podNamespacedName.String(),
 		)
 		r.Log.V(1).Info("Pod warm restarted", "podName", podNamespacedName.Name)
 	} else {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, "PodConfUpdated",
-			"[rack-%d] Updated Pod %s", rackID, podNamespacedName.Name,
+			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodConfUpdated,
+			"[rack-%d] Updated config for Pod %s",
+			rackID, podNamespacedName.String(),
 		)
 		r.Log.V(1).Info("Pod conf updated", "podName", podNamespacedName.Name)
 	}
@@ -602,8 +604,9 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 
 			r.Log.Info("Pod is restarted", "podName", updatedPod.Name)
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeNormal, "PodRestarted",
-				"[rack-%s] Restarted Pod %s", pod.Labels[asdbv1.AerospikeRackIDLabel], pod.Name,
+				r.aeroCluster, corev1.EventTypeNormal, EventReasonPodRestarted,
+				"[rack-%s] Restarted Pod %s",
+				pod.Labels[asdbv1.AerospikeRackIDLabel], utils.GetNamespacedNameString(pod),
 			)
 		}
 
@@ -756,8 +759,9 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 
 		r.Log.V(1).Info("Pod deleted", "podName", pod.Name)
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, "PodWaitUpdate",
-			"[rack-%d] Waiting to update Pod %s", rackState.Rack.ID, pod.Name,
+			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodWaitUpdate,
+			"[rack-%d] Waiting to update Pod %s",
+			rackState.Rack.ID, utils.GetNamespacedNameString(pod),
 		)
 	}
 

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -360,6 +360,10 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 			if res := r.setMigrateFillDelay(ctx, clientPolicy, &rackState.Rack.AerospikeConfig, false,
 				ignorablePodNames,
 			); !res.IsSuccess {
+				if res.Err != nil {
+					res.Err = fmt.Errorf("revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+				}
+
 				return res
 			}
 		}
@@ -375,6 +379,10 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 			if res := r.setMigrateFillDelay(ctx, clientPolicy, &rackState.Rack.AerospikeConfig, true,
 				ignorablePodNames,
 			); !res.IsSuccess {
+				if res.Err != nil {
+					res.Err = fmt.Errorf("set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+				}
+
 				return res
 			}
 		}
@@ -511,7 +519,10 @@ func (r *SingleClusterReconciler) restartPods(
 		case quickRestart:
 			// We assume that the pod server image supports pod warm restart.
 			if err := r.restartASDOrUpdateAerospikeConf(pod.Name, quickRestart); err != nil {
-				return common.ReconcileError(err)
+				return common.ReconcileError(fmt.Errorf(
+					"warm restart pod %s: %w",
+					utils.NamespacedName(r.aeroCluster.Namespace, pod.Name), err,
+				))
 			}
 
 			restartedASDPodNames = append(restartedASDPodNames, pod.Name)
@@ -523,7 +534,7 @@ func (r *SingleClusterReconciler) restartPods(
 			}
 
 			if err := r.Delete(ctx, pod); err != nil {
-				return common.ReconcileError(err)
+				return common.ReconcileError(fmt.Errorf("delete pod %s: %w", utils.GetNamespacedNameString(pod), err))
 			}
 
 			restartedPods = append(restartedPods, pod)
@@ -703,6 +714,10 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 			if res := r.setMigrateFillDelay(ctx, clientPolicy, &rackState.Rack.AerospikeConfig, false,
 				ignorablePodNames,
 			); !res.IsSuccess {
+				if res.Err != nil {
+					res.Err = fmt.Errorf("revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+				}
+
 				return res
 			}
 		}
@@ -717,6 +732,10 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 			if res := r.setMigrateFillDelay(ctx, clientPolicy, &rackState.Rack.AerospikeConfig, true,
 				ignorablePodNames,
 			); !res.IsSuccess {
+				if res.Err != nil {
+					res.Err = fmt.Errorf("set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+				}
+
 				return res
 			}
 		}
@@ -1967,7 +1986,7 @@ func (r *SingleClusterReconciler) getEvictionBlockedPods(ctx context.Context) (s
 	// List all pods in the cluster namespace
 	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return evictionBlockedPods, err
+		return evictionBlockedPods, fmt.Errorf("list pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	for idx := range pods.Items {

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -421,7 +421,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 
 	switch operation {
 	case noRestart, podRestart:
-		return fmt.Errorf("invalid akoinit operation %d", operation)
+		return fmt.Errorf("invalid operation for akoinit")
 	case quickRestart:
 		subCommand = "quick-restart"
 	case noRestartUpdateConf:
@@ -909,12 +909,18 @@ func (r *SingleClusterReconciler) cleanupPods(
 	// Delete PVCs if cascadeDelete
 	pvcItems, err := r.getPodsPVCList(ctx, podNames, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return fmt.Errorf("listing pvcs for pods %s: %w", strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err)
+		return fmt.Errorf(
+			"could not find pvc for pods %s: %w",
+			strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
+		)
 	}
 
 	storage := rackState.Rack.Storage
 	if err = r.removePVCs(ctx, &storage, pvcItems); err != nil {
-		return fmt.Errorf("removing pvcs for pods %s: %w", strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err)
+		return fmt.Errorf(
+			"could not cleanup pvcs for pods %s: %w",
+			strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
+		)
 	}
 
 	return r.cleanupPodMeshAndStatus(ctx, podNames)
@@ -929,7 +935,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 
 	clusterPodList, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return fmt.Errorf("listing pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("could not get pod list for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	podNameSet := sets.NewString(podNames...)
@@ -994,7 +1000,10 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 		r.Log.Info("Removing pod status for dangling pods", "pods", podNames)
 
 		if err := r.removePodStatus(ctx, needStatusCleanup); err != nil {
-			return fmt.Errorf("removing pod status for pods %s: %w", strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, needStatusCleanup), ", "), err)
+			return fmt.Errorf(
+				"could not cleanup pod status for pods %s: %w",
+				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, needStatusCleanup), ", "), err,
+			)
 		}
 	}
 
@@ -1044,7 +1053,9 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 
 		ordinal, err := getSTSPodOrdinal(podName)
 		if err != nil {
-			return fmt.Errorf("parsing ordinal from pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err)
+			return fmt.Errorf(
+				"invalid pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
+			)
 		}
 
 		if *ordinal >= *sts.Spec.Replicas {
@@ -1055,7 +1066,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 	if len(danglingPods) > 0 {
 		if err := r.cleanupPods(ctx, danglingPods, rackState); err != nil {
 			return fmt.Errorf(
-				"cleaning up dangling pods %s for rack %d in cluster %s: %w",
+				"failed dangling pod cleanup for pods %s in rack %d for cluster %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, danglingPods), ", "),
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
@@ -1662,7 +1673,7 @@ func (r *SingleClusterReconciler) deleteFileStorage(podName, fileName string) er
 			stdout, "stderr", stderr,
 		)
 
-		return fmt.Errorf("deleting file %s on pod %s: %w", fileName, utils.NamespacedName(r.aeroCluster.Namespace, podName), err)
+		return fmt.Errorf("error deleting file %w", err)
 	}
 
 	return nil
@@ -1698,7 +1709,7 @@ func isAllDynamicConfig(log logger, specToStatusDiffs asconfig.DynamicConfigMap,
 func getFlatConfig(log logger, confStr string) (*asconfig.Conf, error) {
 	asConf, err := asconfig.NewASConfigFromBytes(log, []byte(confStr), asconfig.AeroConfig)
 	if err != nil {
-		return nil, fmt.Errorf("parsing aerospike config: %w", err)
+		return nil, fmt.Errorf("loading config map by lib: %w", err)
 	}
 
 	return asConf.GetFlatMap(), nil
@@ -1715,12 +1726,12 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfStatus, err := getFlatConfig(log, statusFromAnnotation)
 	if err != nil {
-		return nil, fmt.Errorf("parsing status aerospike config: %w", err)
+		return nil, fmt.Errorf("loading config map by lib: %w", err)
 	}
 
 	asConf, err := asconfig.NewMapAsConfig(log, specConfig)
 	if err != nil {
-		return nil, fmt.Errorf("loading spec aerospike config: %w", err)
+		return nil, fmt.Errorf("loading config map by lib: %w", err)
 	}
 
 	// special handling for DNE in ldap configurations
@@ -1730,7 +1741,7 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfSpec, err := getFlatConfig(log, specConfFile)
 	if err != nil {
-		return nil, fmt.Errorf("parsing spec aerospike config: %w", err)
+		return nil, fmt.Errorf("loading config map by lib: %w", err)
 	}
 
 	specToStatusDiffs, err := asconfig.ConfDiff(log, *asConfSpec, *asConfStatus,
@@ -1772,7 +1783,7 @@ func (r *SingleClusterReconciler) patchPodStatus(ctx context.Context, patches []
 		if err := r.Client.Status().Patch(
 			ctx, patchedAerospikeCluster, constantPatch, client.FieldOwner("pod"),
 		); err != nil {
-			return fmt.Errorf("patching pod status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+			return fmt.Errorf("error updating status: %w", err)
 		}
 
 		r.Log.Info("Pod status patched successfully")
@@ -1893,7 +1904,7 @@ func (r *SingleClusterReconciler) updateOperationStatus(
 	newAeroCluster.Status.Operations = statusOps
 
 	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
-		return fmt.Errorf("updating operation status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error updating status: %w", err)
 	}
 
 	return nil
@@ -2071,9 +2082,9 @@ func (r *SingleClusterReconciler) checkForPortsUpdate(sts *appsv1.StatefulSet, p
 
 	if serverContainer == nil || stsServerContainer == nil {
 		return false, fmt.Errorf(
-		"server container not found in pod %s or statefulset %s",
-		utils.GetNamespacedNameString(pod), utils.GetNamespacedNameString(sts),
-	)
+			"server container not found in pod %s or statefulset %s",
+			utils.GetNamespacedNameString(pod), utils.GetNamespacedNameString(sts),
+		)
 	}
 
 	desiredContainerPortsMap := make(map[string]corev1.ContainerPort, len(stsServerContainer.Ports))

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -79,7 +79,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(
 	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
-			"could not list pods for rack %d in cluster %s: %w",
+			"list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -364,7 +364,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 			); !res.IsSuccess {
 				if res.Err != nil {
 					res.Err = fmt.Errorf(
-						"could not revert migrate-fill-delay for rack %d before restarting the running pods: %w",
+						"revert migrate-fill-delay for rack %d before restarting running pods: %w",
 						rackState.Rack.ID, res.Err,
 					)
 				}
@@ -410,7 +410,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 	rackID, rackRevision, err := utils.GetRackIDAndRevisionFromPodName(r.aeroCluster.Name, podName)
 	if err != nil {
 		return fmt.Errorf(
-			"unable to get rackID for the pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
+			"get rack ID for pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 		)
 	}
 
@@ -525,7 +525,7 @@ func (r *SingleClusterReconciler) restartPods(
 			// We assume that the pod server image supports pod warm restart.
 			if err := r.restartASDOrUpdateAerospikeConf(pod.Name, quickRestart); err != nil {
 				return common.ReconcileError(fmt.Errorf(
-					"could not warm restart pod %s: %w",
+					"warm restart pod %s: %w",
 					utils.NamespacedName(r.aeroCluster.Namespace, pod.Name), err,
 				))
 			}
@@ -915,7 +915,7 @@ func (r *SingleClusterReconciler) cleanupPods(
 	pvcItems, err := r.getPodsPVCList(ctx, podNames, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return fmt.Errorf(
-			"could not find pvc for pods %s: %w",
+			"find PVCs for pods %s: %w",
 			strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
 		)
 	}
@@ -923,7 +923,7 @@ func (r *SingleClusterReconciler) cleanupPods(
 	storage := rackState.Rack.Storage
 	if err = r.removePVCs(ctx, &storage, pvcItems); err != nil {
 		return fmt.Errorf(
-			"could not cleanup pvcs for pods %s: %w",
+			"clean up PVCs for pods %s: %w",
 			strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
 		)
 	}
@@ -1006,7 +1006,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 
 		if err := r.removePodStatus(ctx, needStatusCleanup); err != nil {
 			return fmt.Errorf(
-				"could not cleanup pod status for pods %s: %w",
+				"clean up pod status for pods %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, needStatusCleanup), ", "), err,
 			)
 		}
@@ -1047,7 +1047,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 		rackID, rackRevision, err := utils.GetRackIDAndRevisionFromPodName(r.aeroCluster.Name, podName)
 		if err != nil {
 			return fmt.Errorf(
-				"unable to get rackID for the pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
+				"get rack ID for pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 			)
 		}
 
@@ -1071,7 +1071,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 	if len(danglingPods) > 0 {
 		if err := r.cleanupPods(ctx, danglingPods, rackState); err != nil {
 			return fmt.Errorf(
-				"could not complete dangling pod cleanup for pods %s in rack %d for cluster %s: %w",
+				"clean up dangling pods %s in rack %d for cluster %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, danglingPods), ", "),
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
@@ -1649,7 +1649,7 @@ func (r *SingleClusterReconciler) deleteFileStorage(podName, fileName string) er
 			"stdout", stdout, "stderr", stderr,
 		)
 
-		return fmt.Errorf("error deleting file %w", err)
+		return fmt.Errorf("delete file: %w", err)
 	}
 
 	return nil
@@ -1759,7 +1759,7 @@ func (r *SingleClusterReconciler) patchPodStatus(ctx context.Context, patches []
 		if err := r.Client.Status().Patch(
 			ctx, patchedAerospikeCluster, constantPatch, client.FieldOwner("pod"),
 		); err != nil {
-			return fmt.Errorf("error updating status: %w", err)
+			return fmt.Errorf("update status: %w", err)
 		}
 
 		r.Log.Info("Pod status patched successfully")
@@ -1880,7 +1880,7 @@ func (r *SingleClusterReconciler) updateOperationStatus(
 	newAeroCluster.Status.Operations = statusOps
 
 	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
-		return fmt.Errorf("error updating status: %w", err)
+		return fmt.Errorf("update status: %w", err)
 	}
 
 	return nil

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -245,7 +245,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 
 	podSpecUpdated, err := r.isAnyPodSpecUpdated(ctx, rackState, pod)
 	if err != nil {
-		return restartType, fmt.Errorf("could not check whether pod %s spec is updated: %w",
+		return restartType, fmt.Errorf("check pod %s spec update state: %w",
 			utils.GetNamespacedNameString(pod), err)
 	}
 
@@ -385,7 +385,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("could not set migrate-fill-delay to `0` for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("set migrate-fill-delay to `0` for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -539,7 +539,7 @@ func (r *SingleClusterReconciler) restartPods(
 			}
 
 			if err := r.Delete(ctx, pod); err != nil {
-				return common.ReconcileError(fmt.Errorf("could not delete pod %s: %w", utils.GetNamespacedNameString(pod), err))
+				return common.ReconcileError(fmt.Errorf("delete pod %s: %w", utils.GetNamespacedNameString(pod), err))
 			}
 
 			restartedPods = append(restartedPods, pod)
@@ -720,7 +720,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("could not revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -738,7 +738,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("could not set migrate-fill-delay to `0` for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("set migrate-fill-delay to `0` for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -940,7 +940,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 
 	clusterPodList, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return fmt.Errorf("could not cleanup pod PVCs %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("clean up pod PVCs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	podNameSet := sets.NewString(podNames...)
@@ -1714,7 +1714,7 @@ func isAllDynamicConfig(log logger, specToStatusDiffs asconfig.DynamicConfigMap,
 func getFlatConfig(log logger, confStr string) (*asconfig.Conf, error) {
 	asConf, err := asconfig.NewASConfigFromBytes(log, []byte(confStr), asconfig.AeroConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to load config map by lib: %w", err)
+		return nil, fmt.Errorf("load ConfigMap via management lib: %w", err)
 	}
 
 	return asConf.GetFlatMap(), nil
@@ -1731,12 +1731,12 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfStatus, err := getFlatConfig(log, statusFromAnnotation)
 	if err != nil {
-		return nil, fmt.Errorf("unable to load config map by lib: %w", err)
+		return nil, fmt.Errorf("load ConfigMap via management lib: %w", err)
 	}
 
 	asConf, err := asconfig.NewMapAsConfig(log, specConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to load config map by lib: %w", err)
+		return nil, fmt.Errorf("load ConfigMap via management lib: %w", err)
 	}
 
 	// special handling for DNE in ldap configurations
@@ -1746,7 +1746,7 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfSpec, err := getFlatConfig(log, specConfFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to load config map by lib: %w", err)
+		return nil, fmt.Errorf("load ConfigMap via management lib: %w", err)
 	}
 
 	specToStatusDiffs, err := asconfig.ConfDiff(log, *asConfSpec, *asConfStatus,
@@ -2002,7 +2002,7 @@ func (r *SingleClusterReconciler) getEvictionBlockedPods(ctx context.Context) (s
 	// List all pods in the cluster namespace
 	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return evictionBlockedPods, fmt.Errorf("could not list pods for cluster %s: %w",
+		return evictionBlockedPods, fmt.Errorf("list pods for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -67,19 +68,23 @@ func mergeRestartType(current, incoming RestartType) RestartType {
 }
 
 // Fetching RestartType of all pods, based on the operation being performed.
-func (r *SingleClusterReconciler) getRollingRestartTypeMap(rackState *RackState, ignorablePodNames sets.Set[string]) (
+func (r *SingleClusterReconciler) getRollingRestartTypeMap(
+	ctx context.Context, rackState *RackState, ignorablePodNames sets.Set[string]) (
 	restartTypeMap map[string]RestartType, dynamicConfDiffPerPod map[string]asconfig.DynamicConfigMap, err error) {
 	var addedNSDevices []string
 
 	restartTypeMap = make(map[string]RestartType)
 	dynamicConfDiffPerPod = make(map[string]asconfig.DynamicConfigMap)
 
-	pods, err := r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to list pods: %v", err)
+		return nil, nil, fmt.Errorf(
+			"listing pods for rack %d in cluster %s: %w",
+			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
-	confMap, err := r.getConfigMap(utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
+	confMap, err := r.getConfigMap(ctx, utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,7 +93,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(rackState *RackState,
 	requiredConfHash := confMap.Data[aerospikeConfHashFileName]
 
 	// Fetching all pods requested for on-demand operations.
-	onDemandQuickRestarts, onDemandPodRestarts, err := r.podsToRestart()
+	onDemandQuickRestarts, onDemandPodRestarts, err := r.podsToRestart(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -158,14 +163,14 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(rackState *RackState,
 
 			if addedNSDevices == nil {
 				// Fetching all block devices that have been added in namespaces.
-				addedNSDevices, err = r.getNSAddedDevices(rackState)
+				addedNSDevices, err = r.getNSAddedDevices(ctx, rackState)
 				if err != nil {
 					return nil, nil, err
 				}
 			}
 		}
 
-		restartType, err := r.getRollingRestartTypePod(rackState, pods[idx], confMap, addedNSDevices,
+		restartType, err := r.getRollingRestartTypePod(ctx, rackState, pods[idx], confMap, addedNSDevices,
 			len(dynamicConfDiffPerPod[pods[idx].Name]) > 0, onDemandQuickRestarts, onDemandPodRestarts)
 		if err != nil {
 			return nil, nil, err
@@ -178,7 +183,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(rackState *RackState,
 }
 
 func (r *SingleClusterReconciler) getRollingRestartTypePod(
-	rackState *RackState, pod *corev1.Pod, confMap *corev1.ConfigMap,
+	ctx context.Context, rackState *RackState, pod *corev1.Pod, confMap *corev1.ConfigMap,
 	addedNSDevices []string, onlyDynamicConfigChange bool,
 	onDemandQuickRestarts, onDemandPodRestarts sets.Set[string],
 ) (RestartType, error) {
@@ -238,9 +243,9 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 		)
 	}
 
-	podSpecUpdated, err := r.isAnyPodSpecUpdated(rackState, pod)
+	podSpecUpdated, err := r.isAnyPodSpecUpdated(ctx, rackState, pod)
 	if err != nil {
-		return restartType, fmt.Errorf("failed to check if pod spec is updated: %v", err)
+		return restartType, fmt.Errorf("checking whether pod %s spec is updated: %w", utils.GetNamespacedNameString(pod), err)
 	}
 
 	if podSpecUpdated {
@@ -316,6 +321,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 }
 
 func (r *SingleClusterReconciler) rollingRestartPods(
+	ctx context.Context,
 	rackState *RackState, podsToRestart []*corev1.Pod, ignorablePodNames sets.Set[string],
 	restartTypeMap map[string]RestartType,
 ) common.ReconcileResult {
@@ -327,7 +333,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 	if len(failedPods) != 0 {
 		r.Log.Info("Restart failed pods", "pods", getPodNames(failedPods))
 
-		if res := r.restartPods(rackState, failedPods, restartTypeMap, true); !res.IsSuccess {
+		if res := r.restartPods(ctx, rackState, failedPods, restartTypeMap, true); !res.IsSuccess {
 			return res
 		}
 	}
@@ -335,7 +341,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 	if len(activePods) != 0 {
 		r.Log.Info("Restart active pods", "pods", getPodNames(activePods))
 
-		if res := r.waitForMultipleNodesSafeStopReady(activePods, ignorablePodNames); !res.IsSuccess {
+		if res := r.waitForMultipleNodesSafeStopReady(ctx, activePods, ignorablePodNames); !res.IsSuccess {
 			return res
 		}
 
@@ -350,30 +356,26 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 		// Revert migrate-fill-delay to the original value before restarting active pods.
 		// This will be a no-op in the first reconcile
 		if setMigrateFillDelay {
-			clientPolicy = r.getClientPolicy()
+			clientPolicy = r.getClientPolicy(ctx)
 
-			if res := r.setMigrateFillDelay(clientPolicy, &rackState.Rack.AerospikeConfig, false,
+			if res := r.setMigrateFillDelay(ctx, clientPolicy, &rackState.Rack.AerospikeConfig, false,
 				ignorablePodNames,
 			); !res.IsSuccess {
-				r.Log.Error(res.Err,
-					"Failed to set migrate-fill-delay to original value before restarting the running pods")
-
 				return res
 			}
 		}
 
 		// Active pods are healthy — any restart of them is a planned operation.
-		if res := r.restartPods(rackState, activePods, restartTypeMap, false); !res.IsSuccess {
+		if res := r.restartPods(ctx, rackState, activePods, restartTypeMap, false); !res.IsSuccess {
 			return res
 		}
 
 		// Set migrate-fill-delay O to immediately start the migration. Will be reverted back to the original value
 		// in the next reconcile.
 		if setMigrateFillDelay {
-			if res := r.setMigrateFillDelay(clientPolicy, &rackState.Rack.AerospikeConfig, true,
+			if res := r.setMigrateFillDelay(ctx, clientPolicy, &rackState.Rack.AerospikeConfig, true,
 				ignorablePodNames,
 			); !res.IsSuccess {
-				r.Log.Error(res.Err, "Failed to set migrate-fill-delay to `0` after restarting the running pods")
 				return res
 			}
 		}
@@ -396,7 +398,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 	rackID, rackRevision, err := utils.GetRackIDAndRevisionFromPodName(r.aeroCluster.Name, podName)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to get rackID for the pod %s", podName,
+			"parsing rackID from pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 		)
 	}
 
@@ -412,7 +414,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 
 	switch operation {
 	case noRestart, podRestart:
-		return fmt.Errorf("invalid operation for akoinit")
+		return reconcile.TerminalError(fmt.Errorf("invalid operation %d for akoinit", operation))
 	case quickRestart:
 		subCommand = "quick-restart"
 	case noRestartUpdateConf:
@@ -485,12 +487,13 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 }
 
 func (r *SingleClusterReconciler) restartPods(
+	ctx context.Context,
 	rackState *RackState, podsToRestart []*corev1.Pod, restartTypeMap map[string]RestartType,
 	isFailureRecovery bool,
 ) common.ReconcileResult {
 	// For each block volume removed from a namespace, pod status dirtyVolumes is appended with that volume name.
 	// For each file removed from a namespace, it is deleted right away.
-	if err := r.handleNSOrDeviceRemoval(rackState, podsToRestart); err != nil {
+	if err := r.handleNSOrDeviceRemoval(ctx, rackState, podsToRestart); err != nil {
 		return common.ReconcileError(err)
 	}
 
@@ -507,20 +510,18 @@ func (r *SingleClusterReconciler) restartPods(
 		case quickRestart:
 			// We assume that the pod server image supports pod warm restart.
 			if err := r.restartASDOrUpdateAerospikeConf(pod.Name, quickRestart); err != nil {
-				r.Log.Error(err, "Failed to warm restart pod", "podName", pod.Name)
 				return common.ReconcileError(err)
 			}
 
 			restartedASDPodNames = append(restartedASDPodNames, pod.Name)
 		case podRestart:
 			if r.isLocalPVCDeletionRequired(rackState, pod, isFailureRecovery) {
-				if err := r.deleteLocalPVCs(rackState, pod); err != nil {
+				if err := r.deleteLocalPVCs(ctx, rackState, pod); err != nil {
 					return common.ReconcileError(err)
 				}
 			}
 
-			if err := r.Delete(context.TODO(), pod); err != nil {
-				r.Log.Error(err, "Failed to delete pod")
+			if err := r.Delete(ctx, pod); err != nil {
 				return common.ReconcileError(err)
 			}
 
@@ -533,12 +534,12 @@ func (r *SingleClusterReconciler) restartPods(
 		}
 	}
 
-	if err := r.updateOperationStatus(restartedASDPodNames, restartedPodNames); err != nil {
+	if err := r.updateOperationStatus(ctx, restartedASDPodNames, restartedPodNames); err != nil {
 		return common.ReconcileError(err)
 	}
 
 	if len(restartedPods) > 0 {
-		if result := r.ensurePodsRunningAndReady(restartedPods); !result.IsSuccess {
+		if result := r.ensurePodsRunningAndReady(ctx, restartedPods); !result.IsSuccess {
 			return result
 		}
 	}
@@ -558,7 +559,8 @@ func (r *SingleClusterReconciler) updateAerospikeConfInPod(podName string) error
 	return nil
 }
 
-func (r *SingleClusterReconciler) ensurePodsRunningAndReady(podsToCheck []*corev1.Pod) common.ReconcileResult {
+func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
+	ctx context.Context, podsToCheck []*corev1.Pod) common.ReconcileResult {
 	podNames := getPodNames(podsToCheck)
 	readyPods := map[string]bool{}
 
@@ -584,7 +586,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(podsToCheck []*corev
 			updatedPod := &corev1.Pod{}
 			podName := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 
-			if err := r.Get(context.TODO(), podName, updatedPod); err != nil {
+			if err := r.Get(ctx, podName, updatedPod); err != nil {
 				return common.ReconcileError(err)
 			}
 
@@ -663,6 +665,7 @@ func getNonIgnorablePods(pods []*corev1.Pod, ignorablePodNames sets.Set[string],
 }
 
 func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
+	ctx context.Context,
 	rackState *RackState, podsToUpdate []*corev1.Pod, ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
 	failedPods, failedWithinGracePeriodPods, activePods := getFailedAndActivePods(podsToUpdate, true)
@@ -671,7 +674,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 	if len(failedPods) != 0 {
 		r.Log.Info("Restart failed pods with updated container image", "pods", getPodNames(failedPods))
 
-		if res := r.deletePodAndEnsureImageUpdated(rackState, failedPods, true); !res.IsSuccess {
+		if res := r.deletePodAndEnsureImageUpdated(ctx, rackState, failedPods, true); !res.IsSuccess {
 			return res
 		}
 	}
@@ -679,7 +682,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 	if len(activePods) != 0 {
 		r.Log.Info("Restart active pods with updated container image", "pods", getPodNames(activePods))
 
-		if res := r.waitForMultipleNodesSafeStopReady(activePods, ignorablePodNames); !res.IsSuccess {
+		if res := r.waitForMultipleNodesSafeStopReady(ctx, activePods, ignorablePodNames); !res.IsSuccess {
 			return res
 		}
 
@@ -693,29 +696,25 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 		// Revert migrate-fill-delay to the original value before restarting active pods.
 		// This will be a no-op in the first reconcile
 		if setMigrateFillDelay {
-			clientPolicy = r.getClientPolicy()
+			clientPolicy = r.getClientPolicy(ctx)
 
-			if res := r.setMigrateFillDelay(clientPolicy, &rackState.Rack.AerospikeConfig, false,
+			if res := r.setMigrateFillDelay(ctx, clientPolicy, &rackState.Rack.AerospikeConfig, false,
 				ignorablePodNames,
 			); !res.IsSuccess {
-				r.Log.Error(res.Err,
-					"Failed to set migrate-fill-delay to original value before upgrading the running pods")
-
 				return res
 			}
 		}
 
-		if res := r.deletePodAndEnsureImageUpdated(rackState, activePods, false); !res.IsSuccess {
+		if res := r.deletePodAndEnsureImageUpdated(ctx, rackState, activePods, false); !res.IsSuccess {
 			return res
 		}
 
 		// Set migrate-fill-delay O to immediately start the migration. Will be reverted back to the original value
 		// in the next reconcile.
 		if setMigrateFillDelay {
-			if res := r.setMigrateFillDelay(clientPolicy, &rackState.Rack.AerospikeConfig, true,
+			if res := r.setMigrateFillDelay(ctx, clientPolicy, &rackState.Rack.AerospikeConfig, true,
 				ignorablePodNames,
 			); !res.IsSuccess {
-				r.Log.Error(res.Err, "Failed to set migrate-fill-delay to `0` after upgrading the running pods")
 				return res
 			}
 		}
@@ -734,23 +733,24 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 }
 
 func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
+	ctx context.Context,
 	rackState *RackState, podsToUpdate []*corev1.Pod, isFailureRecovery bool,
 ) common.ReconcileResult {
 	// For each block volume removed from a namespace, pod status dirtyVolumes is appended with that volume name.
 	// For each file removed from a namespace, it is deleted right away.
-	if err := r.handleNSOrDeviceRemoval(rackState, podsToUpdate); err != nil {
+	if err := r.handleNSOrDeviceRemoval(ctx, rackState, podsToUpdate); err != nil {
 		return common.ReconcileError(err)
 	}
 
 	// Delete pods
 	for _, pod := range podsToUpdate {
 		if r.isLocalPVCDeletionRequired(rackState, pod, isFailureRecovery) {
-			if err := r.deleteLocalPVCs(rackState, pod); err != nil {
+			if err := r.deleteLocalPVCs(ctx, rackState, pod); err != nil {
 				return common.ReconcileError(err)
 			}
 		}
 
-		if err := r.Delete(context.TODO(), pod); err != nil {
+		if err := r.Delete(ctx, pod); err != nil {
 			return common.ReconcileError(err)
 		}
 
@@ -761,7 +761,7 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 		)
 	}
 
-	return r.ensurePodsImageUpdated(podsToUpdate)
+	return r.ensurePodsImageUpdated(ctx, podsToUpdate)
 }
 
 func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(
@@ -812,7 +812,8 @@ func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(
 	return false
 }
 
-func (r *SingleClusterReconciler) ensurePodsImageUpdated(podsToCheck []*corev1.Pod) common.ReconcileResult {
+func (r *SingleClusterReconciler) ensurePodsImageUpdated(
+	ctx context.Context, podsToCheck []*corev1.Pod) common.ReconcileResult {
 	podNames := getPodNames(podsToCheck)
 	updatedPods := sets.Set[string]{}
 
@@ -838,7 +839,7 @@ func (r *SingleClusterReconciler) ensurePodsImageUpdated(podsToCheck []*corev1.P
 			updatedPod := &corev1.Pod{}
 			podName := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 
-			if err := r.Get(context.TODO(), podName, updatedPod); err != nil {
+			if err := r.Get(ctx, podName, updatedPod); err != nil {
 				return common.ReconcileError(err)
 			}
 
@@ -875,7 +876,7 @@ func (r *SingleClusterReconciler) ensurePodsImageUpdated(podsToCheck []*corev1.P
 // cleanupPods checks pods and status before scale-up to detect and fix any
 // status anomalies.
 func (r *SingleClusterReconciler) cleanupPods(
-	podNames []string, rackState *RackState,
+	ctx context.Context, podNames []string, rackState *RackState,
 ) error {
 	if len(podNames) == 0 {
 		return nil
@@ -884,29 +885,29 @@ func (r *SingleClusterReconciler) cleanupPods(
 	r.Log.Info("Removing pvc for removed pods", "pods", podNames)
 
 	// Delete PVCs if cascadeDelete
-	pvcItems, err := r.getPodsPVCList(podNames, rackState.Rack.ID, rackState.Rack.Revision)
+	pvcItems, err := r.getPodsPVCList(ctx, podNames, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return fmt.Errorf("could not find pvc for pods %v: %v", podNames, err)
+		return fmt.Errorf("listing pvcs for pods %s: %w", strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err)
 	}
 
 	storage := rackState.Rack.Storage
-	if err = r.removePVCs(&storage, pvcItems); err != nil {
-		return fmt.Errorf("could not cleanup pod PVCs: %v", err)
+	if err = r.removePVCs(ctx, &storage, pvcItems); err != nil {
+		return fmt.Errorf("removing pvcs for pods %s: %w", strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err)
 	}
 
-	return r.cleanupPodMeshAndStatus(podNames)
+	return r.cleanupPodMeshAndStatus(ctx, podNames)
 }
 
 // cleanupPodMeshAndStatus clears mesh references (tip-hostnames, alumni) on
 // peer pods, removes per-pod services (MultiPodPerHost), and purges pod status
 // entries. It does not touch PVCs — callers that need PVC cleanup should handle
 // that separately.
-func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(podNames []string) error {
+func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, podNames []string) error {
 	var needStatusCleanup []string
 
-	clusterPodList, err := r.getClusterPodList()
+	clusterPodList, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("listing pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	podNameSet := sets.NewString(podNames...)
@@ -942,11 +943,11 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(podNames []string) err
 				"pod to remove", podName, "remove and reset on pod", np.Name,
 			)
 
-			if err := r.tipClearHostname(np, podName); err != nil {
+			if err := r.tipClearHostname(ctx, np, podName); err != nil {
 				r.Log.V(2).Info("Failed to tipClear", "hostName", podName, "from the pod", np.Name)
 			}
 
-			if err := r.alumniReset(np); err != nil {
+			if err := r.alumniReset(ctx, np); err != nil {
 				r.Log.V(2).Info(fmt.Sprintf("Failed to reset alumni for the pod %s", np.Name))
 			}
 		}
@@ -956,7 +957,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(podNames []string) err
 			// Remove service for pod
 			// TODO: make it more robust, what if it fails
 			if err := r.deletePodService(
-				podName, r.aeroCluster.Namespace,
+				ctx, podName, r.aeroCluster.Namespace,
 			); err != nil {
 				return err
 			}
@@ -970,8 +971,8 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(podNames []string) err
 	if len(needStatusCleanup) > 0 {
 		r.Log.Info("Removing pod status for dangling pods", "pods", podNames)
 
-		if err := r.removePodStatus(needStatusCleanup); err != nil {
-			return fmt.Errorf("could not cleanup pod status: %v", err)
+		if err := r.removePodStatus(ctx, needStatusCleanup); err != nil {
+			return fmt.Errorf("removing pod status for pods %s: %w", strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, needStatusCleanup), ", "), err)
 		}
 	}
 
@@ -980,7 +981,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(podNames []string) err
 
 // removePodStatus removes podNames from the cluster's pod status.
 // Assumes the pods are not running so that the no concurrent update to this pod status is possible.
-func (r *SingleClusterReconciler) removePodStatus(podNames []string) error {
+func (r *SingleClusterReconciler) removePodStatus(ctx context.Context, podNames []string) error {
 	if len(podNames) == 0 {
 		return nil
 	}
@@ -995,10 +996,11 @@ func (r *SingleClusterReconciler) removePodStatus(podNames []string) error {
 		patches = append(patches, patch)
 	}
 
-	return r.patchPodStatus(context.TODO(), patches)
+	return r.patchPodStatus(ctx, patches)
 }
 
-func (r *SingleClusterReconciler) cleanupDanglingPodsRack(sts *appsv1.StatefulSet, rackState *RackState) error {
+func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
+	ctx context.Context, sts *appsv1.StatefulSet, rackState *RackState) error {
 	// Clean up any dangling resources associated with the new pods.
 	// This implements a safety net to protect scale up against failed cleanup operations when cluster
 	// is scaled down.
@@ -1009,7 +1011,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(sts *appsv1.StatefulSe
 		rackID, rackRevision, err := utils.GetRackIDAndRevisionFromPodName(r.aeroCluster.Name, podName)
 		if err != nil {
 			return fmt.Errorf(
-				"failed to get rackID for the pod %s", podName,
+				"parsing rackID from pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 			)
 		}
 
@@ -1020,7 +1022,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(sts *appsv1.StatefulSe
 
 		ordinal, err := getSTSPodOrdinal(podName)
 		if err != nil {
-			return fmt.Errorf("invalid pod name: %s", podName)
+			return fmt.Errorf("parsing ordinal from pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err)
 		}
 
 		if *ordinal >= *sts.Spec.Replicas {
@@ -1029,8 +1031,12 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(sts *appsv1.StatefulSe
 	}
 
 	if len(danglingPods) > 0 {
-		if err := r.cleanupPods(danglingPods, rackState); err != nil {
-			return fmt.Errorf("failed dangling pod cleanup: %v", err)
+		if err := r.cleanupPods(ctx, danglingPods, rackState); err != nil {
+			return fmt.Errorf(
+				"cleaning up dangling pods %s for rack %d in cluster %s: %w",
+				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, danglingPods), ", "),
+				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 		}
 	}
 
@@ -1042,7 +1048,8 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(sts *appsv1.StatefulSe
 // 2. Failed/pending pods including old revisions pods from the configuredRacks identified using maxIgnorablePods field
 // are ignored from stability checks.
 func (r *SingleClusterReconciler) getIgnorablePods(
-	racksToDelete []asdbv1.Rack, configuredRacks []RackState,
+	ctx context.Context, racksToDelete []asdbv1.Rack, configuredRacks []RackState,
+	revisionChangedRacks map[int]revisionChangedRack,
 ) (sets.Set[string], error) {
 	ignorablePodNames := sets.Set[string]{}
 	ignorableRackIDs := sets.Set[int]{}
@@ -1051,7 +1058,7 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 	ignorableRacks = append(ignorableRacks, getRacksToBeBlockedFromRoster(r.Log, configuredRacks)...)
 
 	for rackIdx := range ignorableRacks {
-		rackPods, err := r.getRackPodList(ignorableRacks[rackIdx].ID, ignorableRacks[rackIdx].Revision)
+		rackPods, err := r.getRackPodList(ctx, ignorableRacks[rackIdx].ID, ignorableRacks[rackIdx].Revision)
 		if err != nil {
 			return nil, err
 		}
@@ -1066,6 +1073,34 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 		ignorableRackIDs.Insert(ignorableRacks[rackIdx].ID)
 	}
 
+	// Handle failed pods from old revisions of revision-changed racks
+	for rackID, revisionChangedRackInfo := range revisionChangedRacks {
+		oldRackState := revisionChangedRackInfo.oldRack
+		r.Log.Info("Checking old revision failed pods for revision-changed rack",
+			"rackID", rackID, "oldRevision", oldRackState.Rack.Revision)
+
+		oldPodList, err := r.getRackPodList(ctx, oldRackState.Rack.ID, oldRackState.Rack.Revision)
+		if err != nil {
+			return nil, err
+		}
+
+		var oldFailedPods []string
+
+		for podIdx := range oldPodList.Items {
+			pod := oldPodList.Items[podIdx]
+			if !utils.IsPodRunningAndReady(&pod) {
+				oldFailedPods = append(oldFailedPods, pod.Name)
+				ignorablePodNames.Insert(pod.Name)
+			}
+		}
+
+		if len(oldFailedPods) > 0 {
+			r.Log.Info("Adding old revision failed pods to ignore list (will be replaced)",
+				"rackID", oldRackState.Rack.ID, "oldRevision", oldRackState.Rack.Revision,
+				"failedPods", oldFailedPods)
+		}
+	}
+
 	for idx := range configuredRacks {
 		rackState := &configuredRacks[idx]
 		if ignorableRackIDs.Has(rackState.Rack.ID) {
@@ -1077,7 +1112,7 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 			r.aeroCluster.Spec.RackConfig.MaxIgnorablePods, int(rackState.Size), false,
 		)
 
-		podList, err := r.getAllRevisionRackPodList(rackState.Rack.ID)
+		podList, err := r.getAllRevisionRackPodList(ctx, rackState.Rack.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -1132,9 +1167,9 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 }
 
 func (r *SingleClusterReconciler) getPodsPVCList(
-	podNames []string, rackID int, rackRevision string,
+	ctx context.Context, podNames []string, rackID int, rackRevision string,
 ) ([]corev1.PersistentVolumeClaim, error) {
-	pvcListItems, err := r.getRackPVCList(rackID, rackRevision)
+	pvcListItems, err := r.getRackPVCList(ctx, rackID, rackRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -1157,7 +1192,7 @@ func (r *SingleClusterReconciler) getPodsPVCList(
 	return podPVCs, nil
 }
 
-func (r *SingleClusterReconciler) getClusterPodList() (
+func (r *SingleClusterReconciler) getClusterPodList(ctx context.Context) (
 	*corev1.PodList, error,
 ) {
 	// List the pods for this aeroCluster's statefulset
@@ -1168,7 +1203,7 @@ func (r *SingleClusterReconciler) getClusterPodList() (
 	}
 
 	// TODO: Should we add check to get only non-terminating pod? What if it is rolling restart
-	if err := r.List(context.TODO(), podList, listOps); err != nil {
+	if err := r.List(ctx, podList, listOps); err != nil {
 		return nil, err
 	}
 
@@ -1253,7 +1288,8 @@ func getPodNames(pods []*corev1.Pod) []string {
 }
 
 //nolint:gocyclo // for readability
-func (r *SingleClusterReconciler) handleNSOrDeviceRemoval(rackState *RackState, podsToRestart []*corev1.Pod) error {
+func (r *SingleClusterReconciler) handleNSOrDeviceRemoval(
+	ctx context.Context, rackState *RackState, podsToRestart []*corev1.Pod) error {
 	var (
 		rackStatus     asdbv1.Rack
 		removedDevices []string
@@ -1418,7 +1454,7 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemoval(rackState *RackState, 
 	}
 
 	for _, pod := range podsToRestart {
-		err := r.handleNSOrDeviceRemovalPerPod(removedDevices, removedFiles, pod.Name)
+		err := r.handleNSOrDeviceRemovalPerPod(ctx, removedDevices, removedFiles, pod.Name)
 		if err != nil {
 			return err
 		}
@@ -1428,7 +1464,7 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemoval(rackState *RackState, 
 }
 
 func (r *SingleClusterReconciler) handleNSOrDeviceRemovalPerPod(
-	removedDevices, removedFiles []string, podName string,
+	ctx context.Context, removedDevices, removedFiles []string, podName string,
 ) error {
 	podStatus := r.aeroCluster.Status.Pods[podName]
 
@@ -1453,7 +1489,7 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemovalPerPod(
 		}
 		patches = append(patches, patch1)
 
-		if err := r.patchPodStatus(context.TODO(), patches); err != nil {
+		if err := r.patchPodStatus(ctx, patches); err != nil {
 			return err
 		}
 	}
@@ -1461,7 +1497,7 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemovalPerPod(
 	return nil
 }
 
-func (r *SingleClusterReconciler) getNSAddedDevices(rackState *RackState) ([]string, error) {
+func (r *SingleClusterReconciler) getNSAddedDevices(ctx context.Context, rackState *RackState) ([]string, error) {
 	var (
 		rackStatus asdbv1.Rack
 		volumes    []string
@@ -1469,7 +1505,7 @@ func (r *SingleClusterReconciler) getNSAddedDevices(rackState *RackState) ([]str
 
 	newAeroCluster := &asdbv1.AerospikeCluster{}
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, newAeroCluster,
 	); err != nil {
@@ -1604,17 +1640,17 @@ func (r *SingleClusterReconciler) deleteFileStorage(podName, fileName string) er
 			stdout, "stderr", stderr,
 		)
 
-		return fmt.Errorf("error deleting file %v", err)
+		return fmt.Errorf("deleting file %s on pod %s: %w", fileName, utils.NamespacedName(r.aeroCluster.Namespace, podName), err)
 	}
 
 	return nil
 }
 
-func (r *SingleClusterReconciler) getConfigMap(rackIdentifier string) (*corev1.ConfigMap, error) {
+func (r *SingleClusterReconciler) getConfigMap(ctx context.Context, rackIdentifier string) (*corev1.ConfigMap, error) {
 	cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster, rackIdentifier)
 	confMap := &corev1.ConfigMap{}
 
-	if err := r.Get(context.TODO(), cmName, confMap); err != nil {
+	if err := r.Get(ctx, cmName, confMap); err != nil {
 		return nil, err
 	}
 
@@ -1640,7 +1676,7 @@ func isAllDynamicConfig(log logger, specToStatusDiffs asconfig.DynamicConfigMap,
 func getFlatConfig(log logger, confStr string) (*asconfig.Conf, error) {
 	asConf, err := asconfig.NewASConfigFromBytes(log, []byte(confStr), asconfig.AeroConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config map by lib: %v", err)
+		return nil, fmt.Errorf("parsing aerospike config: %w", err)
 	}
 
 	return asConf.GetFlatMap(), nil
@@ -1657,12 +1693,12 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfStatus, err := getFlatConfig(log, statusFromAnnotation)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config map by lib: %v", err)
+		return nil, fmt.Errorf("parsing status aerospike config: %w", err)
 	}
 
 	asConf, err := asconfig.NewMapAsConfig(log, specConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config map by lib: %v", err)
+		return nil, fmt.Errorf("loading spec aerospike config: %w", err)
 	}
 
 	// special handling for DNE in ldap configurations
@@ -1672,7 +1708,7 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfSpec, err := getFlatConfig(log, specConfFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load config map by lib: %v", err)
+		return nil, fmt.Errorf("parsing spec aerospike config: %w", err)
 	}
 
 	specToStatusDiffs, err := asconfig.ConfDiff(log, *asConfSpec, *asConfStatus,
@@ -1714,7 +1750,7 @@ func (r *SingleClusterReconciler) patchPodStatus(ctx context.Context, patches []
 		if err := r.Client.Status().Patch(
 			ctx, patchedAerospikeCluster, constantPatch, client.FieldOwner("pod"),
 		); err != nil {
-			return fmt.Errorf("error updating status: %v", err)
+			return fmt.Errorf("patching pod status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 
 		r.Log.Info("Pod status patched successfully")
@@ -1741,7 +1777,8 @@ func (r *SingleClusterReconciler) onDemandOperationType(podName string, onDemand
 	return noRestart
 }
 
-func (r *SingleClusterReconciler) updateOperationStatus(restartedASDPodNames, restartedPodNames []string) error {
+func (r *SingleClusterReconciler) updateOperationStatus(
+	ctx context.Context, restartedASDPodNames, restartedPodNames []string) error {
 	if len(restartedASDPodNames)+len(restartedPodNames) == 0 || len(r.aeroCluster.Spec.Operations) == 0 {
 		return nil
 	}
@@ -1824,7 +1861,7 @@ func (r *SingleClusterReconciler) updateOperationStatus(restartedASDPodNames, re
 	// Get the old object, it may have been updated in between.
 	newAeroCluster := &asdbv1.AerospikeCluster{}
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, newAeroCluster,
 	); err != nil {
@@ -1833,15 +1870,16 @@ func (r *SingleClusterReconciler) updateOperationStatus(restartedASDPodNames, re
 
 	newAeroCluster.Status.Operations = statusOps
 
-	if err := r.patchStatus(newAeroCluster); err != nil {
-		return fmt.Errorf("error updating status: %w", err)
+	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
+		return fmt.Errorf("updating operation status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	return nil
 }
 
 // podsToRestart returns the pods that need to be restarted(quick/pod restart) based on the on-demand operations.
-func (r *SingleClusterReconciler) podsToRestart() (quickRestarts, podRestarts sets.Set[string], err error) {
+func (r *SingleClusterReconciler) podsToRestart(
+	ctx context.Context) (quickRestarts, podRestarts sets.Set[string], err error) {
 	quickRestarts = make(sets.Set[string])
 	podRestarts = make(sets.Set[string])
 
@@ -1850,7 +1888,7 @@ func (r *SingleClusterReconciler) podsToRestart() (quickRestarts, podRestarts se
 	allPodNames := asdbv1.GetAllPodNames(r.aeroCluster.Status.Pods)
 
 	// Check for pods with eviction-blocked annotation that need restart
-	evictionBlockedPods, err := r.getEvictionBlockedPods()
+	evictionBlockedPods, err := r.getEvictionBlockedPods(ctx)
 	if err != nil {
 		return quickRestarts, podRestarts, err
 	}
@@ -1920,13 +1958,12 @@ func (r *SingleClusterReconciler) podsToRestart() (quickRestarts, podRestarts se
 }
 
 // getEvictionBlockedPods returns pods that have eviction-blocked annotation and need restart
-func (r *SingleClusterReconciler) getEvictionBlockedPods() (sets.Set[string], error) {
+func (r *SingleClusterReconciler) getEvictionBlockedPods(ctx context.Context) (sets.Set[string], error) {
 	evictionBlockedPods := make(sets.Set[string])
 
 	// List all pods in the cluster namespace
-	pods, err := r.getClusterPodList()
+	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
-		r.Log.Error(err, "Failed to list pods for eviction-blocked check")
 		return evictionBlockedPods, err
 	}
 
@@ -1991,10 +2028,10 @@ func (r *SingleClusterReconciler) shouldSetMigrateFillDelay(rackState *RackState
 
 // isAnyPodSpecUpdated checks if any pod spec has been updated indirectly based on
 // aerospikeConfig or aerospikeNetworkPolicy change
-func (r *SingleClusterReconciler) isAnyPodSpecUpdated(rackState *RackState,
+func (r *SingleClusterReconciler) isAnyPodSpecUpdated(ctx context.Context, rackState *RackState,
 	pod *corev1.Pod) (bool, error) {
 	// Creating a local copy of the statefulset to avoid modifying the original object
-	sts, err := r.getSTS(rackState)
+	sts, err := r.getSTS(ctx, rackState)
 	if err != nil {
 		return false, err
 	}
@@ -2011,7 +2048,10 @@ func (r *SingleClusterReconciler) checkForPortsUpdate(sts *appsv1.StatefulSet, p
 	serverContainer := getContainer(pod.Spec.Containers, asdbv1.AerospikeServerContainerName)
 
 	if serverContainer == nil || stsServerContainer == nil {
-		return false, fmt.Errorf("server container not found in pod or statefulset")
+		return false, reconcile.TerminalError(fmt.Errorf(
+			"server container not found in pod %s or statefulset %s",
+			utils.GetNamespacedNameString(pod), utils.GetNamespacedNameString(sts),
+		))
 	}
 
 	desiredContainerPortsMap := make(map[string]corev1.ContainerPort, len(stsServerContainer.Ports))

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -384,8 +384,8 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("set migrate-fill-delay to `0` for rack %d after restarting the running pods: %w",
-						rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("set migrate-fill-delay to `0` after restarting the running pods: %w",
+						res.Err)
 				}
 
 				return res
@@ -723,7 +723,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("revert migrate-fill-delay: %w", res.Err)
 				}
 
 				return res
@@ -741,7 +741,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("set migrate-fill-delay to `0` for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("set migrate-fill-delay to `0`: %w", res.Err)
 				}
 
 				return res

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -80,7 +80,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -266,7 +266,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 		restartType = mergeRestartType(restartType, opType)
 
 		r.Log.Info("Pod warm/cold restart requested. Need rolling restart",
-			"pod name", pod.Name, "operation", opType, "restartType", restartType)
+			"pod", klog.KObj(pod), "operation", opType, "restartType", restartType)
 	}
 
 	// Check if EnableRackIDOverride in spec differs from RackIDOverridden in pod status
@@ -465,7 +465,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 			)
 			if err != nil {
 				return fmt.Errorf(
-					"pod %s: warm restart via /etc/aerospike/refresh-cmap-restart-asd.sh failed "+
+					"pod %s: warm restart via /etc/aerospike/refresh-cmap-restart-asd.sh: "+
 						"stdout=%q stderr=%q: %w",
 					utils.NamespacedName(podNamespacedName.Namespace, podNamespacedName.Name),
 					stdout, stderr, err,
@@ -473,7 +473,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 			}
 		} else {
 			return fmt.Errorf(
-				"pod %s: %s %s failed: stdout=%q stderr=%q: %w",
+				"pod %s: %s %s: stdout=%q stderr=%q: %w",
 				utils.NamespacedName(podNamespacedName.Namespace, podNamespacedName.Name),
 				initBinary, subCommand,
 				stdout, stderr, err,
@@ -596,7 +596,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 
 			r.Log.V(1).Info(
 				"Waiting for pod to be ready", "pod", klog.KObj(pod),
-				"status", pod.Status.Phase, "DeletionTimestamp",
+				"status", pod.Status.Phase, "deletionTimestamp",
 				pod.DeletionTimestamp,
 			)
 
@@ -940,7 +940,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 
 	clusterPodList, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return fmt.Errorf("clean up pod PVCs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("clean up pod PVCs for cluster %s: %w", utils.GetNamespacedNameString(r.aeroCluster), err)
 	}
 
 	podNameSet := sets.NewString(podNames...)
@@ -973,11 +973,11 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 			// All nodes from other rack
 			r.Log.Info(
 				"About to remove host from tipHostnames and reset alumni in pod...",
-				"pod to remove", podName, "remove and reset on pod", np.Name,
+				"podToRemove", podName, "pod", klog.KObj(np),
 			)
 
 			if err := r.tipClearHostname(ctx, np, podName); err != nil {
-				r.Log.V(2).Info("Failed to tipClear", "hostName", podName, "from the pod", np.Name)
+				r.Log.V(2).Info("Failed to tipClear", "hostName", podName, "pod", klog.KObj(np))
 			}
 
 			if err := r.alumniReset(ctx, np); err != nil {
@@ -1073,7 +1073,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 			return fmt.Errorf(
 				"clean up dangling pods %s in rack %d for cluster %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, danglingPods), ", "),
-				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 	}
@@ -1974,7 +1974,7 @@ func (r *SingleClusterReconciler) getEvictionBlockedPods(ctx context.Context) (s
 	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
 		return evictionBlockedPods, fmt.Errorf("list pods for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err)
+			utils.GetNamespacedNameString(r.aeroCluster), err)
 	}
 
 	for idx := range pods.Items {

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
@@ -79,8 +78,8 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(
 	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
-			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"list Pods for rack %d: %w",
+			rackState.Rack.ID, err,
 		)
 	}
 
@@ -105,7 +104,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypeMap(
 
 		if blockedK8sNodes.Has(pods[idx].Spec.NodeName) {
 			r.Log.Info("Pod found in blocked nodes list, will be migrated to a different node",
-				"pod", klog.KObj(pods[idx]))
+				"pod", utils.GetNamespacedName(pods[idx]))
 
 			restartTypeMap[pods[idx].Name] = podRestart
 
@@ -237,7 +236,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 		restartType = mergeRestartType(restartType, podRestart)
 
 		r.Log.Info(
-			"Aerospike pod spec changed. Need rolling restart",
+			"Aerospike Pod spec changed. Need rolling restart",
 			"requiredHash", requiredPodSpecHash,
 			"currentHash", podStatus.PodSpecHash,
 		)
@@ -245,14 +244,14 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 
 	podSpecUpdated, err := r.isAnyPodSpecUpdated(ctx, rackState, pod)
 	if err != nil {
-		return restartType, fmt.Errorf("check pod %s spec update state: %w",
+		return restartType, fmt.Errorf("check Pod %s spec update state: %w",
 			utils.GetNamespacedNameString(pod), err)
 	}
 
 	if podSpecUpdated {
 		restartType = mergeRestartType(restartType, podRestart)
 
-		r.Log.Info("Aerospike pod ports changed. Need rolling restart")
+		r.Log.Info("Aerospike Pod ports changed. Need rolling restart")
 	}
 
 	// Check if rack storage is updated
@@ -266,7 +265,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 		restartType = mergeRestartType(restartType, opType)
 
 		r.Log.Info("Pod warm/cold restart requested. Need rolling restart",
-			"pod", klog.KObj(pod), "operation", opType, "restartType", restartType)
+			"pod", utils.GetNamespacedName(pod), "operation", opType, "restartType", restartType)
 	}
 
 	// Check if EnableRackIDOverride in spec differs from RackIDOverridden in pod status
@@ -292,7 +291,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 
 		if val < 0 {
 			r.Log.Info(
-				"Init container version is older than minimum required for enableRackIDOverride support, full pod restart needed",
+				"Init container version is older than minimum required for enableRackIDOverride support, full Pod restart needed",
 				"initImageVersion", version,
 				"minRequiredVersion", minInitVersionForOverrideRackID)
 
@@ -314,7 +313,7 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 
 		r.Log.Info(
 			"DynamicConfigUpdateStatus is PartiallyFailed. Need quick restart",
-			"pod", klog.KObj(pod),
+			"pod", utils.GetNamespacedName(pod),
 		)
 	}
 
@@ -332,7 +331,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 	// (upgrade, k8sNodeBlockList, planned rolling restart) — they failed for an unknown reason
 	// and their local disk data must be protected.
 	if len(failedPods) != 0 {
-		r.Log.Info("Restart failed pods", "pods", getPodNames(failedPods))
+		r.Log.Info("Restart failed Pods", "pods", getPodNames(failedPods))
 
 		if res := r.restartPods(ctx, rackState, failedPods, restartTypeMap, true); !res.IsSuccess {
 			return res
@@ -340,7 +339,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 	}
 
 	if len(activePods) != 0 {
-		r.Log.Info("Restart active pods", "pods", getPodNames(activePods))
+		r.Log.Info("Restart active Pods", "pods", getPodNames(activePods))
 
 		if res := r.waitForMultipleNodesSafeStopReady(ctx, activePods, ignorablePodNames); !res.IsSuccess {
 			return res
@@ -351,7 +350,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 		setMigrateFillDelay := r.shouldSetMigrateFillDelay(rackState, podsToRestart, restartTypeMap)
 
 		r.Log.Info(
-			fmt.Sprintf("Adjust migrate-fill-delay prior to pod restart: %t", setMigrateFillDelay),
+			fmt.Sprintf("Adjust migrate-fill-delay prior to Pod restart: %t", setMigrateFillDelay),
 		)
 
 		// Revert migrate-fill-delay to the original value before restarting active pods.
@@ -364,7 +363,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 			); !res.IsSuccess {
 				if res.Err != nil {
 					res.Err = fmt.Errorf(
-						"revert migrate-fill-delay for rack %d before restarting running pods: %w",
+						"revert migrate-fill-delay for rack %d before restarting running Pods: %w",
 						rackState.Rack.ID, res.Err,
 					)
 				}
@@ -385,7 +384,8 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("set migrate-fill-delay to `0` for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("set migrate-fill-delay to `0` for rack %d after restarting the running pods: %w",
+						rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -410,7 +410,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 	rackID, rackRevision, err := utils.GetRackIDAndRevisionFromPodName(r.aeroCluster.Name, podName)
 	if err != nil {
 		return fmt.Errorf(
-			"get rack ID for pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
+			"get rack ID for Pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 		)
 	}
 
@@ -465,7 +465,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 			)
 			if err != nil {
 				return fmt.Errorf(
-					"pod %s: warm restart via /etc/aerospike/refresh-cmap-restart-asd.sh: "+
+					"warm restart Pod %s via /etc/aerospike/refresh-cmap-restart-asd.sh: "+
 						"stdout=%q stderr=%q: %w",
 					utils.NamespacedName(podNamespacedName.Namespace, podNamespacedName.Name),
 					stdout, stderr, err,
@@ -473,7 +473,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 			}
 		} else {
 			return fmt.Errorf(
-				"pod %s: %s %s: stdout=%q stderr=%q: %w",
+				"exec on Pod %s: %s %s: stdout=%q stderr=%q: %w",
 				utils.NamespacedName(podNamespacedName.Namespace, podNamespacedName.Name),
 				initBinary, subCommand,
 				stdout, stderr, err,
@@ -487,14 +487,16 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 			"[rack-%d] Warm restarted Pod %s",
 			rackID, podNamespacedName.String(),
 		)
-		r.Log.V(1).Info("Pod warm restarted", "pod", klog.KRef(podNamespacedName.Namespace, podNamespacedName.Name))
+		r.Log.V(1).Info("Pod warm restarted", "pod",
+			utils.NewNamespacedName(podNamespacedName.Namespace, podNamespacedName.Name))
 	} else {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeNormal, "PodConfUpdated",
 			"[rack-%d] Updated config for Pod %s",
 			rackID, podNamespacedName.String(),
 		)
-		r.Log.V(1).Info("Pod conf updated", "pod", klog.KRef(podNamespacedName.Namespace, podNamespacedName.Name))
+		r.Log.V(1).Info("Pod conf updated", "pod",
+			utils.NewNamespacedName(podNamespacedName.Namespace, podNamespacedName.Name))
 	}
 
 	return nil
@@ -525,7 +527,7 @@ func (r *SingleClusterReconciler) restartPods(
 			// We assume that the pod server image supports pod warm restart.
 			if err := r.restartASDOrUpdateAerospikeConf(pod.Name, quickRestart); err != nil {
 				return common.ReconcileError(fmt.Errorf(
-					"warm restart pod %s: %w",
+					"warm restart Pod %s: %w",
 					utils.NamespacedName(r.aeroCluster.Namespace, pod.Name), err,
 				))
 			}
@@ -539,13 +541,13 @@ func (r *SingleClusterReconciler) restartPods(
 			}
 
 			if err := r.Delete(ctx, pod); err != nil {
-				return common.ReconcileError(fmt.Errorf("delete pod %s: %w", utils.GetNamespacedNameString(pod), err))
+				return common.ReconcileError(fmt.Errorf("delete Pod %s: %w", utils.GetNamespacedNameString(pod), err))
 			}
 
 			restartedPods = append(restartedPods, pod)
 			restartedPodNames = append(restartedPodNames, pod.Name)
 
-			r.Log.V(1).Info("Pod deleted", "pod", klog.KObj(pod))
+			r.Log.V(1).Info("Pod deleted", "pod", utils.GetNamespacedName(pod))
 		case noRestart, noRestartUpdateConf:
 			// No action needed for these restart types
 		}
@@ -565,13 +567,14 @@ func (r *SingleClusterReconciler) restartPods(
 }
 
 func (r *SingleClusterReconciler) updateAerospikeConfInPod(podName string) error {
-	r.Log.Info("Updating aerospike config file in pod", "pod", klog.KRef(r.aeroCluster.Namespace, podName))
+	r.Log.Info("Updating aerospike config file in Pod", "pod", utils.NewNamespacedName(r.aeroCluster.Namespace, podName))
 
 	if err := r.restartASDOrUpdateAerospikeConf(podName, noRestartUpdateConf); err != nil {
 		return err
 	}
 
-	r.Log.V(1).Info("Updated aerospike config file in pod", "pod", klog.KRef(r.aeroCluster.Namespace, podName))
+	r.Log.V(1).Info("Updated aerospike config file in Pod", "pod",
+		utils.NewNamespacedName(r.aeroCluster.Namespace, podName))
 
 	return nil
 }
@@ -587,7 +590,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 	)
 
 	for i := 0; i < maxRetries; i++ {
-		r.Log.V(1).Info("Waiting for pods to be ready after delete", "pods", podNames)
+		r.Log.V(1).Info("Waiting for Pods to be ready after delete", "pods", podNames)
 
 		for _, pod := range podsToCheck {
 			if readyPods[pod.Name] {
@@ -595,7 +598,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 			}
 
 			r.Log.V(1).Info(
-				"Waiting for pod to be ready", "pod", klog.KObj(pod),
+				"Waiting for Pod to be ready", "pod", utils.GetNamespacedName(pod),
 				"status", pod.Status.Phase, "deletionTimestamp",
 				pod.DeletionTimestamp,
 			)
@@ -617,7 +620,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 
 			readyPods[pod.Name] = true
 
-			r.Log.Info("Pod is restarted", "pod", klog.KObj(updatedPod))
+			r.Log.Info("Pod is restarted", "pod", utils.GetNamespacedName(updatedPod))
 			r.Recorder.Eventf(
 				r.aeroCluster, corev1.EventTypeNormal, "PodRestarted",
 				"[rack-%s] Restarted Pod %s",
@@ -638,7 +641,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 	}
 
 	r.Log.Info(
-		"Timed out waiting for pods to come up", "pods",
+		"Timed out waiting for Pods to come up", "pods",
 		podNames,
 	)
 
@@ -690,7 +693,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 
 	// If already dead node (failed pod) then no need to check node safety, migration
 	if len(failedPods) != 0 {
-		r.Log.Info("Restart failed pods with updated container image", "pods", getPodNames(failedPods))
+		r.Log.Info("Restart failed Pods with updated container image", "pods", getPodNames(failedPods))
 
 		if res := r.deletePodAndEnsureImageUpdated(ctx, rackState, failedPods, true); !res.IsSuccess {
 			return res
@@ -698,7 +701,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 	}
 
 	if len(activePods) != 0 {
-		r.Log.Info("Restart active pods with updated container image", "pods", getPodNames(activePods))
+		r.Log.Info("Restart active Pods with updated container image", "pods", getPodNames(activePods))
 
 		if res := r.waitForMultipleNodesSafeStopReady(ctx, activePods, ignorablePodNames); !res.IsSuccess {
 			return res
@@ -709,7 +712,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 		setMigrateFillDelay := r.shouldSetMigrateFillDelay(rackState, podsToUpdate, nil)
 
 		r.Log.Info(
-			fmt.Sprintf("Adjust migrate-fill-delay prior to pod restart: %t", setMigrateFillDelay))
+			fmt.Sprintf("Adjust migrate-fill-delay prior to Pod restart: %t", setMigrateFillDelay))
 
 		// Revert migrate-fill-delay to the original value before restarting active pods.
 		// This will be a no-op in the first reconcile
@@ -780,7 +783,7 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 			return common.ReconcileError(err)
 		}
 
-		r.Log.V(1).Info("Pod deleted", "pod", klog.KObj(pod))
+		r.Log.V(1).Info("Pod deleted", "pod", utils.GetNamespacedName(pod))
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeNormal, "PodWaitUpdate",
 			"[rack-%d] Waiting to update Pod %s",
@@ -800,7 +803,7 @@ func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(
 		// Do not delete local PVCs unless the user has explicitly opted in via deleteLocalStorageOnPodRecovery,
 		// regardless of the eviction-blocked annotation, node block-list, or deleteLocalStorageOnRestart.
 		if asdbv1.GetBool(rackState.Rack.Storage.DeleteLocalStorageOnPodRecovery) {
-			r.Log.Info("deleteLocalStorageOnPodRecovery is enabled, deleting local PVCs for failed pod",
+			r.Log.Info("deleteLocalStorageOnPodRecovery is enabled, deleting local PVCs for failed Pod",
 				"podName", pod.Name)
 
 			return true
@@ -808,7 +811,7 @@ func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(
 
 		// Only log if local storage classes are configured
 		if len(rackState.Rack.Storage.LocalStorageClasses) != 0 {
-			r.Log.Info("Skipping local PVC deletion for failed pod", "pod", pod.Name)
+			r.Log.Info("Skipping local PVC deletion for failed Pod", "pod", pod.Name)
 		}
 
 		return false
@@ -817,21 +820,21 @@ func (r *SingleClusterReconciler) isLocalPVCDeletionRequired(
 	// Planned restart path — existing logic unchanged.
 	if _, hasEvictionBlocked := pod.Annotations[asdbv1.EvictionBlockedAnnotation]; hasEvictionBlocked {
 		r.Log.Info("Pod has eviction-blocked annotation, deleting corresponding local PVCs if any",
-			"pod", klog.KObj(pod))
+			"pod", utils.GetNamespacedName(pod))
 
 		return true
 	}
 
 	if utils.ContainsString(r.aeroCluster.Spec.K8sNodeBlockList, pod.Spec.NodeName) {
 		r.Log.Info("Pod found in blocked nodes list, deleting corresponding local PVCs if any",
-			"pod", klog.KObj(pod))
+			"pod", utils.GetNamespacedName(pod))
 
 		return true
 	}
 
 	if asdbv1.GetBool(rackState.Rack.Storage.DeleteLocalStorageOnRestart) {
 		r.Log.Info("deleteLocalStorageOnRestart flag is enabled, deleting corresponding local PVCs if any",
-			"pod", klog.KObj(pod))
+			"pod", utils.GetNamespacedName(pod))
 
 		return true
 	}
@@ -851,7 +854,7 @@ func (r *SingleClusterReconciler) ensurePodsImageUpdated(
 
 	for i := 0; i < maxRetries; i++ {
 		r.Log.V(1).Info(
-			"Waiting for pods to be ready after delete", "pods", podNames,
+			"Waiting for Pods to be ready after delete", "pods", podNames,
 		)
 
 		for _, pod := range podsToCheck {
@@ -860,7 +863,7 @@ func (r *SingleClusterReconciler) ensurePodsImageUpdated(
 			}
 
 			r.Log.V(1).Info(
-				"Waiting for pod to be ready", "pod", klog.KObj(pod),
+				"Waiting for Pod to be ready", "pod", utils.GetNamespacedName(pod),
 			)
 
 			updatedPod := &corev1.Pod{}
@@ -881,7 +884,7 @@ func (r *SingleClusterReconciler) ensurePodsImageUpdated(
 
 			updatedPods.Insert(pod.Name)
 
-			r.Log.Info("Pod is upgraded/downgraded", "pod", klog.KObj(updatedPod))
+			r.Log.Info("Pod is upgraded/downgraded", "pod", utils.GetNamespacedName(updatedPod))
 		}
 
 		if len(updatedPods) == len(podsToCheck) {
@@ -893,7 +896,7 @@ func (r *SingleClusterReconciler) ensurePodsImageUpdated(
 	}
 
 	r.Log.Info(
-		"Timed out waiting for pods to come up with new image", "pods",
+		"Timed out waiting for Pods to come up with new image", "pods",
 		podNames,
 	)
 
@@ -909,13 +912,13 @@ func (r *SingleClusterReconciler) cleanupPods(
 		return nil
 	}
 
-	r.Log.Info("Removing pvc for removed pods", "pods", podNames)
+	r.Log.Info("Removing PVC for removed Pods", "pods", podNames)
 
 	// Delete PVCs if cascadeDelete
 	pvcItems, err := r.getPodsPVCList(ctx, podNames, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return fmt.Errorf(
-			"find PVCs for pods %s: %w",
+			"find PVCs for Pods %s: %w",
 			strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
 		)
 	}
@@ -923,7 +926,7 @@ func (r *SingleClusterReconciler) cleanupPods(
 	storage := rackState.Rack.Storage
 	if err = r.removePVCs(ctx, &storage, pvcItems); err != nil {
 		return fmt.Errorf(
-			"clean up PVCs for pods %s: %w",
+			"clean up PVCs for Pods %s: %w",
 			strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
 		)
 	}
@@ -940,7 +943,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 
 	clusterPodList, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return fmt.Errorf("clean up pod PVCs for cluster %s: %w", utils.GetNamespacedNameString(r.aeroCluster), err)
+		return fmt.Errorf("clean up Pod PVCs: %w", err)
 	}
 
 	podNameSet := sets.NewString(podNames...)
@@ -952,7 +955,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 			if !utils.IsPodRunningAndReady(np) {
 				r.Log.Info(
 					"Pod is not running and ready. Skip clearing from tipHostnames.",
-					"pod", klog.KObj(np), "hostsToRemove", podNames,
+					"pod", utils.GetNamespacedName(np), "hostsToRemove", podNames,
 				)
 
 				continue
@@ -972,16 +975,16 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 			// TODO: tip after scale-up and create
 			// All nodes from other rack
 			r.Log.Info(
-				"About to remove host from tipHostnames and reset alumni in pod...",
-				"podToRemove", podName, "pod", klog.KObj(np),
+				"About to remove host from tipHostnames and reset alumni in Pod...",
+				"podToRemove", podName, "pod", utils.GetNamespacedName(np),
 			)
 
 			if err := r.tipClearHostname(ctx, np, podName); err != nil {
-				r.Log.V(2).Info("Failed to tipClear", "hostName", podName, "pod", klog.KObj(np))
+				r.Log.V(2).Info("Failed to tipClear", "hostName", podName, "pod", utils.GetNamespacedName(np))
 			}
 
 			if err := r.alumniReset(ctx, np); err != nil {
-				r.Log.V(2).Info("Failed to reset alumni for pod", "pod", klog.KObj(np))
+				r.Log.V(2).Info("Failed to reset alumni for Pod", "pod", utils.GetNamespacedName(np))
 			}
 		}
 
@@ -1002,11 +1005,11 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 	}
 
 	if len(needStatusCleanup) > 0 {
-		r.Log.Info("Removing pod status for dangling pods", "pods", podNames)
+		r.Log.Info("Removing Pod status for dangling Pods", "pods", podNames)
 
 		if err := r.removePodStatus(ctx, needStatusCleanup); err != nil {
 			return fmt.Errorf(
-				"clean up pod status for pods %s: %w",
+				"clean up Pod status for Pods %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, needStatusCleanup), ", "), err,
 			)
 		}
@@ -1047,7 +1050,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 		rackID, rackRevision, err := utils.GetRackIDAndRevisionFromPodName(r.aeroCluster.Name, podName)
 		if err != nil {
 			return fmt.Errorf(
-				"get rack ID for pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
+				"get rack ID for Pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 			)
 		}
 
@@ -1059,7 +1062,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 		ordinal, err := getSTSPodOrdinal(podName)
 		if err != nil {
 			return fmt.Errorf(
-				"invalid pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
+				"invalid Pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 			)
 		}
 
@@ -1071,9 +1074,9 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 	if len(danglingPods) > 0 {
 		if err := r.cleanupPods(ctx, danglingPods, rackState); err != nil {
 			return fmt.Errorf(
-				"clean up dangling pods %s in rack %d for cluster %s: %w",
+				"clean up dangling Pods %s in rack %d: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, danglingPods), ", "),
-				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+				rackState.Rack.ID, err,
 			)
 		}
 	}
@@ -1232,7 +1235,7 @@ func (r *SingleClusterReconciler) isAnyPodInImageFailedState(podList []*corev1.P
 		// If node was crashed due to wrong config then only rollingRestart can bring it back.
 		if err := utils.CheckPodImageFailed(pod); err != nil {
 			r.Log.Info(
-				"AerospikeCluster Pod is in failed state", "pod", klog.KObj(pod), "err", err,
+				"AerospikeCluster Pod is in failed state", "pod", utils.GetNamespacedName(pod), "err", err,
 			)
 
 			return true
@@ -1645,7 +1648,7 @@ func (r *SingleClusterReconciler) deleteFileStorage(podName, fileName string) er
 		cmd, r.KubeClient, r.KubeConfig)
 	if err != nil {
 		r.Log.V(1).Info(
-			"File deletion failed", "pod", klog.KRef(r.aeroCluster.Namespace, podName),
+			"File deletion failed", "pod", utils.NewNamespacedName(r.aeroCluster.Namespace, podName),
 			"stdout", stdout, "stderr", stderr,
 		)
 
@@ -1973,8 +1976,7 @@ func (r *SingleClusterReconciler) getEvictionBlockedPods(ctx context.Context) (s
 	// List all pods in the cluster namespace
 	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return evictionBlockedPods, fmt.Errorf("list pods for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err)
+		return evictionBlockedPods, fmt.Errorf("list Pods: %w", err)
 	}
 
 	for idx := range pods.Items {
@@ -2059,7 +2061,7 @@ func (r *SingleClusterReconciler) checkForPortsUpdate(sts *appsv1.StatefulSet, p
 
 	if serverContainer == nil || stsServerContainer == nil {
 		return false, fmt.Errorf(
-			"server container not found in pod %s or statefulset %s",
+			"server container not found in Pod %s or StatefulSet %s",
 			utils.GetNamespacedNameString(pod), utils.GetNamespacedNameString(sts),
 		)
 	}
@@ -2088,7 +2090,7 @@ func (r *SingleClusterReconciler) checkForPortsUpdate(sts *appsv1.StatefulSet, p
 			(desiredPort.HostPort != 0 && currentPort.HostPort == 0) {
 			r.Log.Info(
 				"Pod spec is updated, container port changed",
-				"pod", klog.KObj(pod), "desiredPort", desiredPort, "currentPort", currentPort,
+				"pod", utils.GetNamespacedName(pod), "desiredPort", desiredPort, "currentPort", currentPort,
 			)
 
 			return true, nil

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -244,7 +244,8 @@ func (r *SingleClusterReconciler) getRollingRestartTypePod(
 
 	podSpecUpdated, err := r.isAnyPodSpecUpdated(ctx, rackState, pod)
 	if err != nil {
-		return restartType, fmt.Errorf("could not check whether pod %s spec is up to date: %w", utils.GetNamespacedNameString(pod), err)
+		return restartType, fmt.Errorf("could not check whether pod %s spec is updated: %w",
+			utils.GetNamespacedNameString(pod), err)
 	}
 
 	if podSpecUpdated {
@@ -361,7 +362,10 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("could not revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf(
+						"could not revert migrate-fill-delay for rack %d before restarting the running pods: %w",
+						rackState.Rack.ID, res.Err,
+					)
 				}
 
 				return res
@@ -380,7 +384,7 @@ func (r *SingleClusterReconciler) rollingRestartPods(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("could not set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("could not set migrate-fill-delay to `0` for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -405,7 +409,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 	rackID, rackRevision, err := utils.GetRackIDAndRevisionFromPodName(r.aeroCluster.Name, podName)
 	if err != nil {
 		return fmt.Errorf(
-			"parsing rackID from pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
+			"unable to get rackID for the pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 		)
 	}
 
@@ -733,7 +737,7 @@ func (r *SingleClusterReconciler) safelyDeletePodsAndEnsureImageUpdated(
 				ignorablePodNames,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("could not set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("could not set migrate-fill-delay to `0` for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -935,7 +939,7 @@ func (r *SingleClusterReconciler) cleanupPodMeshAndStatus(ctx context.Context, p
 
 	clusterPodList, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return fmt.Errorf("could not get pod list for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("could not cleanup pod PVCs %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	podNameSet := sets.NewString(podNames...)
@@ -1042,7 +1046,7 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 		rackID, rackRevision, err := utils.GetRackIDAndRevisionFromPodName(r.aeroCluster.Name, podName)
 		if err != nil {
 			return fmt.Errorf(
-				"parsing rackID from pod name %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
+				"unable to get rackID for the pod %s: %w", utils.NamespacedName(r.aeroCluster.Namespace, podName), err,
 			)
 		}
 
@@ -1709,7 +1713,7 @@ func isAllDynamicConfig(log logger, specToStatusDiffs asconfig.DynamicConfigMap,
 func getFlatConfig(log logger, confStr string) (*asconfig.Conf, error) {
 	asConf, err := asconfig.NewASConfigFromBytes(log, []byte(confStr), asconfig.AeroConfig)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse Aerospike configuration from text with management library: %w", err)
+		return nil, fmt.Errorf("unable to load config map by lib: %w", err)
 	}
 
 	return asConf.GetFlatMap(), nil
@@ -1726,12 +1730,12 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfStatus, err := getFlatConfig(log, statusFromAnnotation)
 	if err != nil {
-		return nil, fmt.Errorf("could not flatten Aerospike configuration from pod status annotation: %w", err)
+		return nil, fmt.Errorf("unable to load config map by lib: %w", err)
 	}
 
 	asConf, err := asconfig.NewMapAsConfig(log, specConfig)
 	if err != nil {
-		return nil, fmt.Errorf("could not build Aerospike configuration from spec map with management library: %w", err)
+		return nil, fmt.Errorf("unable to load config map by lib: %w", err)
 	}
 
 	// special handling for DNE in ldap configurations
@@ -1741,7 +1745,7 @@ func getConfDiff(log logger, specConfig map[string]interface{}, podAnnotations m
 
 	asConfSpec, err := getFlatConfig(log, specConfFile)
 	if err != nil {
-		return nil, fmt.Errorf("could not normalize Aerospike configuration from spec for diff with management library: %w", err)
+		return nil, fmt.Errorf("unable to load config map by lib: %w", err)
 	}
 
 	specToStatusDiffs, err := asconfig.ConfDiff(log, *asConfSpec, *asConfStatus,
@@ -1997,7 +2001,8 @@ func (r *SingleClusterReconciler) getEvictionBlockedPods(ctx context.Context) (s
 	// List all pods in the cluster namespace
 	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
-		return evictionBlockedPods, fmt.Errorf("could not list pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return evictionBlockedPods, fmt.Errorf("could not list pods for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	for idx := range pods.Items {

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -483,14 +483,14 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 
 	if subCommand == "quick-restart" {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodWarmRestarted,
+			r.aeroCluster, corev1.EventTypeNormal, "PodWarmRestarted",
 			"[rack-%d] Warm restarted Pod %s",
 			rackID, podNamespacedName.String(),
 		)
 		r.Log.V(1).Info("Pod warm restarted", "pod", klog.KRef(podNamespacedName.Namespace, podNamespacedName.Name))
 	} else {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodConfUpdated,
+			r.aeroCluster, corev1.EventTypeNormal, "PodConfUpdated",
 			"[rack-%d] Updated config for Pod %s",
 			rackID, podNamespacedName.String(),
 		)
@@ -619,7 +619,7 @@ func (r *SingleClusterReconciler) ensurePodsRunningAndReady(
 
 			r.Log.Info("Pod is restarted", "pod", klog.KObj(updatedPod))
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeNormal, EventReasonPodRestarted,
+				r.aeroCluster, corev1.EventTypeNormal, "PodRestarted",
 				"[rack-%s] Restarted Pod %s",
 				pod.Labels[asdbv1.AerospikeRackIDLabel], utils.GetNamespacedNameString(pod),
 			)
@@ -782,7 +782,7 @@ func (r *SingleClusterReconciler) deletePodAndEnsureImageUpdated(
 
 		r.Log.V(1).Info("Pod deleted", "pod", klog.KObj(pod))
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodWaitUpdate,
+			r.aeroCluster, corev1.EventTypeNormal, "PodWaitUpdate",
 			"[rack-%d] Waiting to update Pod %s",
 			rackState.Rack.ID, utils.GetNamespacedNameString(pod),
 		)

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -414,7 +413,7 @@ func (r *SingleClusterReconciler) restartASDOrUpdateAerospikeConf(podName string
 
 	switch operation {
 	case noRestart, podRestart:
-		return reconcile.TerminalError(fmt.Errorf("invalid operation %d for akoinit", operation))
+		return fmt.Errorf("invalid akoinit operation %d", operation)
 	case quickRestart:
 		subCommand = "quick-restart"
 	case noRestartUpdateConf:
@@ -2052,10 +2051,10 @@ func (r *SingleClusterReconciler) checkForPortsUpdate(sts *appsv1.StatefulSet, p
 	serverContainer := getContainer(pod.Spec.Containers, asdbv1.AerospikeServerContainerName)
 
 	if serverContainer == nil || stsServerContainer == nil {
-		return false, reconcile.TerminalError(fmt.Errorf(
-			"server container not found in pod %s or statefulset %s",
-			utils.GetNamespacedNameString(pod), utils.GetNamespacedNameString(sts),
-		))
+		return false, fmt.Errorf(
+		"server container not found in pod %s or statefulset %s",
+		utils.GetNamespacedNameString(pod), utils.GetNamespacedNameString(sts),
+	)
 	}
 
 	desiredContainerPortsMap := make(map[string]corev1.ContainerPort, len(stsServerContainer.Ports))

--- a/internal/controller/cluster/pod.go
+++ b/internal/controller/cluster/pod.go
@@ -1087,7 +1087,6 @@ func (r *SingleClusterReconciler) cleanupDanglingPodsRack(
 // are ignored from stability checks.
 func (r *SingleClusterReconciler) getIgnorablePods(
 	ctx context.Context, racksToDelete []asdbv1.Rack, configuredRacks []RackState,
-	revisionChangedRacks map[int]revisionChangedRack,
 ) (sets.Set[string], error) {
 	ignorablePodNames := sets.Set[string]{}
 	ignorableRackIDs := sets.Set[int]{}
@@ -1109,34 +1108,6 @@ func (r *SingleClusterReconciler) getIgnorablePods(
 		}
 
 		ignorableRackIDs.Insert(ignorableRacks[rackIdx].ID)
-	}
-
-	// Handle failed pods from old revisions of revision-changed racks
-	for rackID, revisionChangedRackInfo := range revisionChangedRacks {
-		oldRackState := revisionChangedRackInfo.oldRack
-		r.Log.Info("Checking old revision failed pods for revision-changed rack",
-			"rackID", rackID, "oldRevision", oldRackState.Rack.Revision)
-
-		oldPodList, err := r.getRackPodList(ctx, oldRackState.Rack.ID, oldRackState.Rack.Revision)
-		if err != nil {
-			return nil, err
-		}
-
-		var oldFailedPods []string
-
-		for podIdx := range oldPodList.Items {
-			pod := oldPodList.Items[podIdx]
-			if !utils.IsPodRunningAndReady(&pod) {
-				oldFailedPods = append(oldFailedPods, pod.Name)
-				ignorablePodNames.Insert(pod.Name)
-			}
-		}
-
-		if len(oldFailedPods) > 0 {
-			r.Log.Info("Adding old revision failed pods to ignore list (will be replaced)",
-				"rackID", oldRackState.Rack.ID, "oldRevision", oldRackState.Rack.Revision,
-				"failedPods", oldFailedPods)
-		}
 	}
 
 	for idx := range configuredRacks {

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -70,7 +70,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 		clusterReadinessEnabled, err := r.getClusterReadinessStatus(ctx)
 		if err != nil {
 			return fmt.Errorf(
-				"getting readiness status for cluster %s: %w",
+				"could not get cluster readiness status for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -117,7 +117,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 			ctx, pdb, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"creating poddisruptionbudget %s: %w",
+				"could not create PodDisruptionBudget %s: %w",
 				getPDBNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -148,7 +148,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 			ctx, pdb, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"updating poddisruptionbudget %s: %w",
+				"could not update PodDisruptionBudget %s: %w",
 				getPDBNamespacedName(r.aeroCluster), err,
 			)
 		}

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -9,19 +9,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/internal/controller/common"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/pkg/utils"
 )
 
-func (r *SingleClusterReconciler) reconcilePDB() error {
+func (r *SingleClusterReconciler) reconcilePDB(ctx context.Context) error {
 	// If spec.DisablePDB is set to true, then we don't need to create PDB
 	// If it exists then delete it
 	if asdbv1.GetBool(r.aeroCluster.Spec.DisablePDB) {
 		if !asdbv1.GetBool(r.aeroCluster.Status.DisablePDB) {
 			r.Log.Info("PodDisruptionBudget is disabled. Deleting old PodDisruptionBudget")
-			return r.deletePDB()
+			return r.deletePDB(ctx)
 		}
 
 		r.Log.Info("PodDisruptionBudget is disabled, skipping PodDisruptionBudget creation")
@@ -30,15 +31,15 @@ func (r *SingleClusterReconciler) reconcilePDB() error {
 	}
 
 	// Create or update PodDisruptionBudget
-	return r.createOrUpdatePDB()
+	return r.createOrUpdatePDB(ctx)
 }
 
-func (r *SingleClusterReconciler) deletePDB() error {
+func (r *SingleClusterReconciler) deletePDB(ctx context.Context) error {
 	pdb := &v1.PodDisruptionBudget{}
 
 	// Get the PodDisruptionBudget
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, pdb,
 	); err != nil {
@@ -60,16 +61,19 @@ func (r *SingleClusterReconciler) deletePDB() error {
 	}
 
 	// Delete the PodDisruptionBudget
-	return r.Delete(context.TODO(), pdb)
+	return r.Delete(ctx, pdb)
 }
 
-func (r *SingleClusterReconciler) createOrUpdatePDB() error {
+func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 	// Check for cluster readiness status only when it's false.
 	// Once enabled it won't be disabled.
 	if !r.IsStatusEmpty() && !r.aeroCluster.Status.IsReadinessProbeEnabled {
-		clusterReadinessEnabled, err := r.getClusterReadinessStatus()
+		clusterReadinessEnabled, err := r.getClusterReadinessStatus(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get cluster readiness status: %v", err)
+			return fmt.Errorf(
+				"getting readiness status for cluster %s: %w",
+				utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 		}
 
 		if !clusterReadinessEnabled {
@@ -84,7 +88,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB() error {
 	pdb := &v1.PodDisruptionBudget{}
 
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, pdb,
 	); err != nil {
@@ -111,11 +115,11 @@ func (r *SingleClusterReconciler) createOrUpdatePDB() error {
 		}
 
 		if err = r.Create(
-			context.TODO(), pdb, common.CreateOption,
+			ctx, pdb, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"failed to create PodDisruptionBudget: %v",
-				err,
+				"creating poddisruptionbudget %s: %w",
+				getPDBNamespacedName(r.aeroCluster), err,
 			)
 		}
 
@@ -132,21 +136,21 @@ func (r *SingleClusterReconciler) createOrUpdatePDB() error {
 	// This will ensure that the cluster is not deployed with PDB created by the user.
 	// If PDB is not created by operator then no need to even match the spec
 	if !utils.IsOwnedBy(pdb, r.aeroCluster) {
-		return fmt.Errorf(
-			"failed to update PodDisruptionBudget, PodDisruptionBudget is not "+
-				"created/owned by operator. name: %s", getPDBNamespacedName(r.aeroCluster),
-		)
+		return reconcile.TerminalError(fmt.Errorf(
+			"poddisruptionbudget %s exists but is not created/owned by the operator",
+			getPDBNamespacedName(r.aeroCluster),
+		))
 	}
 
 	if pdb.Spec.MaxUnavailable.String() != r.aeroCluster.Spec.MaxUnavailable.String() {
 		pdb.Spec.MaxUnavailable = r.aeroCluster.Spec.MaxUnavailable
 
 		if err := r.Update(
-			context.TODO(), pdb, common.UpdateOption,
+			ctx, pdb, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"failed to update PodDisruptionBudget: %v",
-				err,
+				"updating poddisruptionbudget %s: %w",
+				getPDBNamespacedName(r.aeroCluster), err,
 			)
 		}
 

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/internal/controller/common"
@@ -136,10 +135,10 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 	// This will ensure that the cluster is not deployed with PDB created by the user.
 	// If PDB is not created by operator then no need to even match the spec
 	if !utils.IsOwnedBy(pdb, r.aeroCluster) {
-		return reconcile.TerminalError(fmt.Errorf(
+		return fmt.Errorf(
 			"poddisruptionbudget %s exists but is not created/owned by the operator",
 			getPDBNamespacedName(r.aeroCluster),
-		))
+		)
 	}
 
 	if pdb.Spec.MaxUnavailable.String() != r.aeroCluster.Spec.MaxUnavailable.String() {

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -136,8 +136,8 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 	// If PDB is not created by operator then no need to even match the spec
 	if !utils.IsOwnedBy(pdb, r.aeroCluster) {
 		return fmt.Errorf(
-			"poddisruptionbudget %s exists but is not created/owned by the operator",
-			getPDBNamespacedName(r.aeroCluster),
+			"could not update PodDisruptionBudget: PodDisruptionBudget is not "+
+				"created/owned by operator. name: %s", getPDBNamespacedName(r.aeroCluster).String(),
 		)
 	}
 

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -53,7 +54,7 @@ func (r *SingleClusterReconciler) deletePDB(ctx context.Context) error {
 	if !utils.IsOwnedBy(pdb, r.aeroCluster) {
 		r.Log.Info(
 			"PodDisruptionBudget is not created/owned by operator. Skipping delete",
-			"name", getPDBNamespacedName(r.aeroCluster),
+			"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		)
 
 		return nil
@@ -95,7 +96,8 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 			return err
 		}
 
-		r.Log.Info("Create PodDisruptionBudget", "name", getPDBNamespacedName(r.aeroCluster))
+		r.Log.Info("Create PodDisruptionBudget",
+			"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name))
 
 		pdb.SetName(r.aeroCluster.Name)
 		pdb.SetNamespace(r.aeroCluster.Namespace)
@@ -122,14 +124,15 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 			)
 		}
 
-		r.Log.Info("Created new PodDisruptionBudget", "name", getPDBNamespacedName(r.aeroCluster))
+		r.Log.Info("Created new PodDisruptionBudget",
+			"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name))
 
 		return nil
 	}
 
 	r.Log.Info(
 		"PodDisruptionBudget already exist. Updating existing PodDisruptionBudget if required",
-		"name", getPDBNamespacedName(r.aeroCluster),
+		"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
 	)
 
 	// This will ensure that the cluster is not deployed with PDB created by the user.
@@ -153,7 +156,8 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 			)
 		}
 
-		r.Log.Info("Updated PodDisruptionBudget", "name", getPDBNamespacedName(r.aeroCluster))
+		r.Log.Info("Updated PodDisruptionBudget",
+			"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name))
 	}
 
 	return nil

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -54,7 +53,7 @@ func (r *SingleClusterReconciler) deletePDB(ctx context.Context) error {
 	if !utils.IsOwnedBy(pdb, r.aeroCluster) {
 		r.Log.Info(
 			"PodDisruptionBudget is not created/owned by operator. Skipping delete",
-			"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+			"podDisruptionBudget", utils.NewNamespacedName(r.aeroCluster.Namespace, r.aeroCluster.Name),
 		)
 
 		return nil
@@ -70,10 +69,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 	if !r.IsStatusEmpty() && !r.aeroCluster.Status.IsReadinessProbeEnabled {
 		clusterReadinessEnabled, err := r.getClusterReadinessStatus(ctx)
 		if err != nil {
-			return fmt.Errorf(
-				"get cluster readiness status for cluster %s: %w",
-				utils.GetNamespacedNameString(r.aeroCluster), err,
-			)
+			return fmt.Errorf("get cluster readiness status: %w", err)
 		}
 
 		if !clusterReadinessEnabled {
@@ -97,7 +93,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 		}
 
 		r.Log.Info("Create PodDisruptionBudget",
-			"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name))
+			"podDisruptionBudget", utils.NewNamespacedName(r.aeroCluster.Namespace, r.aeroCluster.Name))
 
 		pdb.SetName(r.aeroCluster.Name)
 		pdb.SetNamespace(r.aeroCluster.Namespace)
@@ -125,21 +121,21 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 		}
 
 		r.Log.Info("Created new PodDisruptionBudget",
-			"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name))
+			"podDisruptionBudget", utils.NewNamespacedName(r.aeroCluster.Namespace, r.aeroCluster.Name))
 
 		return nil
 	}
 
 	r.Log.Info(
 		"PodDisruptionBudget already exist. Updating existing PodDisruptionBudget if required",
-		"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name),
+		"podDisruptionBudget", utils.NewNamespacedName(r.aeroCluster.Namespace, r.aeroCluster.Name),
 	)
 
 	// This will ensure that the cluster is not deployed with PDB created by the user.
 	// If PDB is not created by operator then no need to even match the spec
 	if !utils.IsOwnedBy(pdb, r.aeroCluster) {
 		return fmt.Errorf(
-			"update PodDisruptionBudget %s: not created/owned by operator", getPDBNamespacedName(r.aeroCluster).String(),
+			"update PodDisruptionBudget %s: not created/owned by operator", getPDBNamespacedName(r.aeroCluster),
 		)
 	}
 
@@ -156,7 +152,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 		}
 
 		r.Log.Info("Updated PodDisruptionBudget",
-			"podDisruptionBudget", klog.KRef(r.aeroCluster.Namespace, r.aeroCluster.Name))
+			"podDisruptionBudget", utils.NewNamespacedName(r.aeroCluster.Namespace, r.aeroCluster.Name))
 	}
 
 	return nil

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -71,7 +71,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 		clusterReadinessEnabled, err := r.getClusterReadinessStatus(ctx)
 		if err != nil {
 			return fmt.Errorf(
-				"could not get cluster readiness status for cluster %s: %w",
+				"get cluster readiness status for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -119,7 +119,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 			ctx, pdb, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"could not create PodDisruptionBudget %s: %w",
+				"create PodDisruptionBudget %s: %w",
 				getPDBNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -139,8 +139,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 	// If PDB is not created by operator then no need to even match the spec
 	if !utils.IsOwnedBy(pdb, r.aeroCluster) {
 		return fmt.Errorf(
-			"could not update PodDisruptionBudget: PodDisruptionBudget is not "+
-				"created/owned by operator. name: %s", getPDBNamespacedName(r.aeroCluster).String(),
+			"update PodDisruptionBudget %s: not created/owned by operator", getPDBNamespacedName(r.aeroCluster).String(),
 		)
 	}
 
@@ -151,7 +150,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 			ctx, pdb, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"could not update PodDisruptionBudget %s: %w",
+				"update PodDisruptionBudget %s: %w",
 				getPDBNamespacedName(r.aeroCluster), err,
 			)
 		}

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -72,7 +72,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf(
 				"get cluster readiness status for cluster %s: %w",
-				utils.ClusterNamespacedName(r.aeroCluster), err,
+				utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 

--- a/internal/controller/cluster/poddistruptionbudget.go
+++ b/internal/controller/cluster/poddistruptionbudget.go
@@ -135,7 +135,7 @@ func (r *SingleClusterReconciler) createOrUpdatePDB(ctx context.Context) error {
 	// If PDB is not created by operator then no need to even match the spec
 	if !utils.IsOwnedBy(pdb, r.aeroCluster) {
 		return fmt.Errorf(
-			"update PodDisruptionBudget %s: not created/owned by operator", getPDBNamespacedName(r.aeroCluster),
+			"existing PodDisruptionBudget %s: not created/owned by operator", getPDBNamespacedName(r.aeroCluster),
 		)
 	}
 

--- a/internal/controller/cluster/pvc.go
+++ b/internal/controller/cluster/pvc.go
@@ -88,7 +88,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 
 			if err := r.Delete(ctx, &pvc); err != nil {
 				return nil, fmt.Errorf(
-					"deleting pvc %s: %w", utils.NamespacedName(pvc.Namespace, pvc.Name), err,
+					"could not delete pvc %s: %w", utils.NamespacedName(pvc.Namespace, pvc.Name), err,
 				)
 			}
 
@@ -112,7 +112,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState *RackState, pod *corev1.Pod) error {
 	pvcItems, err := r.getPodsPVCList(ctx, []string{pod.Name}, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return fmt.Errorf("listing pvcs for pod %s: %w", utils.GetNamespacedNameString(pod), err)
+		return fmt.Errorf("could not find pvc for pod %s: %w", utils.GetNamespacedNameString(pod), err)
 	}
 
 	for idx := range pvcItems {
@@ -127,7 +127,7 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState
 			if err := r.Delete(ctx, &pvcItems[idx]); err != nil {
 				if !errors.IsNotFound(err) {
 					return fmt.Errorf(
-						"deleting pvc %s: %w",
+						"could not delete pvc %s: %w",
 						utils.NamespacedName(pvcItems[idx].Namespace, pvcItems[idx].Name), err,
 					)
 				}

--- a/internal/controller/cluster/pvc.go
+++ b/internal/controller/cluster/pvc.go
@@ -116,7 +116,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState *RackState, pod *corev1.Pod) error {
 	pvcItems, err := r.getPodsPVCList(ctx, []string{pod.Name}, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return fmt.Errorf("could not find pvc for pod %s: %w", utils.GetNamespacedNameString(pod), err)
+		return fmt.Errorf("find PVC for pod %s: %w", utils.GetNamespacedNameString(pod), err)
 	}
 
 	for idx := range pvcItems {

--- a/internal/controller/cluster/pvc.go
+++ b/internal/controller/cluster/pvc.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -56,8 +57,9 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 					"it does not have storage-volume annotation",
 			)
 			r.Log.Error(
-				err, "Failed to remove PVC", "PVC", pvc.Name, "annotations",
-				pvc.Annotations,
+				err, "Failed to remove PVC",
+				"persistentVolumeClaim", klog.KObj(&pvc),
+				"annotations", pvc.Annotations,
 			)
 
 			continue
@@ -76,8 +78,8 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 			r.Log.Info(
 				"PVC's volume not found in configured storage volumes. "+
 					"Use storage level cascadeDelete policy",
-				"PVC", pvc.Name, "volume", pvcStorageVolName, "cascadeDelete",
-				cascadeDelete,
+				"persistentVolumeClaim", klog.KObj(&pvc),
+				"volume", pvcStorageVolName, "cascadeDelete", cascadeDelete,
 			)
 		} else {
 			cascadeDelete = v.CascadeDelete
@@ -93,13 +95,15 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 			}
 
 			r.Log.Info(
-				"PVC removed", "PVC", pvc.Name, "PVCCascadeDelete",
-				cascadeDelete,
+				"PVC removed",
+				"persistentVolumeClaim", klog.KObj(&pvc),
+				"pvcCascadeDelete", cascadeDelete,
 			)
 		} else {
 			r.Log.Info(
-				"PVC not removed", "PVC", pvc.Name, "PVCCascadeDelete",
-				cascadeDelete,
+				"PVC not removed",
+				"persistentVolumeClaim", klog.KObj(&pvc),
+				"pvcCascadeDelete", cascadeDelete,
 			)
 		}
 	}
@@ -118,7 +122,10 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState
 	for idx := range pvcItems {
 		pvcStorageClass := pvcItems[idx].Spec.StorageClassName
 		if pvcStorageClass == nil {
-			r.Log.Info("PVC does not have storageClass set, no need to delete PVC", "pvcName", pvcItems[idx].Name)
+			r.Log.Info(
+				"PVC does not have storageClass set, no need to delete PVC",
+				"persistentVolumeClaim", klog.KObj(&pvcItems[idx]),
+			)
 
 			continue
 		}
@@ -132,9 +139,16 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState
 					)
 				}
 
-				r.Log.Info("PVC not found, may have been already deleted", "pvcName", pvcItems[idx].Name)
+				r.Log.Info(
+					"PVC not found, may have been already deleted",
+					"persistentVolumeClaim", klog.KObj(&pvcItems[idx]),
+				)
 			} else {
-				r.Log.Info("Successfully deleted local PVC", "pvcName", pvcItems[idx].Name, "storageClass", *pvcStorageClass)
+				r.Log.Info(
+					"Successfully deleted local PVC",
+					"persistentVolumeClaim", klog.KObj(&pvcItems[idx]),
+					"storageClass", *pvcStorageClass,
+				)
 			}
 		}
 	}
@@ -167,7 +181,10 @@ func (r *SingleClusterReconciler) waitForPVCTermination(
 
 			for existingIdx := range existingPVCs {
 				if existingPVCs[existingIdx].Name == pvc.Name {
-					r.Log.Info("Waiting for PVC termination", "PVC", pvc.Name)
+					r.Log.Info(
+						"Waiting for PVC termination",
+						"persistentVolumeClaim", klog.KObj(&pvc),
+					)
 
 					found = true
 

--- a/internal/controller/cluster/pvc.go
+++ b/internal/controller/cluster/pvc.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,18 +16,20 @@ import (
 )
 
 func (r *SingleClusterReconciler) removePVCs(
+	ctx context.Context,
 	storage *asdbv1.AerospikeStorageSpec,
 	pvcItems []corev1.PersistentVolumeClaim,
 ) error {
-	deletedPVCs, err := r.removePVCsAsync(storage, pvcItems)
+	deletedPVCs, err := r.removePVCsAsync(ctx, storage, pvcItems)
 	if err != nil {
 		return err
 	}
 
-	return r.waitForPVCTermination(deletedPVCs)
+	return r.waitForPVCTermination(ctx, deletedPVCs)
 }
 
 func (r *SingleClusterReconciler) removePVCsAsync(
+	ctx context.Context,
 	storage *asdbv1.AerospikeStorageSpec,
 	pvcItems []corev1.PersistentVolumeClaim,
 ) ([]corev1.PersistentVolumeClaim, error) {
@@ -83,9 +86,9 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 		if cascadeDelete {
 			deletedPVCs = append(deletedPVCs, pvc)
 
-			if err := r.Delete(context.TODO(), &pvc); err != nil {
+			if err := r.Delete(ctx, &pvc); err != nil {
 				return nil, fmt.Errorf(
-					"could not delete pvc %s: %v", pvc.Name, err,
+					"deleting pvc %s: %w", utils.NamespacedName(pvc.Namespace, pvc.Name), err,
 				)
 			}
 
@@ -106,10 +109,10 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 
 // deleteLocalPVCs deletes PVCs which are created using local storage classes
 // It considers the user given LocalStorageClasses list from spec to determine if a PVC is local or not.
-func (r *SingleClusterReconciler) deleteLocalPVCs(rackState *RackState, pod *corev1.Pod) error {
-	pvcItems, err := r.getPodsPVCList([]string{pod.Name}, rackState.Rack.ID, rackState.Rack.Revision)
+func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState *RackState, pod *corev1.Pod) error {
+	pvcItems, err := r.getPodsPVCList(ctx, []string{pod.Name}, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return fmt.Errorf("could not find pvc for pod %v: %v", pod.Name, err)
+		return fmt.Errorf("listing pvcs for pod %s: %w", utils.GetNamespacedNameString(pod), err)
 	}
 
 	for idx := range pvcItems {
@@ -121,10 +124,11 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(rackState *RackState, pod *cor
 		}
 
 		if utils.ContainsString(rackState.Rack.Storage.LocalStorageClasses, *pvcStorageClass) {
-			if err := r.Delete(context.TODO(), &pvcItems[idx]); err != nil {
+			if err := r.Delete(ctx, &pvcItems[idx]); err != nil {
 				if !errors.IsNotFound(err) {
 					return fmt.Errorf(
-						"could not delete pvc %s: %v", pvcItems[idx].Name, err,
+						"deleting pvc %s: %w",
+						utils.NamespacedName(pvcItems[idx].Namespace, pvcItems[idx].Name), err,
 					)
 				}
 
@@ -138,7 +142,8 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(rackState *RackState, pod *cor
 	return nil
 }
 
-func (r *SingleClusterReconciler) waitForPVCTermination(deletedPVCs []corev1.PersistentVolumeClaim) error {
+func (r *SingleClusterReconciler) waitForPVCTermination(
+	ctx context.Context, deletedPVCs []corev1.PersistentVolumeClaim) error {
 	if len(deletedPVCs) == 0 {
 		return nil
 	}
@@ -151,7 +156,7 @@ func (r *SingleClusterReconciler) waitForPVCTermination(deletedPVCs []corev1.Per
 	for i := 0; i < pollAttempts; i++ {
 		pending = false
 
-		existingPVCs, err := r.getClusterPVCList()
+		existingPVCs, err := r.getClusterPVCList(ctx)
 		if err != nil {
 			return err
 		}
@@ -186,7 +191,12 @@ func (r *SingleClusterReconciler) waitForPVCTermination(deletedPVCs []corev1.Per
 	}
 
 	if pending {
-		return fmt.Errorf("PVC termination timed out PVC: %v", deletedPVCs)
+		pvcNames := make([]string, 0, len(deletedPVCs))
+		for idx := range deletedPVCs {
+			pvcNames = append(pvcNames, utils.GetNamespacedNameString(&deletedPVCs[idx]))
+		}
+
+		return fmt.Errorf("pvc termination timed out for pvcs %s", strings.Join(pvcNames, ", "))
 	}
 
 	return nil
@@ -196,10 +206,10 @@ func (r *SingleClusterReconciler) waitForPVCTermination(deletedPVCs []corev1.Per
 // regardless of the cascadeDelete flag on individual volumes. It is used during
 // recoverFailedCreate where all storage must be wiped so the cluster can be
 // cleanly recreated.
-func (r *SingleClusterReconciler) deleteAllClusterPVCsForce() error {
-	pvcItems, err := r.getClusterPVCList()
+func (r *SingleClusterReconciler) deleteAllClusterPVCsForce(ctx context.Context) error {
+	pvcItems, err := r.getClusterPVCList(ctx)
 	if err != nil {
-		return fmt.Errorf("could not list cluster PVCs: %v", err)
+		return fmt.Errorf("listing cluster PVCs: %w", err)
 	}
 
 	var deletedPVCs []corev1.PersistentVolumeClaim
@@ -211,21 +221,21 @@ func (r *SingleClusterReconciler) deleteAllClusterPVCsForce() error {
 			continue
 		}
 
-		if err := r.Delete(context.TODO(), pvc); err != nil {
+		if err := r.Delete(ctx, pvc); err != nil {
 			if !errors.IsNotFound(err) {
-				return fmt.Errorf("could not delete PVC %s: %v", pvc.Name, err)
+				return fmt.Errorf("deleting PVC %s: %w", pvc.Name, err)
 			}
 		}
 
-		r.Log.Info("PVC force-deleted during cluster recovery", "PVC", pvc.Name)
+		r.Log.Info("PVC force-deleted during cluster recovery", "pvc", pvc.Name)
 
 		deletedPVCs = append(deletedPVCs, *pvc)
 	}
 
-	return r.waitForPVCTermination(deletedPVCs)
+	return r.waitForPVCTermination(ctx, deletedPVCs)
 }
 
-func (r *SingleClusterReconciler) getClusterPVCList() (
+func (r *SingleClusterReconciler) getClusterPVCList(ctx context.Context) (
 	[]corev1.PersistentVolumeClaim, error,
 ) {
 	// List the pvc for this aeroCluster's statefulset
@@ -235,14 +245,14 @@ func (r *SingleClusterReconciler) getClusterPVCList() (
 		Namespace: r.aeroCluster.Namespace, LabelSelector: labelSelector,
 	}
 
-	if err := r.List(context.TODO(), pvcList, listOps); err != nil {
+	if err := r.List(ctx, pvcList, listOps); err != nil {
 		return nil, err
 	}
 
 	return pvcList.Items, nil
 }
 
-func (r *SingleClusterReconciler) getRackPVCList(rackID int, rackRevision string) (
+func (r *SingleClusterReconciler) getRackPVCList(ctx context.Context, rackID int, rackRevision string) (
 	[]corev1.PersistentVolumeClaim, error,
 ) {
 	// List the pvc for this aeroCluster's statefulset
@@ -252,7 +262,7 @@ func (r *SingleClusterReconciler) getRackPVCList(rackID int, rackRevision string
 		LabelSelector: utils.GetAerospikeClusterRackLabelSelector(r.aeroCluster.Name, rackID, rackRevision),
 	}
 
-	if err := r.List(context.TODO(), pvcList, listOps); err != nil {
+	if err := r.List(ctx, pvcList, listOps); err != nil {
 		return nil, err
 	}
 

--- a/internal/controller/cluster/pvc.go
+++ b/internal/controller/cluster/pvc.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -58,7 +57,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 			)
 			r.Log.Error(
 				err, "Failed to remove PVC",
-				"persistentVolumeClaim", klog.KObj(&pvc),
+				"persistentVolumeClaim", utils.GetNamespacedName(&pvc),
 				"annotations", pvc.Annotations,
 			)
 
@@ -78,7 +77,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 			r.Log.Info(
 				"PVC's volume not found in configured storage volumes. "+
 					"Use storage level cascadeDelete policy",
-				"persistentVolumeClaim", klog.KObj(&pvc),
+				"persistentVolumeClaim", utils.GetNamespacedName(&pvc),
 				"volume", pvcStorageVolName, "cascadeDelete", cascadeDelete,
 			)
 		} else {
@@ -96,13 +95,13 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 
 			r.Log.Info(
 				"PVC removed",
-				"persistentVolumeClaim", klog.KObj(&pvc),
+				"persistentVolumeClaim", utils.GetNamespacedName(&pvc),
 				"pvcCascadeDelete", cascadeDelete,
 			)
 		} else {
 			r.Log.Info(
 				"PVC not removed",
-				"persistentVolumeClaim", klog.KObj(&pvc),
+				"persistentVolumeClaim", utils.GetNamespacedName(&pvc),
 				"pvcCascadeDelete", cascadeDelete,
 			)
 		}
@@ -116,7 +115,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState *RackState, pod *corev1.Pod) error {
 	pvcItems, err := r.getPodsPVCList(ctx, []string{pod.Name}, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return fmt.Errorf("find PVC for pod %s: %w", utils.GetNamespacedNameString(pod), err)
+		return fmt.Errorf("find PVC for Pod %s: %w", utils.GetNamespacedNameString(pod), err)
 	}
 
 	for idx := range pvcItems {
@@ -124,7 +123,7 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState
 		if pvcStorageClass == nil {
 			r.Log.Info(
 				"PVC does not have storageClass set, no need to delete PVC",
-				"persistentVolumeClaim", klog.KObj(&pvcItems[idx]),
+				"persistentVolumeClaim", utils.GetNamespacedName(&pvcItems[idx]),
 			)
 
 			continue
@@ -141,12 +140,12 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState
 
 				r.Log.Info(
 					"PVC not found, may have been already deleted",
-					"persistentVolumeClaim", klog.KObj(&pvcItems[idx]),
+					"persistentVolumeClaim", utils.GetNamespacedName(&pvcItems[idx]),
 				)
 			} else {
 				r.Log.Info(
 					"Successfully deleted local PVC",
-					"persistentVolumeClaim", klog.KObj(&pvcItems[idx]),
+					"persistentVolumeClaim", utils.GetNamespacedName(&pvcItems[idx]),
 					"storageClass", *pvcStorageClass,
 				)
 			}
@@ -183,7 +182,7 @@ func (r *SingleClusterReconciler) waitForPVCTermination(
 				if existingPVCs[existingIdx].Name == pvc.Name {
 					r.Log.Info(
 						"Waiting for PVC termination",
-						"persistentVolumeClaim", klog.KObj(&pvc),
+						"persistentVolumeClaim", utils.GetNamespacedName(&pvc),
 					)
 
 					found = true
@@ -213,7 +212,7 @@ func (r *SingleClusterReconciler) waitForPVCTermination(
 			pvcNames = append(pvcNames, utils.GetNamespacedNameString(&deletedPVCs[idx]))
 		}
 
-		return fmt.Errorf("pvc termination timed out for pvcs %s", strings.Join(pvcNames, ", "))
+		return fmt.Errorf("PVC termination timed out for PVCs %s", strings.Join(pvcNames, ", "))
 	}
 
 	return nil
@@ -244,7 +243,7 @@ func (r *SingleClusterReconciler) deleteAllClusterPVCsForce(ctx context.Context)
 			}
 		}
 
-		r.Log.Info("PVC force-deleted during cluster recovery", "persistentVolumeClaim", klog.KObj(pvc))
+		r.Log.Info("PVC force-deleted during cluster recovery", "persistentVolumeClaim", utils.GetNamespacedName(pvc))
 
 		deletedPVCs = append(deletedPVCs, *pvc)
 	}

--- a/internal/controller/cluster/pvc.go
+++ b/internal/controller/cluster/pvc.go
@@ -90,7 +90,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 
 			if err := r.Delete(ctx, &pvc); err != nil {
 				return nil, fmt.Errorf(
-					"could not delete pvc %s: %w", utils.NamespacedName(pvc.Namespace, pvc.Name), err,
+					"delete PVC %s: %w", utils.NamespacedName(pvc.Namespace, pvc.Name), err,
 				)
 			}
 
@@ -134,7 +134,7 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState
 			if err := r.Delete(ctx, &pvcItems[idx]); err != nil {
 				if !errors.IsNotFound(err) {
 					return fmt.Errorf(
-						"could not delete pvc %s: %w",
+						"delete PVC %s: %w",
 						utils.NamespacedName(pvcItems[idx].Namespace, pvcItems[idx].Name), err,
 					)
 				}

--- a/internal/controller/cluster/pvc.go
+++ b/internal/controller/cluster/pvc.go
@@ -90,7 +90,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 
 			if err := r.Delete(ctx, &pvc); err != nil {
 				return nil, fmt.Errorf(
-					"delete PVC %s: %w", utils.NamespacedName(pvc.Namespace, pvc.Name), err,
+					"delete PVC %s: %w", utils.GetNamespacedNameString(&pvc), err,
 				)
 			}
 
@@ -135,7 +135,7 @@ func (r *SingleClusterReconciler) deleteLocalPVCs(ctx context.Context, rackState
 				if !errors.IsNotFound(err) {
 					return fmt.Errorf(
 						"delete PVC %s: %w",
-						utils.NamespacedName(pvcItems[idx].Namespace, pvcItems[idx].Name), err,
+						utils.GetNamespacedNameString(&pvcItems[idx]), err,
 					)
 				}
 
@@ -226,7 +226,7 @@ func (r *SingleClusterReconciler) waitForPVCTermination(
 func (r *SingleClusterReconciler) deleteAllClusterPVCsForce(ctx context.Context) error {
 	pvcItems, err := r.getClusterPVCList(ctx)
 	if err != nil {
-		return fmt.Errorf("listing cluster PVCs: %w", err)
+		return fmt.Errorf("list cluster PVCs: %w", err)
 	}
 
 	var deletedPVCs []corev1.PersistentVolumeClaim
@@ -240,11 +240,11 @@ func (r *SingleClusterReconciler) deleteAllClusterPVCsForce(ctx context.Context)
 
 		if err := r.Delete(ctx, pvc); err != nil {
 			if !errors.IsNotFound(err) {
-				return fmt.Errorf("deleting PVC %s: %w", pvc.Name, err)
+				return fmt.Errorf("delete PVC %s: %w", utils.GetNamespacedNameString(pvc), err)
 			}
 		}
 
-		r.Log.Info("PVC force-deleted during cluster recovery", "pvc", pvc.Name)
+		r.Log.Info("PVC force-deleted during cluster recovery", "persistentVolumeClaim", klog.KObj(pvc))
 
 		deletedPVCs = append(deletedPVCs, *pvc)
 	}

--- a/internal/controller/cluster/pvc.go
+++ b/internal/controller/cluster/pvc.go
@@ -52,7 +52,7 @@ func (r *SingleClusterReconciler) removePVCsAsync(
 
 		if !ok {
 			err := fmt.Errorf(
-				"PVC can not be removed, " +
+				"annotation missing on PVC: can not be removed, " +
 					"it does not have storage-volume annotation",
 			)
 			r.Log.Error(
@@ -212,7 +212,7 @@ func (r *SingleClusterReconciler) waitForPVCTermination(
 			pvcNames = append(pvcNames, utils.GetNamespacedNameString(&deletedPVCs[idx]))
 		}
 
-		return fmt.Errorf("PVC termination timed out for PVCs %s", strings.Join(pvcNames, ", "))
+		return fmt.Errorf("termination timed out for PVCs %s", strings.Join(pvcNames, ", "))
 	}
 
 	return nil

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -171,7 +171,7 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 			// terminate times out and event is re-queued.
 			// Next reconcile will not invoke scale up or down and will
 			// fall through,
-			// and might run reconcile steps common to all racks before the racks
+			// and might run reconcile step	s common to all racks before the racks
 			// have scaled up.
 			r.Log.Error(
 				err, "Failed to wait for StatefulSet to be ready, will requeue",
@@ -206,10 +206,6 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 
 	found, err := r.createSTS(ctx, stsName, rackState)
 	if err != nil {
-		r.Log.V(1).Info(
-			"StatefulSet setup failed. Deleting StatefulSet", "name",
-			stsName,
-		)
 		// Delete statefulset and everything related so that it can be properly created and updated in next run
 		if found != nil {
 			r.Log.V(1).Info(
@@ -403,10 +399,10 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 					r.Recorder.Eventf(
 						r.aeroCluster, corev1.EventTypeWarning,
 						"RackRollingRestartFailed",
-						"[rack-%d] Failed to roll StatefulSet %s",
+						"[rack-%d] Failed to do rolling restart of StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
-					res.Err = fmt.Errorf("complete rolling restart for rack %d StatefulSet %s: %w",
+					res.Err = fmt.Errorf("rolling restart rack %d StatefulSet %s: %w",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
@@ -595,8 +591,8 @@ func (r *SingleClusterReconciler) reconcileRack(
 				nil,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("revert migrate-fill-delay after scale down for rack %d: %w",
-						rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("revert migrate-fill-delay after scale down: %w",
+						res.Err)
 				}
 
 				return res
@@ -619,15 +615,15 @@ func (r *SingleClusterReconciler) reconcileRack(
 	if currentSize < desiredSize {
 		found, res = r.scaleUpRack(ctx, found, rackState, ignorablePodNames)
 		if !res.IsSuccess {
-			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, "RackScaleUpFailed",
-				eventRackScaleFailureMessageWithCause(
-					"scale up", rackState.Rack.ID,
-					utils.GetNamespacedNameString(found), currentSize, desiredSize, res.Err,
-				),
-			)
-
 			if res.Err != nil {
+				r.Recorder.Eventf(
+					r.aeroCluster, corev1.EventTypeWarning, "RackScaleUpFailed",
+					eventRackScaleFailureMessageWithCause(
+						"scale up", rackState.Rack.ID,
+						utils.GetNamespacedNameString(found), currentSize, desiredSize, res.Err,
+					),
+				)
+
 				res.Err = fmt.Errorf(
 					"scale up StatefulSet %s for rack %d (current %d, desired %d replicas): %w",
 					utils.GetNamespacedNameString(found), rackState.Rack.ID, currentSize, desiredSize, res.Err,
@@ -681,7 +677,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 
 	if r.isAnyPodInImageFailedState(podList, ignorablePodNames) {
 		return found, common.ReconcileError(fmt.Errorf(
-			"scale up rack %d: a Pod is already in failed state", rackState.Rack.ID))
+			"cannot scale up rack %d: a Pod is already in failed state", rackState.Rack.ID))
 	}
 
 	var newPodNames []string
@@ -695,7 +691,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 			if podList[idx].Name == newPodName {
 				return found, common.ReconcileError(
 					fmt.Errorf(
-						"check Pod %s: yet to be launched is still present",
+						"pending Pod %s: yet to be launched is still present",
 						utils.NamespacedName(r.aeroCluster.Namespace, newPodName),
 					),
 				)
@@ -909,7 +905,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 
 	if r.isAnyPodInImageFailedState(oldPodList, ignorablePodNames) {
 		return found, common.ReconcileError(
-			fmt.Errorf("scale down rack %d: a Pod is already in failed state", rackState.Rack.ID))
+			fmt.Errorf("cannot scale down rack %d: a Pod is already in failed state", rackState.Rack.ID))
 	}
 
 	// Code flow will reach this stage only when found.Spec.Replicas > desiredSize
@@ -974,7 +970,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		// The user can override this by raising maxIgnorablePods.
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"check Pod %s: not ready; waiting for recovery before scale-down to prevent data loss",
+				"status for Pod %s: not ready; waiting for recovery before scale-down to prevent data loss",
 				podsBatch[idx].Name,
 			),
 		)
@@ -996,7 +992,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			ctx, policy, &rackState.Rack.AerospikeConfig, true, ignorablePodNames,
 		); !res.IsSuccess {
 			if res.Err != nil {
-				res.Err = fmt.Errorf("set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+				res.Err = fmt.Errorf("set migrate-fill-delay to 0: %w", res.Err)
 			}
 
 			return found, res
@@ -1839,7 +1835,7 @@ func (r *SingleClusterReconciler) getOrderedRackPodList(ctx context.Context, rac
 
 		if indexInt >= len(podList.Items) {
 			// Happens if we do not get full list of pods due to a crash,
-			return nil, fmt.Errorf("list Pods for rack %d revision %s: incomplete Pod list", rackID, rackRevision)
+			return nil, fmt.Errorf("error get pod list for rack:%v, rackRevision:%v", rackID, rackRevision)
 		}
 
 		sortedList[(len(podList.Items)-1)-indexInt] = &podList.Items[idx]
@@ -1923,7 +1919,7 @@ func (r *SingleClusterReconciler) handleEnableSecurity(
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		return err
+		return fmt.Errorf("reconcile access control: %w", err)
 	}
 
 	return nil

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -228,7 +228,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackCreated,
+		r.aeroCluster, corev1.EventTypeNormal, "RackCreated",
 		"[rack-%d] Created rack", rackState.Rack.ID,
 	)
 
@@ -311,7 +311,7 @@ func (r *SingleClusterReconciler) deleteRacks(
 		// Delete sts
 		if err = r.deleteSTS(ctx, found); err != nil {
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, EventReasonStatefulSetDeleteFailed,
+				r.aeroCluster, corev1.EventTypeWarning, "STSDeleteFailed",
 				"[rack-%d] Failed to delete StatefulSet %s", rack.ID,
 				utils.GetNamespacedNameString(found),
 			)
@@ -333,7 +333,7 @@ func (r *SingleClusterReconciler) deleteRacks(
 		}
 
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, EventReasonRackDeleted,
+			r.aeroCluster, corev1.EventTypeNormal, "RackDeleted",
 			"[rack-%d] Deleted rack", rack.ID,
 		)
 	}
@@ -382,7 +382,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 			if res.Err != nil {
 				r.Recorder.Eventf(
 					r.aeroCluster, corev1.EventTypeWarning,
-					EventReasonRackImageUpdateFailed,
+					"RackImageUpdateFailed",
 					"[rack-%d] Failed to update image for StatefulSet %s",
 					rackState.Rack.ID, utils.GetNamespacedNameString(found),
 				)
@@ -406,7 +406,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 				if res.Err != nil {
 					r.Recorder.Eventf(
 						r.aeroCluster, corev1.EventTypeWarning,
-						EventReasonRackRollingRestartFailed,
+						"RackRollingRestartFailed",
 						"[rack-%d] Failed to roll StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
@@ -427,7 +427,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 				if res.Err != nil {
 					r.Recorder.Eventf(
 						r.aeroCluster, corev1.EventTypeWarning,
-						EventReasonRackDynamicConfigFailed,
+						"RackDynamicConfigUpdateFailed",
 						"[rack-%d] Failed to update dynamic config for StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
@@ -465,7 +465,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	r.Log.Info("Update dynamic config in Aerospike pods")
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonDynamicConfigUpdate,
+		r.aeroCluster, corev1.EventTypeNormal, "DynamicConfigUpdate",
 		"[rack-%d] Started dynamic config update", rackState.Rack.ID,
 	)
 
@@ -503,7 +503,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonDynamicConfigUpdated,
+		r.aeroCluster, corev1.EventTypeNormal, "DynamicConfigUpdated",
 		"[rack-%d] Finished dynamic config update", rackState.Rack.ID,
 	)
 
@@ -571,7 +571,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 			if res.Err != nil {
 				r.Recorder.Eventf(
 					r.aeroCluster, corev1.EventTypeWarning,
-					EventReasonRackScaleDownFailed,
+					"RackScaleDownFailed",
 					eventRackScaleFailureMessageWithCause(
 						"scale down", rackState.Rack.ID,
 						utils.GetNamespacedNameString(found), currentSize, desiredSize, res.Err,
@@ -624,7 +624,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 		found, res = r.scaleUpRack(ctx, found, rackState, ignorablePodNames)
 		if !res.IsSuccess {
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, EventReasonRackScaleUpFailed,
+				r.aeroCluster, corev1.EventTypeWarning, "RackScaleUpFailed",
 				eventRackScaleFailureMessageWithCause(
 					"scale up", rackState.Rack.ID,
 					utils.GetNamespacedNameString(found), currentSize, desiredSize, res.Err,
@@ -666,7 +666,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 
 	r.Log.Info("Scaling up pods", "currentSz", oldSz, "desiredSz", desiredSize)
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaleUp,
+		r.aeroCluster, corev1.EventTypeNormal, "RackScaleUp",
 		eventRackScaleMessage(
 			"Scaling up", rackState.Rack.ID,
 			utils.GetNamespacedNameString(found), oldSz, desiredSize,
@@ -741,7 +741,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaledUp,
+		r.aeroCluster, corev1.EventTypeNormal, "RackScaledUp",
 		eventRackScaleMessage(
 			"Scaled up", rackState.Rack.ID,
 			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
@@ -844,7 +844,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 		}
 
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodImageUpdate,
+			r.aeroCluster, corev1.EventTypeNormal, "PodImageUpdate",
 			"[rack-%d] Updating containers on Pods %s",
 			rackState.Rack.ID, eventNamespacedNames(r.aeroCluster.Namespace, podNames),
 		)
@@ -855,7 +855,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 		}
 
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodImageUpdated,
+			r.aeroCluster, corev1.EventTypeNormal, "PodImageUpdated",
 			"[rack-%d] Updated containers on Pods %s",
 			rackState.Rack.ID, eventNamespacedNames(r.aeroCluster.Namespace, podNames),
 		)
@@ -873,7 +873,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackImageUpdated,
+		r.aeroCluster, corev1.EventTypeNormal, "RackImageUpdated",
 		"[rack-%d] Updated image for StatefulSet %s",
 		rackState.Rack.ID, utils.GetNamespacedNameString(statefulSet),
 	)
@@ -897,7 +897,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		"currentSize", *found.Spec.Replicas, "rackID", rackState.Rack.ID, "rackRevision", rackState.Rack.Revision,
 	)
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaleDown,
+		r.aeroCluster, corev1.EventTypeNormal, "RackScaleDown",
 		eventRackScaleMessage(
 			"Scaling down", rackState.Rack.ID,
 			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
@@ -1106,13 +1106,13 @@ func (r *SingleClusterReconciler) scaleDownRack(
 
 	r.Log.Info("Pod Removed", "podNames", podNames)
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonPodDeleted,
+		r.aeroCluster, corev1.EventTypeNormal, "PodDeleted",
 		"[rack-%d] Deleted Pods %s",
 		rackState.Rack.ID, eventNamespacedNames(r.aeroCluster.Namespace, podNames),
 	)
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaledDown,
+		r.aeroCluster, corev1.EventTypeNormal, "RackScaledDown",
 		eventRackScaleMessage(
 			"Scaled down", rackState.Rack.ID,
 			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
@@ -1130,7 +1130,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	r.Log.Info("Rolling restart AerospikeCluster statefulset pods", "statefulSet", klog.KObj(found))
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackRollingRestart,
+		r.aeroCluster, corev1.EventTypeNormal, "RackRollingRestart",
 		"[rack-%d] Started rolling restart", rackState.Rack.ID,
 	)
 
@@ -1239,7 +1239,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackRollingRestarted,
+		r.aeroCluster, corev1.EventTypeNormal, "RackRollingRestarted",
 		"[rack-%d] Finished rolling restart", rackState.Rack.ID,
 	)
 
@@ -1919,7 +1919,7 @@ func (r *SingleClusterReconciler) handleEnableSecurity(
 	// Setup access control.
 	if err := r.validateAndReconcileAccessControl(ctx, securityEnabledPods, ignorablePodNames); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, EventReasonAccessControlUpdateFailed,
+			r.aeroCluster, corev1.EventTypeWarning, ReasonACLUpdateFailed,
 			"Failed to set up access control for AerospikeCluster %s",
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -131,12 +131,12 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 	}
 
 	if len(r.aeroCluster.Status.RackConfig.Racks) != 0 {
-		// Remove removed racks
+		// Delete racks removed from the cluster spec (scale down, delete STS/ConfigMap, cleanup dangling resources).
 		if res = r.deleteRacks(ctx, racksToDelete, ignorablePodNames); !res.IsSuccess {
 			if res.Err != nil {
 				res.Err = fmt.Errorf(
-					"remove StatefulSets for removed racks in cluster %s: %w",
-					utils.ClusterNamespacedName(r.aeroCluster), res.Err,
+					"delete removed racks in cluster %s: %w",
+					utils.GetNamespacedNameString(r.aeroCluster), res.Err,
 				)
 			}
 
@@ -177,8 +177,8 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 			// fall through,
 			// and might run reconcile steps common to all racks before the racks
 			// have scaled up.
-			r.Log.V(1).Info(
-				"StatefulSet not ready, will requeue", "statefulSet", klog.KObj(found),
+			r.Log.Info(
+				"Failed to wait for StatefulSet to be ready, will requeue", "statefulSet", klog.KObj(found),
 				"err", err,
 			)
 
@@ -195,7 +195,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	r.Log.Info("Create new Aerospike cluster rack if needed")
 
 	// NoOp if already exist
-	r.Log.V(2).Info("AerospikeCluster", "Spec", r.aeroCluster.Spec)
+	r.Log.V(1).Info("AerospikeCluster", "spec", r.aeroCluster.Spec)
 
 	// Bad config should not come here. It should be validated in validation hook
 	cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
@@ -479,7 +479,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
 			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		))
 	}
 
@@ -517,7 +517,7 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemovalForIgnorablePods(
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
 			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		))
 	}
 	// Filter ignoredPods to update their dirtyVolumes in the status.
@@ -679,14 +679,14 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	if err != nil {
 		return found, common.ReconcileError(fmt.Errorf(
 			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		))
 	}
 
 	if r.isAnyPodInImageFailedState(podList, ignorablePodNames) {
 		return found, common.ReconcileError(fmt.Errorf(
-			"cannot scale up cluster %s rack %d: a pod is already in failed state",
-			utils.ClusterNamespacedName(r.aeroCluster), rackState.Rack.ID))
+			"scale up cluster %s rack %d: a pod is already in failed state",
+			utils.GetNamespacedNameString(r.aeroCluster), rackState.Rack.ID))
 	}
 
 	var newPodNames []string
@@ -712,7 +712,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 		return found, common.ReconcileError(
 			fmt.Errorf(
 				"run scale-up pre-check for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 			),
 		)
 	}
@@ -769,7 +769,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 			return statefulSet, common.ReconcileError(
 				fmt.Errorf(
 					"list pods for rack %d in cluster %s: %w",
-					rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+					rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 				),
 			)
 		}
@@ -787,7 +787,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 	if err != nil {
 		return statefulSet, common.ReconcileError(
 			fmt.Errorf("update StatefulSet spec for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err),
+				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err),
 		)
 	}
 
@@ -908,14 +908,14 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if err != nil {
 		return found, common.ReconcileError(fmt.Errorf(
 			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		))
 	}
 
 	if r.isAnyPodInImageFailedState(oldPodList, ignorablePodNames) {
 		return found, common.ReconcileError(
-			fmt.Errorf("cannot scale down cluster %s rack %d: a pod is already in failed state",
-				utils.ClusterNamespacedName(r.aeroCluster), rackState.Rack.ID))
+			fmt.Errorf("scale down cluster %s rack %d: a pod is already in failed state",
+				utils.GetNamespacedNameString(r.aeroCluster), rackState.Rack.ID))
 	}
 
 	// Code flow will reach this stage only when found.Spec.Replicas > desiredSize
@@ -1042,7 +1042,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if isAnyPodRunningAndReady {
 		// Wait for pods to get terminated
 		if err = r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
-			r.Log.V(1).Info("StatefulSet not ready, will requeue", "statefulSet", klog.KObj(found), "err", err)
+			r.Log.Info("Failed to wait for StatefulSet to be ready, will requeue", "statefulSet", klog.KObj(found), "err", err)
 			return found, common.ReconcileRequeueAfter(1)
 		}
 
@@ -1056,7 +1056,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			newSize := *found.Spec.Replicas + utils.Len32(podsBatch)
 			found.Spec.Replicas = &newSize
 
-			r.Log.V(1).Info(
+			r.Log.Info(
 				"Cluster validation failed, re-setting AerospikeCluster statefulset to previous size",
 				"statefulSet", klog.KObj(found), "size", newSize, "err", err,
 			)
@@ -1073,7 +1073,10 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			}
 
 			if err = r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
-				r.Log.V(1).Info("StatefulSet not ready after reset, will requeue", "statefulSet", klog.KObj(found), "err", err)
+				r.Log.Info(
+					"Failed to wait for StatefulSet to be ready after reset, will requeue",
+					"statefulSet", klog.KObj(found), "err", err,
+				)
 			}
 
 			return found, common.ReconcileRequeueAfter(1)
@@ -1086,7 +1089,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		return found, common.ReconcileError(
 			fmt.Errorf(
 				"get StatefulSet for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 			),
 		)
 	}
@@ -1152,7 +1155,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		if err != nil {
 			return found, common.ReconcileError(fmt.Errorf(
 				"list pods for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 			))
 		}
 	}
@@ -1160,7 +1163,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	err = r.updateSTS(ctx, found, rackState)
 	if err != nil {
 		return found, common.ReconcileError(
-			fmt.Errorf("rolling restart failed: %w", err),
+			fmt.Errorf("update StatefulSet during rolling restart: %w", err),
 		)
 	}
 
@@ -1252,7 +1255,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
 	if err := r.updateSTS(ctx, statefulSet, rackState); err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("k8s node block list processing failed: %w", err),
+			fmt.Errorf("process k8s node block list: %w", err),
 		)
 	}
 
@@ -1269,7 +1272,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 		if err != nil {
 			return statefulSet, common.ReconcileError(fmt.Errorf(
 				"list pods for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 			))
 		}
 	}
@@ -1371,7 +1374,7 @@ func (r *SingleClusterReconciler) isRackUpgradeNeeded(
 	if err != nil {
 		return true, fmt.Errorf(
 			"list pods for rack %d in cluster %s: %w",
-			rackID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rackID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -1531,8 +1534,8 @@ func (r *SingleClusterReconciler) isStorageVolumeSourceUpdated(volume *asdbv1.Vo
 
 	if !reflect.DeepEqual(podVolume.Secret, volumeCopy.Source.Secret) {
 		r.Log.Info(
-			"Volume source updated", "old volume.source ",
-			podVolume.VolumeSource, "new volume.source", volume.Source,
+			"Volume source updated", "oldVolumeSource",
+			podVolume.VolumeSource, "newVolumeSource", volume.Source,
 		)
 
 		return true
@@ -1540,8 +1543,8 @@ func (r *SingleClusterReconciler) isStorageVolumeSourceUpdated(volume *asdbv1.Vo
 
 	if !reflect.DeepEqual(podVolume.ConfigMap, volumeCopy.Source.ConfigMap) {
 		r.Log.Info(
-			"Volume source updated", "old volume.source ",
-			podVolume.VolumeSource, "new volume.source", volume.Source,
+			"Volume source updated", "oldVolumeSource",
+			podVolume.VolumeSource, "newVolumeSource", volume.Source,
 		)
 
 		return true
@@ -1549,8 +1552,8 @@ func (r *SingleClusterReconciler) isStorageVolumeSourceUpdated(volume *asdbv1.Vo
 
 	if !reflect.DeepEqual(podVolume.EmptyDir, volumeCopy.Source.EmptyDir) {
 		r.Log.Info(
-			"Volume source updated", "old volume.source ",
-			podVolume.VolumeSource, "new volume.source", volume.Source,
+			"Volume source updated", "oldVolumeSource",
+			podVolume.VolumeSource, "newVolumeSource", volume.Source,
 		)
 
 		return true
@@ -1681,7 +1684,7 @@ func (r *SingleClusterReconciler) isVolumeAttachmentRemoved(
 				r.Log.Info(
 					"Volume for container."+
 						"volumeDevice removed from rack storage",
-					"container.volumeDevice", volumeDevice.Name,
+					"containerVolumeDevice", volumeDevice.Name,
 					"containerName", container.Name,
 				)
 
@@ -1708,7 +1711,7 @@ func (r *SingleClusterReconciler) isVolumeAttachmentRemoved(
 				r.Log.Info(
 					"Volume for container."+
 						"volumeMount removed from rack storage",
-					"container.volumeMount", volumeMount.Name, "containerName",
+					"containerVolumeMount", volumeMount.Name, "containerName",
 					container.Name,
 				)
 
@@ -1940,7 +1943,7 @@ func (r *SingleClusterReconciler) getPodsWithUpdatedConfigForRack(
 	if err != nil {
 		return nil, fmt.Errorf(
 			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -2236,7 +2239,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf("list pods for rack %d-%s in cluster %s: %w",
-				rackState.Rack.ID, rackState.Rack.Revision, utils.ClusterNamespacedName(r.aeroCluster), err),
+				rackState.Rack.ID, rackState.Rack.Revision, utils.GetNamespacedNameString(r.aeroCluster), err),
 		)
 	}
 
@@ -2268,7 +2271,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	if err != nil {
 		return common.ReconcileError(
 			fmt.Errorf("re-fetch pods for restart check on rack %d-%s in cluster %s: %w",
-				rackState.Rack.ID, rackState.Rack.Revision, utils.ClusterNamespacedName(r.aeroCluster), err),
+				rackState.Rack.ID, rackState.Rack.Revision, utils.GetNamespacedNameString(r.aeroCluster), err),
 		)
 	}
 

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -193,7 +193,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 		utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
 	if err := r.createSTSConfigMap(ctx, cmName, rackState.Rack); err != nil {
-		return nil, common.ReconcileError(fmt.Errorf("create configmap %s for rack %d: %w", cmName.String(), rackState.Rack.ID, err))
+		return nil, common.ReconcileError(fmt.Errorf("could not create ConfigMap %s for rack %d: %w", cmName.String(), rackState.Rack.ID, err))
 	}
 
 	stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
@@ -210,7 +210,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 			_ = r.deleteSTS(ctx, found)
 		}
 
-		return nil, common.ReconcileError(fmt.Errorf("create statefulset %s for rack %d: %w", stsName.String(), rackState.Rack.ID, err))
+		return nil, common.ReconcileError(fmt.Errorf("could not create StatefulSet %s for rack %d: %w", stsName.String(), rackState.Rack.ID, err))
 	}
 
 	r.Recorder.Eventf(
@@ -344,7 +344,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 			r.aeroCluster, utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision),
 		), rackState.Rack,
 	); err != nil {
-		return found, common.ReconcileError(fmt.Errorf("update configmap for rack %d: %w", rackState.Rack.ID, err))
+		return found, common.ReconcileError(fmt.Errorf("could not update ConfigMap for rack %d: %w", rackState.Rack.ID, err))
 	}
 
 	// Handle enable security just after updating configMap.
@@ -371,7 +371,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 					"[rack-%d] Failed to update image for StatefulSet %s",
 					rackState.Rack.ID, utils.GetNamespacedNameString(found),
 				)
-				res.Err = fmt.Errorf("upgrade rack %d statefulset %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
+				res.Err = fmt.Errorf("could not upgrade rack %d StatefulSet %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 			}
 
 			return found, res
@@ -394,7 +394,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 						"[rack-%d] Failed to roll StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
-					res.Err = fmt.Errorf("rolling restart rack %d statefulset %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
+					res.Err = fmt.Errorf("could not complete rolling restart for rack %d StatefulSet %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
 				return found, res
@@ -414,7 +414,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 						"[rack-%d] Failed to update dynamic config for StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
-					res.Err = fmt.Errorf("dynamic config update for rack %d statefulset %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
+					res.Err = fmt.Errorf("could not apply dynamic configuration update for rack %d StatefulSet %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
 				return found, res
@@ -460,7 +460,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"listing pods for rack %d in cluster %s: %w",
+			"could not list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		))
 	}
@@ -498,7 +498,7 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemovalForIgnorablePods(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"listing pods for rack %d in cluster %s: %w",
+			"could not list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		))
 	}
@@ -577,7 +577,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 				nil,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("could not revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -586,7 +586,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 	}
 
 	if err := r.updateAerospikeInitContainerImage(ctx, found); err != nil {
-		return common.ReconcileError(fmt.Errorf("update init container image for statefulset %s: %w", utils.GetNamespacedNameString(found), err))
+		return common.ReconcileError(fmt.Errorf("could not update init container image for StatefulSet %s: %w", utils.GetNamespacedNameString(found), err))
 	}
 
 	found, res = r.upgradeOrRollingRestartRack(ctx, found, rackState, ignorablePodNames, failedPods)
@@ -647,7 +647,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return found, common.ReconcileError(fmt.Errorf(
-			"listing pods for rack %d in cluster %s: %w",
+			"could not list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		))
 	}
@@ -680,7 +680,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	if err = r.cleanupDanglingPodsRack(ctx, found, rackState); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"running scale up pre-check for rack %d in cluster %s: %w",
+				"could not run scale-up pre-check for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
@@ -698,7 +698,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	if err = r.Update(ctx, found, common.UpdateOption); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"scaling up statefulset %s: %w", utils.GetNamespacedNameString(found), err,
+				"could not scale up StatefulSet %s: %w", utils.GetNamespacedNameString(found), err,
 			),
 		)
 	}
@@ -737,7 +737,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 		if err != nil {
 			return statefulSet, common.ReconcileError(
 				fmt.Errorf(
-					"listing pods for rack %d in cluster %s: %w",
+					"could not list pods for rack %d in cluster %s: %w",
 					rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 				),
 			)
@@ -755,7 +755,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 	err = r.updateSTS(ctx, statefulSet, rackState)
 	if err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("upgrading rack %d in cluster %s: %w", rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err),
+			fmt.Errorf("could not update StatefulSet spec for rack %d in cluster %s: %w", rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}
 
@@ -875,7 +875,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	oldPodList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return found, common.ReconcileError(fmt.Errorf(
-			"listing pods for rack %d in cluster %s: %w",
+			"could not list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		))
 	}
@@ -970,7 +970,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			ctx, policy, &rackState.Rack.AerospikeConfig, true, ignorablePodNames,
 		); !res.IsSuccess {
 			if res.Err != nil {
-				res.Err = fmt.Errorf("set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+				res.Err = fmt.Errorf("could not set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
 			}
 
 			return found, res
@@ -982,7 +982,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		ignorablePodNames,
 	); !res.IsSuccess {
 		if res.Err != nil {
-			res.Err = fmt.Errorf("wait for migration to complete for rack %d: %w", rackState.Rack.ID, res.Err)
+			res.Err = fmt.Errorf("could not wait for migrations to complete for rack %d: %w", rackState.Rack.ID, res.Err)
 		}
 
 		return found, res
@@ -997,7 +997,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"scaling statefulset %s to %d replicas: %w",
+				"could not scale StatefulSet %s to %d replicas: %w",
 				utils.GetNamespacedNameString(found), newSize, err,
 			),
 		)
@@ -1033,7 +1033,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			); err != nil {
 				return found, common.ReconcileError(
 					fmt.Errorf(
-						"scaling statefulset %s to %d replicas: %w",
+						"could not scale StatefulSet %s to %d replicas: %w",
 						utils.GetNamespacedNameString(found), newSize, err,
 					),
 				)
@@ -1052,7 +1052,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"getting statefulset for rack %d in cluster %s: %w",
+				"could not get StatefulSet for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
@@ -1065,7 +1065,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if err := r.cleanupPods(ctx, podNames, rackState); err != nil {
 		return nFound, common.ReconcileError(
 			fmt.Errorf(
-				"cleaning up pods %s: %w",
+				"could not clean up pods %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
 			),
 		)
@@ -1118,7 +1118,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
 			return found, common.ReconcileError(fmt.Errorf(
-				"listing pods for rack %d in cluster %s: %w",
+				"could not list pods for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			))
 		}
@@ -1127,7 +1127,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	err = r.updateSTS(ctx, found, rackState)
 	if err != nil {
 		return found, common.ReconcileError(
-			fmt.Errorf("rolling restart failed: %w", err),
+			fmt.Errorf("could not update StatefulSet before rolling restart: %w", err),
 		)
 	}
 
@@ -1219,7 +1219,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
 	if err := r.updateSTS(ctx, statefulSet, rackState); err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("k8s node block list processing failed: %w", err),
+			fmt.Errorf("could not apply Kubernetes node block list to StatefulSet: %w", err),
 		)
 	}
 
@@ -1235,7 +1235,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
 			return statefulSet, common.ReconcileError(fmt.Errorf(
-				"listing pods for rack %d in cluster %s: %w",
+				"could not list pods for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			))
 		}
@@ -1336,7 +1336,7 @@ func (r *SingleClusterReconciler) isRackUpgradeNeeded(
 ) {
 	podList, err := r.getRackPodList(ctx, rackID, rackRevision)
 	if err != nil {
-		return true, fmt.Errorf("listing pods for rack %d in cluster %s: %w", rackID, utils.ClusterNamespacedName(r.aeroCluster), err)
+		return true, fmt.Errorf("could not list pods for rack %d in cluster %s: %w", rackID, utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	for idx := range podList.Items {
@@ -1902,7 +1902,7 @@ func (r *SingleClusterReconciler) getPodsWithUpdatedConfigForRack(
 	ctx context.Context, rackState *RackState) ([]corev1.Pod, error) {
 	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return nil, fmt.Errorf("listing pods for rack %d in cluster %s: %w", rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
+		return nil, fmt.Errorf("could not list pods for rack %d in cluster %s: %w", rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	if len(pods) == 0 {
@@ -2193,7 +2193,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(
-			fmt.Errorf("listing pods for rack %d-%s in cluster %s: %w",
+			fmt.Errorf("could not list pods for rack %d-%s in cluster %s: %w",
 				rackState.Rack.ID, rackState.Rack.Revision, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}
@@ -2225,7 +2225,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(
-			fmt.Errorf("re-fetching pods for restart check on rack %d-%s in cluster %s: %w",
+			fmt.Errorf("could not re-fetch pods for restart check on rack %d-%s in cluster %s: %w",
 				rackState.Rack.ID, rackState.Rack.Revision, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -135,7 +135,7 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 		if res = r.deleteRacks(ctx, racksToDelete, ignorablePodNames); !res.IsSuccess {
 			if res.Err != nil {
 				res.Err = fmt.Errorf(
-					"could not remove StatefulSets for removed racks in cluster %s: %w",
+					"remove StatefulSets for removed racks in cluster %s: %w",
 					utils.ClusterNamespacedName(r.aeroCluster), res.Err,
 				)
 			}
@@ -478,7 +478,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"could not list pods for rack %d in cluster %s: %w",
+			"list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		))
 	}
@@ -516,7 +516,7 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemovalForIgnorablePods(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"could not list pods for rack %d in cluster %s: %w",
+			"list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		))
 	}
@@ -578,7 +578,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 					),
 				)
 				res.Err = fmt.Errorf(
-					"could not scale down StatefulSet %s for rack %d (current %d, desired %d replicas): %w",
+					"scale down StatefulSet %s for rack %d (current %d, desired %d replicas): %w",
 					utils.GetNamespacedNameString(found), rackState.Rack.ID, currentSize, desiredSize, res.Err,
 				)
 			}
@@ -633,7 +633,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 
 			if res.Err != nil {
 				res.Err = fmt.Errorf(
-					"could not scale up StatefulSet %s for rack %d (current %d, desired %d replicas): %w",
+					"scale up StatefulSet %s for rack %d (current %d, desired %d replicas): %w",
 					utils.GetNamespacedNameString(found), rackState.Rack.ID, currentSize, desiredSize, res.Err,
 				)
 			}
@@ -678,7 +678,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return found, common.ReconcileError(fmt.Errorf(
-			"could not list pods for rack %d in cluster %s: %w",
+			"list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		))
 	}
@@ -711,7 +711,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	if err = r.cleanupDanglingPodsRack(ctx, found, rackState); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"could not run scale-up pre-check for rack %d in cluster %s: %w",
+				"run scale-up pre-check for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
@@ -729,7 +729,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	if err = r.Update(ctx, found, common.UpdateOption); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"could not scale up StatefulSet %s: %w", utils.GetNamespacedNameString(found), err,
+				"scale up StatefulSet %s: %w", utils.GetNamespacedNameString(found), err,
 			),
 		)
 	}
@@ -768,7 +768,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 		if err != nil {
 			return statefulSet, common.ReconcileError(
 				fmt.Errorf(
-					"could not list pods for rack %d in cluster %s: %w",
+					"list pods for rack %d in cluster %s: %w",
 					rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 				),
 			)
@@ -907,7 +907,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	oldPodList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return found, common.ReconcileError(fmt.Errorf(
-			"could not list pods for rack %d in cluster %s: %w",
+			"list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		))
 	}
@@ -1030,7 +1030,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"could not scale StatefulSet %s to %d replicas: %w",
+				"scale StatefulSet %s to %d replicas: %w",
 				utils.GetNamespacedNameString(found), newSize, err,
 			),
 		)
@@ -1066,7 +1066,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			); err != nil {
 				return found, common.ReconcileError(
 					fmt.Errorf(
-						"could not scale StatefulSet %s to %d replicas: %w",
+						"scale StatefulSet %s to %d replicas: %w",
 						utils.GetNamespacedNameString(found), newSize, err,
 					),
 				)
@@ -1085,7 +1085,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"could not get StatefulSet for rack %d in cluster %s: %w",
+				"get StatefulSet for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
@@ -1098,7 +1098,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if err := r.cleanupPods(ctx, podNames, rackState); err != nil {
 		return nFound, common.ReconcileError(
 			fmt.Errorf(
-				"could not clean up pods %s: %w",
+				"clean up pods %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
 			),
 		)
@@ -1151,7 +1151,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
 			return found, common.ReconcileError(fmt.Errorf(
-				"could not list pods for rack %d in cluster %s: %w",
+				"list pods for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			))
 		}
@@ -1268,7 +1268,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
 			return statefulSet, common.ReconcileError(fmt.Errorf(
-				"could not list pods for rack %d in cluster %s: %w",
+				"list pods for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			))
 		}
@@ -1370,7 +1370,7 @@ func (r *SingleClusterReconciler) isRackUpgradeNeeded(
 	podList, err := r.getRackPodList(ctx, rackID, rackRevision)
 	if err != nil {
 		return true, fmt.Errorf(
-			"could not list pods for rack %d in cluster %s: %w",
+			"list pods for rack %d in cluster %s: %w",
 			rackID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -1840,7 +1840,7 @@ func (r *SingleClusterReconciler) getOrderedRackPodList(ctx context.Context, rac
 
 		if indexInt >= len(podList.Items) {
 			// Happens if we do not get full list of pods due to a crash,
-			return nil, fmt.Errorf("error get pod list for rack:%v, rackRevision:%v", rackID, rackRevision)
+			return nil, fmt.Errorf("list pods for rack %d revision %s: incomplete pod list", rackID, rackRevision)
 		}
 
 		sortedList[(len(podList.Items)-1)-indexInt] = &podList.Items[idx]
@@ -1939,7 +1939,7 @@ func (r *SingleClusterReconciler) getPodsWithUpdatedConfigForRack(
 	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"could not list pods for rack %d in cluster %s: %w",
+			"list pods for rack %d in cluster %s: %w",
 			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -14,6 +14,7 @@ import (
 	ls "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -176,9 +177,9 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 			// fall through,
 			// and might run reconcile steps common to all racks before the racks
 			// have scaled up.
-			r.Log.Error(
-				err, "Failed to wait for statefulset to be ready",
-				"STS", stsName,
+			r.Log.V(1).Info(
+				"StatefulSet not ready, will requeue", "statefulSet", klog.KObj(found),
+				"err", err,
 			)
 
 			return common.ReconcileRequeueAfter(1)
@@ -194,7 +195,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	r.Log.Info("Create new Aerospike cluster rack if needed")
 
 	// NoOp if already exist
-	r.Log.Info("AerospikeCluster", "Spec", r.aeroCluster.Spec)
+	r.Log.V(2).Info("AerospikeCluster", "Spec", r.aeroCluster.Spec)
 
 	// Bad config should not come here. It should be validated in validation hook
 	cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
@@ -211,7 +212,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	if err != nil {
 		r.Log.V(1).Info(
 			"Statefulset setup failed. Deleting statefulset", "name",
-			stsName, "err", err,
+			stsName,
 		)
 		// Delete statefulset and everything related so that it can be properly created and updated in next run
 		if found != nil {
@@ -490,7 +491,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 
 		restartType := restartTypeMap[pod.Name]
 		if restartType != noRestartUpdateConf {
-			r.Log.Info("This Pod doesn't need any update, Skip this", "pod", pod.Name)
+			r.Log.Info("This Pod doesn't need any update, Skip this", "pod", klog.KObj(pod))
 			continue
 		}
 
@@ -549,15 +550,15 @@ func (r *SingleClusterReconciler) reconcileRack(
 	ignorablePodNames sets.Set[string], failedPods []*corev1.Pod,
 ) common.ReconcileResult {
 	r.Log.Info(
-		"Reconcile existing Aerospike cluster statefulset", "stsName",
-		found.Name,
+		"Reconcile existing Aerospike cluster statefulset", "statefulSet",
+		klog.KObj(found),
 	)
 
 	var res common.ReconcileResult
 
 	r.Log.Info(
-		"Ensure rack StatefulSet size is the same as the spec", "stsName",
-		found.Name,
+		"Ensure rack StatefulSet size is the same as the spec", "statefulSet",
+		klog.KObj(found),
 	)
 
 	desiredSize := rackState.Size
@@ -795,15 +796,15 @@ func (r *SingleClusterReconciler) upgradeRack(
 
 	for idx := range podList {
 		pod := podList[idx]
-		r.Log.Info("Check if pod needs upgrade or not", "podName", pod.Name)
+		r.Log.Info("Check if pod needs upgrade or not", "pod", klog.KObj(pod))
 
 		if ignorablePodNames.Has(pod.Name) {
-			r.Log.Info("Pod found in ignore pod list, skipping", "podName", pod.Name)
+			r.Log.Info("Pod found in ignore pod list, skipping", "pod", klog.KObj(pod))
 			continue
 		}
 
 		if r.isPodUpgraded(pod) {
-			r.Log.Info("Pod doesn't need upgrade", "podName", pod.Name)
+			r.Log.Info("Pod doesn't need upgrade", "pod", klog.KObj(pod))
 			continue
 		}
 
@@ -1041,7 +1042,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if isAnyPodRunningAndReady {
 		// Wait for pods to get terminated
 		if err = r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
-			r.Log.Error(err, "Failed to wait for statefulset to be ready")
+			r.Log.V(1).Info("StatefulSet not ready, will requeue", "statefulSet", klog.KObj(found), "err", err)
 			return found, common.ReconcileRequeueAfter(1)
 		}
 
@@ -1055,9 +1056,9 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			newSize := *found.Spec.Replicas + utils.Len32(podsBatch)
 			found.Spec.Replicas = &newSize
 
-			r.Log.Error(
-				err, "Cluster validation failed, re-setting AerospikeCluster statefulset to previous size",
-				"size", newSize,
+			r.Log.V(1).Info(
+				"Cluster validation failed, re-setting AerospikeCluster statefulset to previous size",
+				"statefulSet", klog.KObj(found), "size", newSize, "err", err,
 			)
 
 			if err = r.Update(
@@ -1072,7 +1073,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			}
 
 			if err = r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
-				r.Log.Error(err, "Failed to wait for statefulset to be ready")
+				r.Log.V(1).Info("StatefulSet not ready after reset, will requeue", "statefulSet", klog.KObj(found), "err", err)
 			}
 
 			return found, common.ReconcileRequeueAfter(1)
@@ -1126,7 +1127,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	ignorablePodNames sets.Set[string], restartTypeMap map[string]RestartType,
 	failedPods []*corev1.Pod,
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
-	r.Log.Info("Rolling restart AerospikeCluster statefulset pods", "stsName", found.Name)
+	r.Log.Info("Rolling restart AerospikeCluster statefulset pods", "statefulSet", klog.KObj(found))
 
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackRollingRestart,
@@ -1174,13 +1175,13 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		pod := podList[idx]
 
 		if ignorablePodNames.Has(pod.Name) {
-			r.Log.Info("Pod found in ignore pod list, skipping", "podName", pod.Name)
+			r.Log.Info("Pod found in ignore pod list, skipping", "pod", klog.KObj(pod))
 			continue
 		}
 
 		restartType := restartTypeMap[pod.Name]
 		if restartType == noRestart || restartType == noRestartUpdateConf {
-			r.Log.Info("This Pod doesn't need rolling restart, Skip this", "pod", pod.Name)
+			r.Log.Info("This Pod doesn't need rolling restart, Skip this", "pod", klog.KObj(pod))
 			continue
 		}
 
@@ -1285,7 +1286,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 		if blockedK8sNodes.Has(pod.Spec.NodeName) {
 			r.Log.Info(
 				"Pod found in blocked nodes list, migrating to a different node",
-				"podName", pod.Name,
+				"pod", klog.KObj(pod),
 			)
 
 			podsToRestart = append(podsToRestart, pod)
@@ -1382,7 +1383,7 @@ func (r *SingleClusterReconciler) isRackUpgradeNeeded(
 		}
 
 		if !r.isPodOnDesiredImage(pod, true) {
-			r.Log.Info("Pod needs upgrade/downgrade", "podName", pod.Name)
+			r.Log.Info("Pod needs upgrade/downgrade", "pod", klog.KObj(pod))
 			return true, nil
 		}
 	}
@@ -2169,7 +2170,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 	if newReplicas > targetSize {
 		r.Log.Info(
 			"Migrating rack to new revisions: reconciling new revision STS to scale down",
-			"stsName", newSts.Name,
+			"statefulSet", klog.KObj(newSts),
 		)
 
 		tempState := &RackState{Rack: newRack.Rack, Size: targetSize}
@@ -2211,7 +2212,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		// Scale down old rack
 		podsToScaleDown := min(batchSizeInt32, oldReplicas)
 		r.Log.Info(
-			"Migrating rack: scaling down old revision STS by a batch", "stsName", oldSts.Name,
+			"Migrating rack: scaling down old revision STS by a batch", "statefulSet", klog.KObj(oldSts),
 			"batchSize", podsToScaleDown,
 		)
 

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -132,6 +132,13 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 	if len(r.aeroCluster.Status.RackConfig.Racks) != 0 {
 		// Remove removed racks
 		if res = r.deleteRacks(ctx, racksToDelete, ignorablePodNames); !res.IsSuccess {
+			if res.Err != nil {
+				res.Err = fmt.Errorf(
+					"could not remove StatefulSets for removed racks in cluster %s: %w",
+					utils.ClusterNamespacedName(r.aeroCluster), res.Err,
+				)
+			}
+
 			return res
 		}
 	}
@@ -193,7 +200,8 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 		utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
 	if err := r.createSTSConfigMap(ctx, cmName, rackState.Rack); err != nil {
-		return nil, common.ReconcileError(fmt.Errorf("could not create ConfigMap %s for rack %d: %w", cmName.String(), rackState.Rack.ID, err))
+		return nil, common.ReconcileError(fmt.Errorf("could not create ConfigMap %s for rack %d: %w",
+			cmName.String(), rackState.Rack.ID, err))
 	}
 
 	stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
@@ -201,6 +209,10 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 
 	found, err := r.createSTS(ctx, stsName, rackState)
 	if err != nil {
+		r.Log.V(1).Info(
+			"Statefulset setup failed. Deleting statefulset", "name",
+			stsName, "err", err,
+		)
 		// Delete statefulset and everything related so that it can be properly created and updated in next run
 		if found != nil {
 			r.Log.V(1).Info(
@@ -210,7 +222,8 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 			_ = r.deleteSTS(ctx, found)
 		}
 
-		return nil, common.ReconcileError(fmt.Errorf("could not create StatefulSet %s for rack %d: %w", stsName.String(), rackState.Rack.ID, err))
+		return nil, common.ReconcileError(fmt.Errorf("could not create StatefulSet %s for rack %d: %w",
+			stsName.String(), rackState.Rack.ID, err))
 	}
 
 	r.Recorder.Eventf(
@@ -344,7 +357,8 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 			r.aeroCluster, utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision),
 		), rackState.Rack,
 	); err != nil {
-		return found, common.ReconcileError(fmt.Errorf("could not update ConfigMap for rack %d: %w", rackState.Rack.ID, err))
+		return found, common.ReconcileError(fmt.Errorf("could not update ConfigMap for rack %d, stsName %s: %w",
+			rackState.Rack.ID, utils.GetNamespacedNameString(found), err))
 	}
 
 	// Handle enable security just after updating configMap.
@@ -371,7 +385,8 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 					"[rack-%d] Failed to update image for StatefulSet %s",
 					rackState.Rack.ID, utils.GetNamespacedNameString(found),
 				)
-				res.Err = fmt.Errorf("could not upgrade rack %d StatefulSet %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
+				res.Err = fmt.Errorf("could not upgrade rack %d StatefulSet %s: %w",
+					rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 			}
 
 			return found, res
@@ -394,7 +409,8 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 						"[rack-%d] Failed to roll StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
-					res.Err = fmt.Errorf("could not complete rolling restart for rack %d StatefulSet %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
+					res.Err = fmt.Errorf("could not complete rolling restart for rack %d StatefulSet %s: %w",
+						rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
 				return found, res
@@ -414,7 +430,8 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 						"[rack-%d] Failed to update dynamic config for StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
-					res.Err = fmt.Errorf("could not apply dynamic configuration update for rack %d StatefulSet %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
+					res.Err = fmt.Errorf("could not apply dynamic configuration update for rack %d StatefulSet %s: %w",
+						rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
 				return found, res
@@ -554,10 +571,14 @@ func (r *SingleClusterReconciler) reconcileRack(
 				r.Recorder.Eventf(
 					r.aeroCluster, corev1.EventTypeWarning,
 					EventReasonRackScaleDownFailed,
-					eventRackScaleFailureMessage(
-						"scale down", rackState.Rack.ID, "StatefulSet",
-						utils.GetNamespacedNameString(found), currentSize, desiredSize,
+					eventRackScaleFailureMessageWithCause(
+						"scale down", rackState.Rack.ID,
+						utils.GetNamespacedNameString(found), currentSize, desiredSize, res.Err,
 					),
+				)
+				res.Err = fmt.Errorf(
+					"could not scale down StatefulSet %s for rack %d (current %d, desired %d replicas): %w",
+					utils.GetNamespacedNameString(found), rackState.Rack.ID, currentSize, desiredSize, res.Err,
 				)
 			}
 
@@ -577,7 +598,8 @@ func (r *SingleClusterReconciler) reconcileRack(
 				nil,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("could not revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+					res.Err = fmt.Errorf("could not revert migrate-fill-delay after scale down for rack %d: %w",
+						rackState.Rack.ID, res.Err)
 				}
 
 				return res
@@ -586,7 +608,8 @@ func (r *SingleClusterReconciler) reconcileRack(
 	}
 
 	if err := r.updateAerospikeInitContainerImage(ctx, found); err != nil {
-		return common.ReconcileError(fmt.Errorf("could not update init container image for StatefulSet %s: %w", utils.GetNamespacedNameString(found), err))
+		return common.ReconcileError(fmt.Errorf("could not update init container image for StatefulSet %s: %w",
+			utils.GetNamespacedNameString(found), err))
 	}
 
 	found, res = r.upgradeOrRollingRestartRack(ctx, found, rackState, ignorablePodNames, failedPods)
@@ -601,11 +624,18 @@ func (r *SingleClusterReconciler) reconcileRack(
 		if !res.IsSuccess {
 			r.Recorder.Eventf(
 				r.aeroCluster, corev1.EventTypeWarning, EventReasonRackScaleUpFailed,
-				eventRackScaleFailureMessage(
-					"scale up", rackState.Rack.ID, "StatefulSet",
-					utils.GetNamespacedNameString(found), currentSize, desiredSize,
+				eventRackScaleFailureMessageWithCause(
+					"scale up", rackState.Rack.ID,
+					utils.GetNamespacedNameString(found), currentSize, desiredSize, res.Err,
 				),
 			)
+
+			if res.Err != nil {
+				res.Err = fmt.Errorf(
+					"could not scale up StatefulSet %s for rack %d (current %d, desired %d replicas): %w",
+					utils.GetNamespacedNameString(found), rackState.Rack.ID, currentSize, desiredSize, res.Err,
+				)
+			}
 
 			return res
 		}
@@ -637,7 +667,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaleUp,
 		eventRackScaleMessage(
-			"Scaling up", rackState.Rack.ID, "StatefulSet",
+			"Scaling up", rackState.Rack.ID,
 			utils.GetNamespacedNameString(found), oldSz, desiredSize,
 		),
 	)
@@ -712,7 +742,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaledUp,
 		eventRackScaleMessage(
-			"Scaled up", rackState.Rack.ID, "StatefulSet",
+			"Scaled up", rackState.Rack.ID,
 			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
 		),
 	)
@@ -755,7 +785,8 @@ func (r *SingleClusterReconciler) upgradeRack(
 	err = r.updateSTS(ctx, statefulSet, rackState)
 	if err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("could not update StatefulSet spec for rack %d in cluster %s: %w", rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err),
+			fmt.Errorf("could not update StatefulSet spec for rack %d in cluster %s: %w",
+				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}
 
@@ -867,7 +898,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaleDown,
 		eventRackScaleMessage(
-			"Scaling down", rackState.Rack.ID, "StatefulSet",
+			"Scaling down", rackState.Rack.ID,
 			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
 		),
 	)
@@ -982,7 +1013,8 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		ignorablePodNames,
 	); !res.IsSuccess {
 		if res.Err != nil {
-			res.Err = fmt.Errorf("could not wait for migrations to complete for rack %d: %w", rackState.Rack.ID, res.Err)
+			res.Err = fmt.Errorf("could not wait for migrations to complete before deleting pods for rack %d: %w",
+				rackState.Rack.ID, res.Err)
 		}
 
 		return found, res
@@ -1081,7 +1113,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaledDown,
 		eventRackScaleMessage(
-			"Scaled down", rackState.Rack.ID, "StatefulSet",
+			"Scaled down", rackState.Rack.ID,
 			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
 		),
 	)
@@ -1127,7 +1159,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	err = r.updateSTS(ctx, found, rackState)
 	if err != nil {
 		return found, common.ReconcileError(
-			fmt.Errorf("could not update StatefulSet before rolling restart: %w", err),
+			fmt.Errorf("rolling restart failed: %w", err),
 		)
 	}
 
@@ -1219,7 +1251,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
 	if err := r.updateSTS(ctx, statefulSet, rackState); err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("could not apply Kubernetes node block list to StatefulSet: %w", err),
+			fmt.Errorf("k8s node block list processing failed: %w", err),
 		)
 	}
 
@@ -1336,7 +1368,10 @@ func (r *SingleClusterReconciler) isRackUpgradeNeeded(
 ) {
 	podList, err := r.getRackPodList(ctx, rackID, rackRevision)
 	if err != nil {
-		return true, fmt.Errorf("could not list pods for rack %d in cluster %s: %w", rackID, utils.ClusterNamespacedName(r.aeroCluster), err)
+		return true, fmt.Errorf(
+			"could not list pods for rack %d in cluster %s: %w",
+			rackID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	for idx := range podList.Items {
@@ -1902,7 +1937,10 @@ func (r *SingleClusterReconciler) getPodsWithUpdatedConfigForRack(
 	ctx context.Context, rackState *RackState) ([]corev1.Pod, error) {
 	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return nil, fmt.Errorf("could not list pods for rack %d in cluster %s: %w", rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
+		return nil, fmt.Errorf(
+			"could not list pods for rack %d in cluster %s: %w",
+			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	if len(pods) == 0 {
@@ -2178,7 +2216,10 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		)
 
 		tempState := &RackState{Rack: oldRack.Rack, Size: oldReplicas - podsToScaleDown}
-		_, res := r.scaleDownRack(ctx, oldSts, tempState, ignorablePodNames, r.aeroCluster.Spec.RackConfig.RollingUpdateBatchSize)
+		_, res := r.scaleDownRack(
+			ctx, oldSts, tempState, ignorablePodNames,
+			r.aeroCluster.Spec.RackConfig.RollingUpdateBatchSize,
+		)
 
 		return res
 	}

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -193,7 +193,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 		utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
 	if err := r.createSTSConfigMap(ctx, cmName, rackState.Rack); err != nil {
-		return nil, common.ReconcileError(err)
+		return nil, common.ReconcileError(fmt.Errorf("create configmap %s for rack %d: %w", cmName.String(), rackState.Rack.ID, err))
 	}
 
 	stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
@@ -210,7 +210,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 			_ = r.deleteSTS(ctx, found)
 		}
 
-		return nil, common.ReconcileError(err)
+		return nil, common.ReconcileError(fmt.Errorf("create statefulset %s for rack %d: %w", stsName.String(), rackState.Rack.ID, err))
 	}
 
 	r.Recorder.Eventf(
@@ -344,7 +344,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 			r.aeroCluster, utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision),
 		), rackState.Rack,
 	); err != nil {
-		return found, common.ReconcileError(err)
+		return found, common.ReconcileError(fmt.Errorf("update configmap for rack %d: %w", rackState.Rack.ID, err))
 	}
 
 	// Handle enable security just after updating configMap.
@@ -371,6 +371,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 					"[rack-%d] Failed to update image for StatefulSet %s",
 					rackState.Rack.ID, utils.GetNamespacedNameString(found),
 				)
+				res.Err = fmt.Errorf("upgrade rack %d statefulset %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 			}
 
 			return found, res
@@ -393,6 +394,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 						"[rack-%d] Failed to roll StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
+					res.Err = fmt.Errorf("rolling restart rack %d statefulset %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
 				return found, res
@@ -412,6 +414,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 						"[rack-%d] Failed to update dynamic config for StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
+					res.Err = fmt.Errorf("dynamic config update for rack %d statefulset %s: %w", rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
 				return found, res
@@ -573,13 +576,17 @@ func (r *SingleClusterReconciler) reconcileRack(
 				ctx, r.getClientPolicy(ctx), &rackState.Rack.AerospikeConfig, false,
 				nil,
 			); !res.IsSuccess {
+				if res.Err != nil {
+					res.Err = fmt.Errorf("revert migrate-fill-delay for rack %d: %w", rackState.Rack.ID, res.Err)
+				}
+
 				return res
 			}
 		}
 	}
 
 	if err := r.updateAerospikeInitContainerImage(ctx, found); err != nil {
-		return common.ReconcileError(err)
+		return common.ReconcileError(fmt.Errorf("update init container image for statefulset %s: %w", utils.GetNamespacedNameString(found), err))
 	}
 
 	found, res = r.upgradeOrRollingRestartRack(ctx, found, rackState, ignorablePodNames, failedPods)
@@ -962,6 +969,10 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		if res := r.setMigrateFillDelay(
 			ctx, policy, &rackState.Rack.AerospikeConfig, true, ignorablePodNames,
 		); !res.IsSuccess {
+			if res.Err != nil {
+				res.Err = fmt.Errorf("set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+			}
+
 			return found, res
 		}
 	}
@@ -970,10 +981,9 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if res := r.waitForMigrationToComplete(ctx, policy,
 		ignorablePodNames,
 	); !res.IsSuccess {
-		r.Log.Error(
-			res.Err, "Failed to wait for migration to complete before deleting pods",
-			"rackID", rackState.Rack.ID,
-		)
+		if res.Err != nil {
+			res.Err = fmt.Errorf("wait for migration to complete for rack %d: %w", rackState.Rack.ID, res.Err)
+		}
 
 		return found, res
 	}

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -33,7 +33,7 @@ type revisionChangedRack struct {
 	newRack *RackState
 }
 
-func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
+func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.ReconcileResult {
 	r.Log.Info("Reconciling rack for AerospikeCluster")
 
 	var (
@@ -41,12 +41,12 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		res                common.ReconcileResult
 	)
 
-	configuredRacks, revisionChangedRacks, racksToDelete, err := r.categoriseRacks()
+	configuredRacks, revisionChangedRacks, racksToDelete, err := r.categoriseRacks(ctx)
 	if err != nil {
 		return common.ReconcileError(err)
 	}
 
-	ignorablePodNames, err := r.getIgnorablePods(racksToDelete, configuredRacks)
+	ignorablePodNames, err := r.getIgnorablePods(ctx, racksToDelete, configuredRacks, revisionChangedRacks)
 	if err != nil {
 		return common.ReconcileError(err)
 	}
@@ -63,7 +63,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 			utils.GetRackIdentifier(state.Rack.ID, state.Rack.Revision))
 
-		if err = r.Get(context.TODO(), stsName, found); err != nil {
+		if err = r.Get(ctx, stsName, found); err != nil {
 			if !errors.IsNotFound(err) {
 				return common.ReconcileError(err)
 			}
@@ -72,7 +72,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		}
 
 		// Handle failed pods for this rack (two-pass: reconcile then restart if not recovered)
-		if res = r.handleFailedPodsInRack(found, state, ignorablePodNames); !res.IsSuccess {
+		if res = r.handleFailedPodsInRack(ctx, found, state, ignorablePodNames); !res.IsSuccess {
 			return res
 		}
 	}
@@ -81,7 +81,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		state := &configuredRacks[idx]
 
 		if revisionChangedRackInfo, ok := revisionChangedRacks[state.Rack.ID]; ok {
-			if res = r.reconcileRevisionChangedRacks(revisionChangedRackInfo, ignorablePodNames); !res.IsSuccess {
+			if res = r.reconcileRevisionChangedRacks(ctx, revisionChangedRackInfo, ignorablePodNames); !res.IsSuccess {
 				return res
 			}
 
@@ -92,7 +92,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 			utils.GetRackIdentifier(state.Rack.ID, state.Rack.Revision))
 
-		if err = r.Get(context.TODO(), stsName, found); err != nil {
+		if err = r.Get(ctx, stsName, found); err != nil {
 			if !errors.IsNotFound(err) {
 				return common.ReconcileError(err)
 			}
@@ -100,7 +100,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 			// Create statefulset with 0 size rack and then scaleUp later in Reconcile
 			zeroSizedRack := &RackState{Rack: state.Rack, Size: 0}
 
-			found, res = r.createEmptyRack(zeroSizedRack)
+			found, res = r.createEmptyRack(ctx, zeroSizedRack)
 			if !res.IsSuccess {
 				return res
 			}
@@ -112,7 +112,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		} else {
 			// Reconcile other statefulset
 			if res = r.reconcileRack(
-				found, state, ignorablePodNames, nil,
+				ctx, found, state, ignorablePodNames, nil,
 			); !res.IsSuccess {
 				return res
 			}
@@ -124,21 +124,14 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		state := scaledDownRackList[idx].rackState
 		sts := scaledDownRackList[idx].rackSTS
 
-		if res = r.reconcileRack(sts, state, ignorablePodNames, nil); !res.IsSuccess {
+		if res = r.reconcileRack(ctx, sts, state, ignorablePodNames, nil); !res.IsSuccess {
 			return res
 		}
 	}
 
 	if len(r.aeroCluster.Status.RackConfig.Racks) != 0 {
 		// Remove removed racks
-		if res = r.deleteRacks(racksToDelete, ignorablePodNames); !res.IsSuccess {
-			if res.Err != nil {
-				r.Log.Error(
-					err, "Failed to remove statefulset for removed racks",
-					"err", res.Err,
-				)
-			}
-
+		if res = r.deleteRacks(ctx, racksToDelete, ignorablePodNames); !res.IsSuccess {
 			return res
 		}
 	}
@@ -153,14 +146,14 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 			utils.GetRackIdentifier(state.Rack.ID, state.Rack.Revision))
 
-		if err := r.Get(context.TODO(), stsName, found); err != nil {
+		if err := r.Get(ctx, stsName, found); err != nil {
 			if !errors.IsNotFound(err) {
 				return common.ReconcileError(err)
 			}
 
 			// Create statefulset with 0 size rack and then scaleUp later in Reconcile
 			zeroSizedRack := &RackState{Rack: state.Rack, Size: 0}
-			found, res = r.createEmptyRack(zeroSizedRack)
+			found, res = r.createEmptyRack(ctx, zeroSizedRack)
 
 			if !res.IsSuccess {
 				return res
@@ -168,7 +161,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 		}
 
 		// Wait for pods to be ready.
-		if err := r.waitForSTSToBeReady(found, ignorablePodNames); err != nil {
+		if err := r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
 			// If the wait times out try again.
 			// The wait is required in cases where scale up waits for a pod to
 			// terminate times out and event is re-queued.
@@ -188,7 +181,7 @@ func (r *SingleClusterReconciler) reconcileRacks() common.ReconcileResult {
 	return common.ReconcileSuccess()
 }
 
-func (r *SingleClusterReconciler) createEmptyRack(rackState *RackState) (
+func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState *RackState) (
 	*appsv1.StatefulSet, common.ReconcileResult,
 ) {
 	r.Log.Info("Create new Aerospike cluster rack if needed")
@@ -199,15 +192,14 @@ func (r *SingleClusterReconciler) createEmptyRack(rackState *RackState) (
 	// Bad config should not come here. It should be validated in validation hook
 	cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 		utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
-	if err := r.createSTSConfigMap(cmName, rackState.Rack); err != nil {
-		r.Log.Error(err, "Failed to create configMap from AerospikeConfig")
+	if err := r.createSTSConfigMap(ctx, cmName, rackState.Rack); err != nil {
 		return nil, common.ReconcileError(err)
 	}
 
 	stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 		utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
 
-	found, err := r.createSTS(stsName, rackState)
+	found, err := r.createSTS(ctx, stsName, rackState)
 	if err != nil {
 		// Delete statefulset and everything related so that it can be properly created and updated in next run
 		if found != nil {
@@ -215,7 +207,7 @@ func (r *SingleClusterReconciler) createEmptyRack(rackState *RackState) (
 				"Statefulset setup failed. Deleting statefulset", "name",
 				stsName,
 			)
-			_ = r.deleteSTS(found)
+			_ = r.deleteSTS(ctx, found)
 		}
 
 		return nil, common.ReconcileError(err)
@@ -246,10 +238,10 @@ func getRacksToBeBlockedFromRoster(log logger, rackStateList []RackState) []asdb
 	return racksToBlock
 }
 
-func (r *SingleClusterReconciler) getRacksToDelete(rackStateList []RackState) (
+func (r *SingleClusterReconciler) getRacksToDelete(ctx context.Context, rackStateList []RackState) (
 	[]asdbv1.Rack, error,
 ) {
-	oldRacks, err := r.getCurrentRackList()
+	oldRacks, err := r.getCurrentRackList(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +267,7 @@ func (r *SingleClusterReconciler) getRacksToDelete(rackStateList []RackState) (
 }
 
 func (r *SingleClusterReconciler) deleteRacks(
-	racksToDelete []asdbv1.Rack, ignorablePodNames sets.Set[string],
+	ctx context.Context, racksToDelete []asdbv1.Rack, ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
 	for idx := range racksToDelete {
 		rack := &racksToDelete[idx]
@@ -284,7 +276,7 @@ func (r *SingleClusterReconciler) deleteRacks(
 			r.aeroCluster, utils.GetRackIdentifier(rack.ID, rack.Revision),
 		)
 
-		err := r.Get(context.TODO(), stsName, found)
+		err := r.Get(ctx, stsName, found)
 		if err != nil {
 			// If not found, then go to the next
 			if errors.IsNotFound(err) {
@@ -297,13 +289,13 @@ func (r *SingleClusterReconciler) deleteRacks(
 		// TODO: Add option for quick delete of rack. DefaultRackID should always be removed gracefully
 		rackState := &RackState{Size: 0, Rack: rack}
 
-		found, res := r.scaleDownRack(found, rackState, ignorablePodNames, nil)
+		found, res := r.scaleDownRack(ctx, found, rackState, ignorablePodNames, nil)
 		if !res.IsSuccess {
 			return res
 		}
 
 		// Delete sts
-		if err = r.deleteSTS(found); err != nil {
+		if err = r.deleteSTS(ctx, found); err != nil {
 			r.Recorder.Eventf(
 				r.aeroCluster, corev1.EventTypeWarning, "STSDeleteFailed",
 				"[rack-%d] Failed to delete {STS: %s/%s}", rack.ID,
@@ -316,13 +308,13 @@ func (r *SingleClusterReconciler) deleteRacks(
 		// Delete configMap
 		cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 			utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
-		if err = r.deleteRackConfigMap(cmName); err != nil {
+		if err = r.deleteRackConfigMap(ctx, cmName); err != nil {
 			return common.ReconcileError(err)
 		}
 
 		// Rack cleanup is done. Take time and cleanup dangling nodes and related resources that may not have been
 		// cleaned up previously due to errors.
-		if err = r.cleanupDanglingPodsRack(found, rackState); err != nil {
+		if err = r.cleanupDanglingPodsRack(ctx, found, rackState); err != nil {
 			return common.ReconcileError(err)
 		}
 
@@ -336,7 +328,7 @@ func (r *SingleClusterReconciler) deleteRacks(
 }
 
 func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
-	found *appsv1.StatefulSet, rackState *RackState,
+	ctx context.Context, found *appsv1.StatefulSet, rackState *RackState,
 	ignorablePodNames sets.Set[string], failedPods []*corev1.Pod,
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
 	var res common.ReconcileResult
@@ -347,15 +339,11 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 	// So a check based on spec and status will skip configMap update.
 	// Hence, a rolling restart of pod will never bring pod to desired config
 	if err := r.updateSTSConfigMap(
+		ctx,
 		utils.GetNamespacedNameForSTSOrConfigMap(
 			r.aeroCluster, utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision),
 		), rackState.Rack,
 	); err != nil {
-		r.Log.Error(
-			err, "Failed to update configMap from AerospikeConfig", "stsName",
-			found.Name,
-		)
-
 		return found, common.ReconcileError(err)
 	}
 
@@ -363,25 +351,20 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 	// This code will run only when security is being enabled in an existing cluster
 	// Update for security is verified by checking the config hash of the pod with the
 	// config hash present in config map
-	if err := r.handleEnableSecurity(rackState, ignorablePodNames); err != nil {
+	if err := r.handleEnableSecurity(ctx, rackState, ignorablePodNames); err != nil {
 		return found, common.ReconcileError(err)
 	}
 
 	// Upgrade
-	upgradeNeeded, err := r.isRackUpgradeNeeded(rackState.Rack.ID, rackState.Rack.Revision, ignorablePodNames)
+	upgradeNeeded, err := r.isRackUpgradeNeeded(ctx, rackState.Rack.ID, rackState.Rack.Revision, ignorablePodNames)
 	if err != nil {
 		return found, common.ReconcileError(err)
 	}
 
 	if upgradeNeeded {
-		found, res = r.upgradeRack(found, rackState, ignorablePodNames, failedPods)
+		found, res = r.upgradeRack(ctx, found, rackState, ignorablePodNames, failedPods)
 		if !res.IsSuccess {
 			if res.Err != nil {
-				r.Log.Error(
-					res.Err, "Failed to update StatefulSet image", "stsName",
-					found.Name,
-				)
-
 				r.Recorder.Eventf(
 					r.aeroCluster, corev1.EventTypeWarning,
 					"RackImageUpdateFailed",
@@ -393,22 +376,17 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 			return found, res
 		}
 	} else {
-		var rollingRestartInfo, nErr = r.getRollingRestartInfo(rackState, ignorablePodNames)
+		var rollingRestartInfo, nErr = r.getRollingRestartInfo(ctx, rackState, ignorablePodNames)
 		if nErr != nil {
 			return found, common.ReconcileError(nErr)
 		}
 
 		if rollingRestartInfo.needRestart {
 			found, res = r.rollingRestartRack(
-				found, rackState, ignorablePodNames, rollingRestartInfo.restartTypeMap, failedPods,
+				ctx, found, rackState, ignorablePodNames, rollingRestartInfo.restartTypeMap, failedPods,
 			)
 			if !res.IsSuccess {
 				if res.Err != nil {
-					r.Log.Error(
-						res.Err, "Failed to do rolling restart", "stsName",
-						found.Name,
-					)
-
 					r.Recorder.Eventf(
 						r.aeroCluster, corev1.EventTypeWarning,
 						"RackRollingRestartFailed",
@@ -423,16 +401,11 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 
 		if len(failedPods) == 0 && rollingRestartInfo.needUpdateConf {
 			res = r.updateDynamicConfig(
-				rackState, ignorablePodNames,
+				ctx, rackState, ignorablePodNames,
 				rollingRestartInfo.restartTypeMap, rollingRestartInfo.dynamicConfDiffPerPod,
 			)
 			if !res.IsSuccess {
 				if res.Err != nil {
-					r.Log.Error(
-						res.Err, "Failed to do dynamic update", "stsName",
-						found.Name,
-					)
-
 					r.Recorder.Eventf(
 						r.aeroCluster, corev1.EventTypeWarning,
 						"RackDynamicConfigUpdateFailed",
@@ -447,14 +420,14 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 	}
 
 	if r.aeroCluster.Spec.RackConfig.MaxIgnorablePods != nil {
-		if res = r.handleNSOrDeviceRemovalForIgnorablePods(rackState, ignorablePodNames); !res.IsSuccess {
+		if res = r.handleNSOrDeviceRemovalForIgnorablePods(ctx, rackState, ignorablePodNames); !res.IsSuccess {
 			return found, res
 		}
 	}
 
 	// handle k8sNodeBlockList pods only if it is changed
 	if !reflect.DeepEqual(r.aeroCluster.Spec.K8sNodeBlockList, r.aeroCluster.Status.K8sNodeBlockList) {
-		found, res = r.handleK8sNodeBlockListPods(found, rackState, ignorablePodNames, failedPods)
+		found, res = r.handleK8sNodeBlockListPods(ctx, found, rackState, ignorablePodNames, failedPods)
 		if !res.IsSuccess {
 			return found, res
 		}
@@ -464,7 +437,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 }
 
 func (r *SingleClusterReconciler) updateDynamicConfig(
-	rackState *RackState,
+	ctx context.Context, rackState *RackState,
 	ignorablePodNames sets.Set[string], restartTypeMap map[string]RestartType,
 	dynamicConfDiffPerPod map[string]asconfig.DynamicConfigMap,
 ) common.ReconcileResult {
@@ -481,9 +454,12 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	)
 
 	// List the pods for this aeroCluster's statefulset
-	podList, err = r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+	podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return common.ReconcileError(fmt.Errorf("failed to list pods: %v", err))
+		return common.ReconcileError(fmt.Errorf(
+			"listing pods for rack %d in cluster %s: %w",
+			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		))
 	}
 
 	// Find pods which needs restart
@@ -501,7 +477,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 		podsToUpdate = append(podsToUpdate, pod)
 	}
 
-	if res := r.setDynamicConfig(dynamicConfDiffPerPod, podsToUpdate, ignorablePodNames); !res.IsSuccess {
+	if res := r.setDynamicConfig(ctx, dynamicConfDiffPerPod, podsToUpdate, ignorablePodNames); !res.IsSuccess {
 		return res
 	}
 
@@ -514,11 +490,14 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 }
 
 func (r *SingleClusterReconciler) handleNSOrDeviceRemovalForIgnorablePods(
-	rackState *RackState, ignorablePodNames sets.Set[string],
+	ctx context.Context, rackState *RackState, ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
-	podList, err := r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return common.ReconcileError(fmt.Errorf("failed to list pods: %v", err))
+		return common.ReconcileError(fmt.Errorf(
+			"listing pods for rack %d in cluster %s: %w",
+			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		))
 	}
 	// Filter ignoredPods to update their dirtyVolumes in the status.
 	// IgnoredPods are skipped from upgrade/rolling restart, and as a result in case of device removal, dirtyVolumes
@@ -537,7 +516,7 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemovalForIgnorablePods(
 	}
 
 	if len(ignoredPod) > 0 {
-		if err := r.handleNSOrDeviceRemoval(rackState, ignoredPod); err != nil {
+		if err := r.handleNSOrDeviceRemoval(ctx, rackState, ignoredPod); err != nil {
 			return common.ReconcileError(err)
 		}
 	}
@@ -546,7 +525,8 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemovalForIgnorablePods(
 }
 
 func (r *SingleClusterReconciler) reconcileRack(
-	found *appsv1.StatefulSet, rackState *RackState, ignorablePodNames sets.Set[string], failedPods []*corev1.Pod,
+	ctx context.Context, found *appsv1.StatefulSet, rackState *RackState,
+	ignorablePodNames sets.Set[string], failedPods []*corev1.Pod,
 ) common.ReconcileResult {
 	r.Log.Info(
 		"Reconcile existing Aerospike cluster statefulset", "stsName",
@@ -565,14 +545,9 @@ func (r *SingleClusterReconciler) reconcileRack(
 
 	// Scale down
 	if currentSize > desiredSize {
-		found, res = r.scaleDownRack(found, rackState, ignorablePodNames, nil)
+		found, res = r.scaleDownRack(ctx, found, rackState, ignorablePodNames, nil)
 		if !res.IsSuccess {
 			if res.Err != nil {
-				r.Log.Error(
-					res.Err, "Failed to scaleDown StatefulSet pods", "stsName",
-					found.Name,
-				)
-
 				r.Recorder.Eventf(
 					r.aeroCluster, corev1.EventTypeWarning,
 					"RackScaleDownFailed",
@@ -594,25 +569,19 @@ func (r *SingleClusterReconciler) reconcileRack(
 		if (r.aeroCluster.Status.Size > r.aeroCluster.Spec.Size) ||
 			(!r.IsStatusEmpty() && len(r.aeroCluster.Status.RackConfig.Racks) != len(r.aeroCluster.Spec.RackConfig.Racks)) {
 			if res = r.setMigrateFillDelay(
-				r.getClientPolicy(), &rackState.Rack.AerospikeConfig, false,
+				ctx, r.getClientPolicy(ctx), &rackState.Rack.AerospikeConfig, false,
 				nil,
 			); !res.IsSuccess {
-				r.Log.Error(res.Err, "Failed to revert migrate-fill-delay after scale down")
 				return res
 			}
 		}
 	}
 
-	if err := r.updateAerospikeInitContainerImage(found); err != nil {
-		r.Log.Error(
-			err, "Failed to update Aerospike Init container", "stsName",
-			found.Name,
-		)
-
+	if err := r.updateAerospikeInitContainerImage(ctx, found); err != nil {
 		return common.ReconcileError(err)
 	}
 
-	found, res = r.upgradeOrRollingRestartRack(found, rackState, ignorablePodNames, failedPods)
+	found, res = r.upgradeOrRollingRestartRack(ctx, found, rackState, ignorablePodNames, failedPods)
 	if !res.IsSuccess {
 		return res
 	}
@@ -620,13 +589,8 @@ func (r *SingleClusterReconciler) reconcileRack(
 	// Scale up after upgrading, so that new pods come up with new image
 	currentSize = *found.Spec.Replicas
 	if currentSize < desiredSize {
-		found, res = r.scaleUpRack(found, rackState, ignorablePodNames)
+		found, res = r.scaleUpRack(ctx, found, rackState, ignorablePodNames)
 		if !res.IsSuccess {
-			r.Log.Error(
-				res.Err, "Failed to scaleUp StatefulSet pods", "stsName",
-				found.Name,
-			)
-
 			r.Recorder.Eventf(
 				r.aeroCluster, corev1.EventTypeWarning, "RackScaleUpFailed",
 				"[rack-%d] Failed to scale-up {STS %s/%s, currentSize: %d desiredSize: %d}: %s",
@@ -640,11 +604,11 @@ func (r *SingleClusterReconciler) reconcileRack(
 
 	// All regular operations are complete. Take time and cleanup dangling nodes that have not been cleaned up
 	// previously due to errors.
-	if err := r.cleanupDanglingPodsRack(found, rackState); err != nil {
+	if err := r.cleanupDanglingPodsRack(ctx, found, rackState); err != nil {
 		return common.ReconcileError(err)
 	}
 
-	if err := r.reconcilePodService(rackState); err != nil {
+	if err := r.reconcilePodService(ctx, rackState); err != nil {
 		return common.ReconcileError(err)
 	}
 
@@ -652,7 +616,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 }
 
 func (r *SingleClusterReconciler) scaleUpRack(
-	found *appsv1.StatefulSet, rackState *RackState, ignorablePodNames sets.Set[string],
+	ctx context.Context, found *appsv1.StatefulSet, rackState *RackState, ignorablePodNames sets.Set[string],
 ) (
 	*appsv1.StatefulSet, common.ReconcileResult,
 ) {
@@ -669,13 +633,18 @@ func (r *SingleClusterReconciler) scaleUpRack(
 
 	// No need for this? But if the image is bad, then new pod will also come up
 	// with bad node.
-	podList, err := r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return found, common.ReconcileError(fmt.Errorf("failed to list pods: %v", err))
+		return found, common.ReconcileError(fmt.Errorf(
+			"listing pods for rack %d in cluster %s: %w",
+			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		))
 	}
 
 	if r.isAnyPodInImageFailedState(podList, ignorablePodNames) {
-		return found, common.ReconcileError(fmt.Errorf("cannot scale up AerospikeCluster. A pod is already in failed state"))
+		return found, common.ReconcileError(fmt.Errorf(
+			"scaling up cluster %s rack %d is blocked: a pod is not healthy",
+			utils.ClusterNamespacedName(r.aeroCluster), rackState.Rack.ID))
 	}
 
 	var newPodNames []string
@@ -690,23 +659,24 @@ func (r *SingleClusterReconciler) scaleUpRack(
 				return found, common.ReconcileError(
 					fmt.Errorf(
 						"pod %s yet to be launched is still present",
-						newPodName,
+						utils.NamespacedName(r.aeroCluster.Namespace, newPodName),
 					),
 				)
 			}
 		}
 	}
 
-	if err = r.cleanupDanglingPodsRack(found, rackState); err != nil {
+	if err = r.cleanupDanglingPodsRack(ctx, found, rackState); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"failed scale up pre-check: %v", err,
+				"running scale up pre-check for rack %d in cluster %s: %w",
+				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
 
 	// Create pod service for the scaled up pod when node network is used in network policy
-	if err = r.createOrUpdatePodServiceIfNeeded(newPodNames); err != nil {
+	if err = r.createOrUpdatePodServiceIfNeeded(ctx, newPodNames); err != nil {
 		return nil, common.ReconcileError(err)
 	}
 
@@ -714,16 +684,16 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	found.Spec.Replicas = &desiredSize
 
 	// Scale up the statefulset
-	if err = r.Update(context.TODO(), found, common.UpdateOption); err != nil {
+	if err = r.Update(ctx, found, common.UpdateOption); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"failed to update StatefulSet pods: %v", err,
+				"scaling up statefulset %s: %w", utils.GetNamespacedNameString(found), err,
 			),
 		)
 	}
 
 	// return a fresh copy
-	found, err = r.getSTS(rackState)
+	found, err = r.getSTS(ctx, rackState)
 	if err != nil {
 		return found, common.ReconcileError(err)
 	}
@@ -739,7 +709,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 }
 
 func (r *SingleClusterReconciler) upgradeRack(
-	statefulSet *appsv1.StatefulSet, rackState *RackState,
+	ctx context.Context, statefulSet *appsv1.StatefulSet, rackState *RackState,
 	ignorablePodNames sets.Set[string], failedPods []*corev1.Pod,
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
 	var (
@@ -751,11 +721,12 @@ func (r *SingleClusterReconciler) upgradeRack(
 		podList = failedPods
 	} else {
 		// List the pods for this aeroCluster's statefulset
-		podList, err = r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
 			return statefulSet, common.ReconcileError(
 				fmt.Errorf(
-					"failed to list pods: %v", err,
+					"listing pods for rack %d in cluster %s: %w",
+					rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 				),
 			)
 		}
@@ -769,10 +740,10 @@ func (r *SingleClusterReconciler) upgradeRack(
 	// So first update image in STS and then delete a pod.
 	// Pod will come up with new image.
 	// Repeat the above process.
-	err = r.updateSTS(statefulSet, rackState)
+	err = r.updateSTS(ctx, statefulSet, rackState)
 	if err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("upgrade rack : %v", err),
+			fmt.Errorf("upgrading rack %d in cluster %s: %w", rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}
 
@@ -824,7 +795,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 		)
 
 		podNames := getPodNames(podsBatch)
-		if err = r.createOrUpdatePodServiceIfNeeded(podNames); err != nil {
+		if err = r.createOrUpdatePodServiceIfNeeded(ctx, podNames); err != nil {
 			return nil, common.ReconcileError(err)
 		}
 
@@ -833,7 +804,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 			"[rack-%d] Updating Containers on Pods %v", rackState.Rack.ID, podNames,
 		)
 
-		res := r.safelyDeletePodsAndEnsureImageUpdated(rackState, podsBatch, ignorablePodNames)
+		res := r.safelyDeletePodsAndEnsureImageUpdated(ctx, rackState, podsBatch, ignorablePodNames)
 		if !res.IsSuccess {
 			return statefulSet, res
 		}
@@ -850,7 +821,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 	}
 
 	// If it was last batch then go ahead return a fresh copy
-	statefulSet, err = r.getSTS(rackState)
+	statefulSet, err = r.getSTS(ctx, rackState)
 	if err != nil {
 		return statefulSet, common.ReconcileError(err)
 	}
@@ -864,7 +835,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 }
 
 func (r *SingleClusterReconciler) scaleDownRack(
-	found *appsv1.StatefulSet, rackState *RackState,
+	ctx context.Context, found *appsv1.StatefulSet, rackState *RackState,
 	ignorablePodNames sets.Set[string], customBatchSize *intstr.IntOrString,
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
 	desiredSize := rackState.Size
@@ -885,20 +856,24 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		desiredSize,
 	)
 
-	oldPodList, err := r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+	oldPodList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return found, common.ReconcileError(fmt.Errorf("failed to list pods: %v", err))
+		return found, common.ReconcileError(fmt.Errorf(
+			"listing pods for rack %d in cluster %s: %w",
+			rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		))
 	}
 
 	if r.isAnyPodInImageFailedState(oldPodList, ignorablePodNames) {
 		return found, common.ReconcileError(
-			fmt.Errorf("cannot scale down AerospikeCluster. A pod is already in failed state"))
+			fmt.Errorf("scaling down cluster %s rack %d is blocked: a pod is not healthy",
+				utils.ClusterNamespacedName(r.aeroCluster), rackState.Rack.ID))
 	}
 
 	// Code flow will reach this stage only when found.Spec.Replicas > desiredSize
 	// Maintain a list of removed pods. It will be used for alumni-reset and tip-clear
 
-	policy := r.getClientPolicy()
+	policy := r.getClientPolicy(ctx)
 	diffPods := *found.Spec.Replicas - desiredSize
 
 	// Use custom batch size if provided, otherwise use ScaleDownBatchSize
@@ -966,7 +941,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	// Ignore safe stop check if all pods in the batch are not running.
 	// Ignore migrate-fill-delay if pod is not running. Deleting this pod will not lead to any migration.
 	if isAnyPodRunningAndReady {
-		if res := r.waitForMultipleNodesSafeStopReady(runningPods, ignorablePodNames); !res.IsSuccess {
+		if res := r.waitForMultipleNodesSafeStopReady(ctx, runningPods, ignorablePodNames); !res.IsSuccess {
 			// The pod is running and is unsafe to terminate.
 			return found, res
 		}
@@ -976,14 +951,14 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		// This check ensures that migrate-fill-delay is not set while processing failed racks.
 		// setting migrate-fill-delay will fail if there are any failed pod
 		if res := r.setMigrateFillDelay(
-			policy, &rackState.Rack.AerospikeConfig, true, ignorablePodNames,
+			ctx, policy, &rackState.Rack.AerospikeConfig, true, ignorablePodNames,
 		); !res.IsSuccess {
 			return found, res
 		}
 	}
 
 	// Wait for migration to complete before deleting the pods.
-	if res := r.waitForMigrationToComplete(policy,
+	if res := r.waitForMigrationToComplete(ctx, policy,
 		ignorablePodNames,
 	); !res.IsSuccess {
 		r.Log.Error(
@@ -999,12 +974,12 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	found.Spec.Replicas = &newSize
 
 	if err = r.Update(
-		context.TODO(), found, common.UpdateOption,
+		ctx, found, common.UpdateOption,
 	); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"failed to update pod size %d StatefulSet pods: %v",
-				newSize, err,
+				"scaling statefulset %s to %d replicas: %w",
+				utils.GetNamespacedNameString(found), newSize, err,
 			),
 		)
 	}
@@ -1014,7 +989,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	// These checks will fail if there is any other pod in failed state outside the batch.
 	if isAnyPodRunningAndReady {
 		// Wait for pods to get terminated
-		if err = r.waitForSTSToBeReady(found, ignorablePodNames); err != nil {
+		if err = r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
 			r.Log.Error(err, "Failed to wait for statefulset to be ready")
 			return found, common.ReconcileRequeueAfter(1)
 		}
@@ -1024,7 +999,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		// This can be left to the user but if we would do it here on our own then we can reuse
 		// objects like pvc and service. These objects would have been removed if scaleup is left for the user.
 		// In case of rolling restart, no pod cleanup happens, therefore rolling config back is left to the user.
-		if err = r.validateSCClusterState(policy, ignorablePodNames); err != nil {
+		if err = r.validateSCClusterState(ctx, policy, ignorablePodNames); err != nil {
 			// reset cluster size
 			newSize := *found.Spec.Replicas + utils.Len32(podsBatch)
 			found.Spec.Replicas = &newSize
@@ -1035,17 +1010,17 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			)
 
 			if err = r.Update(
-				context.TODO(), found, common.UpdateOption,
+				ctx, found, common.UpdateOption,
 			); err != nil {
 				return found, common.ReconcileError(
 					fmt.Errorf(
-						"failed to update pod size %d StatefulSet pods: %v",
-						newSize, err,
+						"scaling statefulset %s to %d replicas: %w",
+						utils.GetNamespacedNameString(found), newSize, err,
 					),
 				)
 			}
 
-			if err = r.waitForSTSToBeReady(found, ignorablePodNames); err != nil {
+			if err = r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
 				r.Log.Error(err, "Failed to wait for statefulset to be ready")
 			}
 
@@ -1054,11 +1029,12 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	}
 
 	// Fetch new object
-	nFound, err := r.getSTS(rackState)
+	nFound, err := r.getSTS(ctx, rackState)
 	if err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"failed to get StatefulSet pods: %v", err,
+				"getting statefulset for rack %d in cluster %s: %w",
+				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			),
 		)
 	}
@@ -1067,10 +1043,11 @@ func (r *SingleClusterReconciler) scaleDownRack(
 
 	podNames := getPodNames(podsBatch)
 
-	if err := r.cleanupPods(podNames, rackState); err != nil {
+	if err := r.cleanupPods(ctx, podNames, rackState); err != nil {
 		return nFound, common.ReconcileError(
 			fmt.Errorf(
-				"failed to cleanup pod %s: %v", podNames, err,
+				"cleaning up pods %s: %w",
+				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
 			),
 		)
 	}
@@ -1092,7 +1069,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 }
 
 func (r *SingleClusterReconciler) rollingRestartRack(
-	found *appsv1.StatefulSet, rackState *RackState,
+	ctx context.Context, found *appsv1.StatefulSet, rackState *RackState,
 	ignorablePodNames sets.Set[string], restartTypeMap map[string]RestartType,
 	failedPods []*corev1.Pod,
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
@@ -1117,16 +1094,22 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		}
 	} else {
 		// List the pods for this aeroCluster's statefulset
-		podList, err = r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
-			return found, common.ReconcileError(fmt.Errorf("failed to list pods: %v", err))
+			return found, common.ReconcileError(fmt.Errorf(
+				"listing pods for rack %d in cluster %s: %w",
+				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			))
 		}
 	}
 
-	err = r.updateSTS(found, rackState)
+	err = r.updateSTS(ctx, found, rackState)
 	if err != nil {
 		return found, common.ReconcileError(
-			fmt.Errorf("rolling restart failed: %v", err),
+			fmt.Errorf(
+				"updating statefulset for rolling restart of rack %d in cluster %s: %w",
+				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			),
 		)
 	}
 
@@ -1183,11 +1166,11 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		)
 
 		podNames := getPodNames(podsBatch)
-		if err = r.createOrUpdatePodServiceIfNeeded(podNames); err != nil {
+		if err = r.createOrUpdatePodServiceIfNeeded(ctx, podNames); err != nil {
 			return nil, common.ReconcileError(err)
 		}
 
-		if res := r.rollingRestartPods(rackState, podsBatch, ignorablePodNames, restartTypeMap); !res.IsSuccess {
+		if res := r.rollingRestartPods(ctx, rackState, podsBatch, ignorablePodNames, restartTypeMap); !res.IsSuccess {
 			return found, res
 		}
 
@@ -1199,7 +1182,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	// It's last batch, go ahead
 
 	// Return a fresh copy
-	found, err = r.getSTS(rackState)
+	found, err = r.getSTS(ctx, rackState)
 	if err != nil {
 		return found, common.ReconcileError(err)
 	}
@@ -1213,12 +1196,15 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 }
 
 func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
-	statefulSet *appsv1.StatefulSet, rackState *RackState,
+	ctx context.Context, statefulSet *appsv1.StatefulSet, rackState *RackState,
 	ignorablePodNames sets.Set[string], failedPods []*corev1.Pod,
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
-	if err := r.updateSTS(statefulSet, rackState); err != nil {
+	if err := r.updateSTS(ctx, statefulSet, rackState); err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("k8s node block list processing failed: %v", err),
+			fmt.Errorf(
+				"processing k8s node block list for rack %d in cluster %s: %w",
+				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			),
 		)
 	}
 
@@ -1231,9 +1217,12 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 		podList = failedPods
 	} else {
 		// List the pods for this aeroCluster's statefulset
-		podList, err = r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
-			return statefulSet, common.ReconcileError(fmt.Errorf("failed to list pods: %v", err))
+			return statefulSet, common.ReconcileError(fmt.Errorf(
+				"listing pods for rack %d in cluster %s: %w",
+				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			))
 		}
 	}
 
@@ -1275,7 +1264,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 			"rollingUpdateBatchSize", r.aeroCluster.Spec.RackConfig.RollingUpdateBatchSize,
 		)
 
-		if res := r.rollingRestartPods(rackState, podsBatch, ignorablePodNames, restartTypeMap); !res.IsSuccess {
+		if res := r.rollingRestartPods(ctx, rackState, podsBatch, ignorablePodNames, restartTypeMap); !res.IsSuccess {
 			return statefulSet, res
 		}
 
@@ -1294,10 +1283,11 @@ type rollingRestartInfo struct {
 	needRestart, needUpdateConf bool
 }
 
-func (r *SingleClusterReconciler) getRollingRestartInfo(rackState *RackState, ignorablePodNames sets.Set[string]) (
+func (r *SingleClusterReconciler) getRollingRestartInfo(
+	ctx context.Context, rackState *RackState, ignorablePodNames sets.Set[string]) (
 	info *rollingRestartInfo, err error,
 ) {
-	restartTypeMap, dynamicConfDiffPerPod, err := r.getRollingRestartTypeMap(rackState, ignorablePodNames)
+	restartTypeMap, dynamicConfDiffPerPod, err := r.getRollingRestartTypeMap(ctx, rackState, ignorablePodNames)
 	if err != nil {
 		return nil, err
 	}
@@ -1326,12 +1316,12 @@ func (r *SingleClusterReconciler) getRollingRestartInfo(rackState *RackState, ig
 }
 
 func (r *SingleClusterReconciler) isRackUpgradeNeeded(
-	rackID int, rackRevision string, ignorablePodNames sets.Set[string]) (
+	ctx context.Context, rackID int, rackRevision string, ignorablePodNames sets.Set[string]) (
 	bool, error,
 ) {
-	podList, err := r.getRackPodList(rackID, rackRevision)
+	podList, err := r.getRackPodList(ctx, rackID, rackRevision)
 	if err != nil {
-		return true, fmt.Errorf("failed to list pods: %v", err)
+		return true, fmt.Errorf("listing pods for rack %d in cluster %s: %w", rackID, utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	for idx := range podList.Items {
@@ -1733,7 +1723,7 @@ func (r *SingleClusterReconciler) isContainerVolumeInStorageStatus(
 	return true
 }
 
-func (r *SingleClusterReconciler) getRackPodList(rackID int, rackRevision string) (
+func (r *SingleClusterReconciler) getRackPodList(ctx context.Context, rackID int, rackRevision string) (
 	*corev1.PodList, error,
 ) {
 	// List the pods for this aeroCluster's statefulset
@@ -1744,14 +1734,14 @@ func (r *SingleClusterReconciler) getRackPodList(rackID int, rackRevision string
 	}
 
 	// TODO: Should we add check to get only non-terminating pod? What if it is rolling restart
-	if err := r.List(context.TODO(), podList, listOps); err != nil {
+	if err := r.List(ctx, podList, listOps); err != nil {
 		return nil, err
 	}
 
 	return podList, nil
 }
 
-func (r *SingleClusterReconciler) getAllRevisionRackPodList(rackID int) (
+func (r *SingleClusterReconciler) getAllRevisionRackPodList(ctx context.Context, rackID int) (
 	*corev1.PodList, error,
 ) {
 	// List the pods for this aeroCluster's statefulset
@@ -1762,7 +1752,7 @@ func (r *SingleClusterReconciler) getAllRevisionRackPodList(rackID int) (
 			utils.LabelsForAerospikeClusterRack(r.aeroCluster.Name, rackID, "")),
 	}
 
-	if err := r.List(context.TODO(), podList, listOps); err != nil {
+	if err := r.List(ctx, podList, listOps); err != nil {
 		return nil, err
 	}
 
@@ -1782,10 +1772,10 @@ func (r *SingleClusterReconciler) getRackPodNames(rackState *RackState) []string
 	return podNames
 }
 
-func (r *SingleClusterReconciler) getOrderedRackPodList(rackID int, rackRevision string) (
+func (r *SingleClusterReconciler) getOrderedRackPodList(ctx context.Context, rackID int, rackRevision string) (
 	[]*corev1.Pod, error,
 ) {
-	podList, err := r.getRackPodList(rackID, rackRevision)
+	podList, err := r.getRackPodList(ctx, rackID, rackRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -1799,7 +1789,10 @@ func (r *SingleClusterReconciler) getOrderedRackPodList(rackID int, rackRevision
 
 		if indexInt >= len(podList.Items) {
 			// Happens if we do not get full list of pods due to a crash,
-			return nil, fmt.Errorf("error get pod list for rack:%v, rackRevision:%v", rackID, rackRevision)
+			return nil, fmt.Errorf(
+				"getting ordered pod list for rack %d (revision %q) in cluster %s: incomplete pod list",
+				rackID, rackRevision, utils.ClusterNamespacedName(r.aeroCluster),
+			)
 		}
 
 		sortedList[(len(podList.Items)-1)-indexInt] = &podList.Items[idx]
@@ -1808,7 +1801,7 @@ func (r *SingleClusterReconciler) getOrderedRackPodList(rackID int, rackRevision
 	return sortedList, nil
 }
 
-func (r *SingleClusterReconciler) getCurrentRackList() (
+func (r *SingleClusterReconciler) getCurrentRackList(ctx context.Context) (
 	[]asdbv1.Rack, error,
 ) {
 	var rackList []asdbv1.Rack
@@ -1817,7 +1810,7 @@ func (r *SingleClusterReconciler) getCurrentRackList() (
 
 	// Create dummy rack structures for dangling racks that have stateful sets but were deleted later because rack
 	// before status was updated.
-	statefulSetList, err := r.getClusterSTSList()
+	statefulSetList, err := r.getClusterSTSList(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1857,14 +1850,15 @@ func (r *SingleClusterReconciler) getCurrentRackList() (
 	return rackList, nil
 }
 
-func (r *SingleClusterReconciler) handleEnableSecurity(rackState *RackState, ignorablePodNames sets.Set[string]) error {
+func (r *SingleClusterReconciler) handleEnableSecurity(
+	ctx context.Context, rackState *RackState, ignorablePodNames sets.Set[string]) error {
 	if !r.enablingSecurity() {
 		// No need to proceed if security is not to be enabling
 		return nil
 	}
 
 	// Get pods where security-enabled config is applied
-	securityEnabledPods, err := r.getPodsWithUpdatedConfigForRack(rackState)
+	securityEnabledPods, err := r.getPodsWithUpdatedConfigForRack(ctx, rackState)
 	if err != nil {
 		return err
 	}
@@ -1875,8 +1869,7 @@ func (r *SingleClusterReconciler) handleEnableSecurity(rackState *RackState, ign
 	}
 
 	// Setup access control.
-	if err := r.validateAndReconcileAccessControl(securityEnabledPods, ignorablePodNames); err != nil {
-		r.Log.Error(err, "Failed to Reconcile access control")
+	if err := r.validateAndReconcileAccessControl(ctx, securityEnabledPods, ignorablePodNames); err != nil {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeWarning, "ACLUpdateFailed",
 			"Failed to setup Access Control %s/%s", r.aeroCluster.Namespace,
@@ -1893,10 +1886,11 @@ func (r *SingleClusterReconciler) enablingSecurity() bool {
 	return r.aeroCluster.Spec.AerospikeAccessControl != nil && r.aeroCluster.Status.AerospikeAccessControl == nil
 }
 
-func (r *SingleClusterReconciler) getPodsWithUpdatedConfigForRack(rackState *RackState) ([]corev1.Pod, error) {
-	pods, err := r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+func (r *SingleClusterReconciler) getPodsWithUpdatedConfigForRack(
+	ctx context.Context, rackState *RackState) ([]corev1.Pod, error) {
+	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list pods: %v", err)
+		return nil, fmt.Errorf("listing pods for rack %d in cluster %s: %w", rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	if len(pods) == 0 {
@@ -1904,7 +1898,7 @@ func (r *SingleClusterReconciler) getPodsWithUpdatedConfigForRack(rackState *Rac
 		return nil, nil
 	}
 
-	confMap, err := r.getConfigMap(utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
+	confMap, err := r.getConfigMap(ctx, utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
 	if err != nil {
 		return nil, err
 	}
@@ -2064,7 +2058,7 @@ func chunkBy[T any](items []*T, chunkSize int) (chunks [][]*T) {
 }
 
 func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
-	revisionChangedRackInfo revisionChangedRack, ignorablePodNames sets.Set[string],
+	ctx context.Context, revisionChangedRackInfo revisionChangedRack, ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
 	oldRack := revisionChangedRackInfo.oldRack
 	newRack := revisionChangedRackInfo.newRack
@@ -2076,13 +2070,13 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		"targetSize", targetSize,
 	)
 
-	newSts, err := r.getSTS(newRack)
+	newSts, err := r.getSTS(ctx, newRack)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return common.ReconcileError(err)
 		}
 		// Create new STS
-		found, res := r.createEmptyRack(&RackState{Rack: newRack.Rack, Size: 0})
+		found, res := r.createEmptyRack(ctx, &RackState{Rack: newRack.Rack, Size: 0})
 		if !res.IsSuccess {
 			return res
 		}
@@ -2090,7 +2084,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		newSts = found
 	}
 
-	oldSts, err := r.getSTS(oldRack)
+	oldSts, err := r.getSTS(ctx, oldRack)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return common.ReconcileError(err)
@@ -2107,7 +2101,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 
 		// Use reconcileRack to bring the new rack to its desired state.
 		// This will handle the scale-up logic.
-		return r.reconcileRack(newSts, newRack, ignorablePodNames, nil)
+		return r.reconcileRack(ctx, newSts, newRack, ignorablePodNames, nil)
 	}
 
 	oldReplicas := *oldSts.Spec.Replicas
@@ -2118,7 +2112,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		r.Log.Info("Rack migration to new revision completed, deleting old revision",
 			"revision", newRack.Rack.Revision)
 
-		return r.deleteRacks([]asdbv1.Rack{*oldRack.Rack}, ignorablePodNames)
+		return r.deleteRacks(ctx, []asdbv1.Rack{*oldRack.Rack}, ignorablePodNames)
 	}
 
 	// Handle oversized new rack
@@ -2129,12 +2123,12 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		)
 
 		tempState := &RackState{Rack: newRack.Rack, Size: targetSize}
-		_, res := r.scaleDownRack(newSts, tempState, ignorablePodNames, nil)
+		_, res := r.scaleDownRack(ctx, newSts, tempState, ignorablePodNames, nil)
 
 		return res
 	}
 
-	if err := r.waitForAllSTSToBeReady(ignorablePodNames); err != nil {
+	if err := r.waitForAllSTSToBeReady(ctx, ignorablePodNames); err != nil {
 		return common.ReconcileError(err)
 	}
 
@@ -2156,7 +2150,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		podsToScaleUp := min(batchSizeInt32, targetSize-totalCurrentPods)
 		tempState := &RackState{Rack: newRack.Rack, Size: newReplicas + podsToScaleUp}
 
-		if res := r.reconcileRack(newSts, tempState, ignorablePodNames, nil); !res.IsSuccess {
+		if res := r.reconcileRack(ctx, newSts, tempState, ignorablePodNames, nil); !res.IsSuccess {
 			return res
 		}
 
@@ -2172,7 +2166,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		)
 
 		tempState := &RackState{Rack: oldRack.Rack, Size: oldReplicas - podsToScaleDown}
-		_, res := r.scaleDownRack(oldSts, tempState, ignorablePodNames, r.aeroCluster.Spec.RackConfig.RollingUpdateBatchSize)
+		_, res := r.scaleDownRack(ctx, oldSts, tempState, ignorablePodNames, r.aeroCluster.Spec.RackConfig.RollingUpdateBatchSize)
 
 		return res
 	}
@@ -2181,14 +2175,14 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 }
 
 func (r *SingleClusterReconciler) handleFailedPodsInRack(
-	found *appsv1.StatefulSet, rackState *RackState, ignorablePodNames sets.Set[string],
+	ctx context.Context, found *appsv1.StatefulSet, rackState *RackState, ignorablePodNames sets.Set[string],
 ) common.ReconcileResult {
 	// 1. Fetch the pods for the rack and if there are failed pods, then reconcile the rack
-	podList, err := r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(
-			fmt.Errorf("failed to list pods for rack %d-%s: %v",
-				rackState.Rack.ID, rackState.Rack.Revision, err),
+			fmt.Errorf("listing pods for rack %d-%s in cluster %s: %w",
+				rackState.Rack.ID, rackState.Rack.Revision, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}
 
@@ -2202,7 +2196,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 			"failedPods", getPodNames(failedPods))
 
 		if res := r.reconcileRack(
-			found, rackState, ignorablePodNames, failedPods,
+			ctx, found, rackState, ignorablePodNames, failedPods,
 		); !res.IsSuccess {
 			return res
 		}
@@ -2216,11 +2210,11 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	// This is needed in cases where hash values generated from CR spec are same as hash values in pods.
 	// But, pods are in failed state due to their bad spec.
 	// e.g. configuring unschedulable resources in CR podSpec and reverting them to old value.
-	podList, err = r.getOrderedRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+	podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(
-			fmt.Errorf("failed to re-fetch pods for restart check on rack %d-%s: %v",
-				rackState.Rack.ID, rackState.Rack.Revision, err),
+			fmt.Errorf("re-fetching pods for restart check on rack %d-%s in cluster %s: %w",
+				rackState.Rack.ID, rackState.Rack.Revision, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}
 
@@ -2234,7 +2228,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 			"failedPods", getPodNames(failedPods))
 
 		if _, res := r.rollingRestartRack(
-			found, rackState, ignorablePodNames, nil,
+			ctx, found, rackState, ignorablePodNames, nil,
 			failedPods,
 		); !res.IsSuccess {
 			return res
@@ -2250,17 +2244,17 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	return common.ReconcileSuccess()
 }
 
-func (r *SingleClusterReconciler) categoriseRacks() (configuredRacks []RackState,
+func (r *SingleClusterReconciler) categoriseRacks(ctx context.Context) (configuredRacks []RackState,
 	revisionChangedRacks map[int]revisionChangedRack, racksToDelete []asdbv1.Rack, err error) {
 	configuredRacks = getConfiguredRackStateList(r.aeroCluster)
 
 	// Revision-changed racks are not considered in the racks to delete.
-	racksToDelete, err = r.getRacksToDelete(configuredRacks)
+	racksToDelete, err = r.getRacksToDelete(ctx, configuredRacks)
 	if err != nil {
 		return configuredRacks, revisionChangedRacks, racksToDelete, err
 	}
 
-	oldRacks, err := r.getCurrentRackList()
+	oldRacks, err := r.getCurrentRackList(ctx)
 	if err != nil {
 		return configuredRacks, revisionChangedRacks, racksToDelete, err
 	}

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -47,7 +47,7 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 		return common.ReconcileError(err)
 	}
 
-	ignorablePodNames, err := r.getIgnorablePods(ctx, racksToDelete, configuredRacks, revisionChangedRacks)
+	ignorablePodNames, err := r.getIgnorablePods(ctx, racksToDelete, configuredRacks)
 	if err != nil {
 		return common.ReconcileError(err)
 	}

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -201,7 +201,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	cmName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 		utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision))
 	if err := r.createSTSConfigMap(ctx, cmName, rackState.Rack); err != nil {
-		return nil, common.ReconcileError(fmt.Errorf("could not create ConfigMap %s for rack %d: %w",
+		return nil, common.ReconcileError(fmt.Errorf("create ConfigMap %s for rack %d: %w",
 			cmName.String(), rackState.Rack.ID, err))
 	}
 
@@ -223,7 +223,7 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 			_ = r.deleteSTS(ctx, found)
 		}
 
-		return nil, common.ReconcileError(fmt.Errorf("could not create StatefulSet %s for rack %d: %w",
+		return nil, common.ReconcileError(fmt.Errorf("create StatefulSet %s for rack %d: %w",
 			stsName.String(), rackState.Rack.ID, err))
 	}
 
@@ -358,7 +358,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 			r.aeroCluster, utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision),
 		), rackState.Rack,
 	); err != nil {
-		return found, common.ReconcileError(fmt.Errorf("could not update ConfigMap for rack %d, stsName %s: %w",
+		return found, common.ReconcileError(fmt.Errorf("update ConfigMap for rack %d, statefulSet %s: %w",
 			rackState.Rack.ID, utils.GetNamespacedNameString(found), err))
 	}
 
@@ -386,7 +386,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 					"[rack-%d] Failed to update image for StatefulSet %s",
 					rackState.Rack.ID, utils.GetNamespacedNameString(found),
 				)
-				res.Err = fmt.Errorf("could not upgrade rack %d StatefulSet %s: %w",
+				res.Err = fmt.Errorf("upgrade rack %d StatefulSet %s: %w",
 					rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 			}
 
@@ -410,7 +410,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 						"[rack-%d] Failed to roll StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
-					res.Err = fmt.Errorf("could not complete rolling restart for rack %d StatefulSet %s: %w",
+					res.Err = fmt.Errorf("complete rolling restart for rack %d StatefulSet %s: %w",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
@@ -431,7 +431,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 						"[rack-%d] Failed to update dynamic config for StatefulSet %s",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
-					res.Err = fmt.Errorf("could not apply dynamic configuration update for rack %d StatefulSet %s: %w",
+					res.Err = fmt.Errorf("apply dynamic configuration update for rack %d StatefulSet %s: %w",
 						rackState.Rack.ID, utils.GetNamespacedNameString(found), res.Err)
 				}
 
@@ -599,7 +599,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 				nil,
 			); !res.IsSuccess {
 				if res.Err != nil {
-					res.Err = fmt.Errorf("could not revert migrate-fill-delay after scale down for rack %d: %w",
+					res.Err = fmt.Errorf("revert migrate-fill-delay after scale down for rack %d: %w",
 						rackState.Rack.ID, res.Err)
 				}
 
@@ -609,7 +609,7 @@ func (r *SingleClusterReconciler) reconcileRack(
 	}
 
 	if err := r.updateAerospikeInitContainerImage(ctx, found); err != nil {
-		return common.ReconcileError(fmt.Errorf("could not update init container image for StatefulSet %s: %w",
+		return common.ReconcileError(fmt.Errorf("update init container image for StatefulSet %s: %w",
 			utils.GetNamespacedNameString(found), err))
 	}
 
@@ -786,7 +786,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 	err = r.updateSTS(ctx, statefulSet, rackState)
 	if err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("could not update StatefulSet spec for rack %d in cluster %s: %w",
+			fmt.Errorf("update StatefulSet spec for rack %d in cluster %s: %w",
 				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}
@@ -1002,7 +1002,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			ctx, policy, &rackState.Rack.AerospikeConfig, true, ignorablePodNames,
 		); !res.IsSuccess {
 			if res.Err != nil {
-				res.Err = fmt.Errorf("could not set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
+				res.Err = fmt.Errorf("set migrate-fill-delay to 0 for rack %d: %w", rackState.Rack.ID, res.Err)
 			}
 
 			return found, res
@@ -1014,7 +1014,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		ignorablePodNames,
 	); !res.IsSuccess {
 		if res.Err != nil {
-			res.Err = fmt.Errorf("could not wait for migrations to complete before deleting pods for rack %d: %w",
+			res.Err = fmt.Errorf("wait for migrations to complete before deleting pods for rack %d: %w",
 				rackState.Rack.ID, res.Err)
 		}
 
@@ -2235,7 +2235,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(
-			fmt.Errorf("could not list pods for rack %d-%s in cluster %s: %w",
+			fmt.Errorf("list pods for rack %d-%s in cluster %s: %w",
 				rackState.Rack.ID, rackState.Rack.Revision, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}
@@ -2267,7 +2267,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(
-			fmt.Errorf("could not re-fetch pods for restart check on rack %d-%s in cluster %s: %w",
+			fmt.Errorf("re-fetch pods for restart check on rack %d-%s in cluster %s: %w",
 				rackState.Rack.ID, rackState.Rack.Revision, utils.ClusterNamespacedName(r.aeroCluster), err),
 		)
 	}

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -654,7 +654,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 
 	if r.isAnyPodInImageFailedState(podList, ignorablePodNames) {
 		return found, common.ReconcileError(fmt.Errorf(
-			"scaling up cluster %s rack %d is blocked: a pod is not healthy",
+			"cannot scale up cluster %s rack %d: a pod is already in failed state",
 			utils.ClusterNamespacedName(r.aeroCluster), rackState.Rack.ID))
 	}
 
@@ -882,7 +882,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 
 	if r.isAnyPodInImageFailedState(oldPodList, ignorablePodNames) {
 		return found, common.ReconcileError(
-			fmt.Errorf("scaling down cluster %s rack %d is blocked: a pod is not healthy",
+			fmt.Errorf("cannot scale down cluster %s rack %d: a pod is already in failed state",
 				utils.ClusterNamespacedName(r.aeroCluster), rackState.Rack.ID))
 	}
 
@@ -1127,10 +1127,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	err = r.updateSTS(ctx, found, rackState)
 	if err != nil {
 		return found, common.ReconcileError(
-			fmt.Errorf(
-				"updating statefulset for rolling restart of rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
-			),
+			fmt.Errorf("rolling restart failed: %w", err),
 		)
 	}
 
@@ -1222,10 +1219,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
 	if err := r.updateSTS(ctx, statefulSet, rackState); err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf(
-				"processing k8s node block list for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
-			),
+			fmt.Errorf("k8s node block list processing failed: %w", err),
 		)
 	}
 
@@ -1810,10 +1804,7 @@ func (r *SingleClusterReconciler) getOrderedRackPodList(ctx context.Context, rac
 
 		if indexInt >= len(podList.Items) {
 			// Happens if we do not get full list of pods due to a crash,
-			return nil, fmt.Errorf(
-				"getting ordered pod list for rack %d (revision %q) in cluster %s: incomplete pod list",
-				rackID, rackRevision, utils.ClusterNamespacedName(r.aeroCluster),
-			)
+			return nil, fmt.Errorf("error get pod list for rack:%v, rackRevision:%v", rackID, rackRevision)
 		}
 
 		sortedList[(len(podList.Items)-1)-indexInt] = &podList.Items[idx]

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -14,7 +14,6 @@ import (
 	ls "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -134,10 +133,7 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 		// Delete racks removed from the cluster spec (scale down, delete STS/ConfigMap, cleanup dangling resources).
 		if res = r.deleteRacks(ctx, racksToDelete, ignorablePodNames); !res.IsSuccess {
 			if res.Err != nil {
-				res.Err = fmt.Errorf(
-					"delete removed racks in cluster %s: %w",
-					utils.GetNamespacedNameString(r.aeroCluster), res.Err,
-				)
+				res.Err = fmt.Errorf("delete removed racks: %w", res.Err)
 			}
 
 			return res
@@ -177,9 +173,9 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 			// fall through,
 			// and might run reconcile steps common to all racks before the racks
 			// have scaled up.
-			r.Log.Info(
-				"Failed to wait for StatefulSet to be ready, will requeue", "statefulSet", klog.KObj(found),
-				"err", err,
+			r.Log.Error(
+				err, "Failed to wait for StatefulSet to be ready, will requeue",
+				"statefulSet", utils.GetNamespacedName(found),
 			)
 
 			return common.ReconcileRequeueAfter(1)
@@ -192,7 +188,7 @@ func (r *SingleClusterReconciler) reconcileRacks(ctx context.Context) common.Rec
 func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState *RackState) (
 	*appsv1.StatefulSet, common.ReconcileResult,
 ) {
-	r.Log.Info("Create new Aerospike cluster rack if needed")
+	r.Log.Info("Create new AerospikeCluster rack if needed")
 
 	// NoOp if already exist
 	r.Log.V(1).Info("AerospikeCluster", "spec", r.aeroCluster.Spec)
@@ -211,13 +207,13 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	found, err := r.createSTS(ctx, stsName, rackState)
 	if err != nil {
 		r.Log.V(1).Info(
-			"Statefulset setup failed. Deleting statefulset", "name",
+			"StatefulSet setup failed. Deleting StatefulSet", "name",
 			stsName,
 		)
 		// Delete statefulset and everything related so that it can be properly created and updated in next run
 		if found != nil {
 			r.Log.V(1).Info(
-				"Statefulset setup failed. Deleting statefulset", "name",
+				"StatefulSet setup failed. Deleting StatefulSet", "name",
 				stsName,
 			)
 			_ = r.deleteSTS(ctx, found)
@@ -358,7 +354,7 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 			r.aeroCluster, utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision),
 		), rackState.Rack,
 	); err != nil {
-		return found, common.ReconcileError(fmt.Errorf("update ConfigMap for rack %d, statefulSet %s: %w",
+		return found, common.ReconcileError(fmt.Errorf("update ConfigMap for rack %d, StatefulSet %s: %w",
 			rackState.Rack.ID, utils.GetNamespacedNameString(found), err))
 	}
 
@@ -462,7 +458,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	ignorablePodNames sets.Set[string], restartTypeMap map[string]RestartType,
 	dynamicConfDiffPerPod map[string]asconfig.DynamicConfigMap,
 ) common.ReconcileResult {
-	r.Log.Info("Update dynamic config in Aerospike pods")
+	r.Log.Info("Update dynamic config in Aerospike Pods")
 
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, "DynamicConfigUpdate",
@@ -478,8 +474,8 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"list Pods for rack %d: %w",
+			rackState.Rack.ID, err,
 		))
 	}
 
@@ -491,7 +487,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 
 		restartType := restartTypeMap[pod.Name]
 		if restartType != noRestartUpdateConf {
-			r.Log.Info("This Pod doesn't need any update, Skip this", "pod", klog.KObj(pod))
+			r.Log.Info("This Pod doesn't need any update, Skip this", "pod", utils.GetNamespacedName(pod))
 			continue
 		}
 
@@ -516,8 +512,8 @@ func (r *SingleClusterReconciler) handleNSOrDeviceRemovalForIgnorablePods(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"list Pods for rack %d: %w",
+			rackState.Rack.ID, err,
 		))
 	}
 	// Filter ignoredPods to update their dirtyVolumes in the status.
@@ -550,15 +546,15 @@ func (r *SingleClusterReconciler) reconcileRack(
 	ignorablePodNames sets.Set[string], failedPods []*corev1.Pod,
 ) common.ReconcileResult {
 	r.Log.Info(
-		"Reconcile existing Aerospike cluster statefulset", "statefulSet",
-		klog.KObj(found),
+		"Reconcile existing Aerospike cluster StatefulSet", "statefulSet",
+		utils.GetNamespacedName(found),
 	)
 
 	var res common.ReconcileResult
 
 	r.Log.Info(
 		"Ensure rack StatefulSet size is the same as the spec", "statefulSet",
-		klog.KObj(found),
+		utils.GetNamespacedName(found),
 	)
 
 	desiredSize := rackState.Size
@@ -664,7 +660,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 
 	oldSz := *found.Spec.Replicas
 
-	r.Log.Info("Scaling up pods", "currentSz", oldSz, "desiredSz", desiredSize)
+	r.Log.Info("Scaling up Pods", "currentSz", oldSz, "desiredSz", desiredSize)
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, "RackScaleUp",
 		eventRackScaleMessage(
@@ -678,15 +674,14 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return found, common.ReconcileError(fmt.Errorf(
-			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"list Pods for rack %d: %w",
+			rackState.Rack.ID, err,
 		))
 	}
 
 	if r.isAnyPodInImageFailedState(podList, ignorablePodNames) {
 		return found, common.ReconcileError(fmt.Errorf(
-			"scale up cluster %s rack %d: a pod is already in failed state",
-			utils.GetNamespacedNameString(r.aeroCluster), rackState.Rack.ID))
+			"scale up rack %d: a Pod is already in failed state", rackState.Rack.ID))
 	}
 
 	var newPodNames []string
@@ -700,7 +695,7 @@ func (r *SingleClusterReconciler) scaleUpRack(
 			if podList[idx].Name == newPodName {
 				return found, common.ReconcileError(
 					fmt.Errorf(
-						"pod %s yet to be launched is still present",
+						"check Pod %s: yet to be launched is still present",
 						utils.NamespacedName(r.aeroCluster.Namespace, newPodName),
 					),
 				)
@@ -711,8 +706,8 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	if err = r.cleanupDanglingPodsRack(ctx, found, rackState); err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"run scale-up pre-check for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+				"run scale-up pre-check for rack %d: %w",
+				rackState.Rack.ID, err,
 			),
 		)
 	}
@@ -768,8 +763,8 @@ func (r *SingleClusterReconciler) upgradeRack(
 		if err != nil {
 			return statefulSet, common.ReconcileError(
 				fmt.Errorf(
-					"list pods for rack %d in cluster %s: %w",
-					rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+					"list Pods for rack %d: %w",
+					rackState.Rack.ID, err,
 				),
 			)
 		}
@@ -786,8 +781,8 @@ func (r *SingleClusterReconciler) upgradeRack(
 	err = r.updateSTS(ctx, statefulSet, rackState)
 	if err != nil {
 		return statefulSet, common.ReconcileError(
-			fmt.Errorf("update StatefulSet spec for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err),
+			fmt.Errorf("update StatefulSet spec for rack %d: %w",
+				rackState.Rack.ID, err),
 		)
 	}
 
@@ -796,15 +791,15 @@ func (r *SingleClusterReconciler) upgradeRack(
 
 	for idx := range podList {
 		pod := podList[idx]
-		r.Log.Info("Check if pod needs upgrade or not", "pod", klog.KObj(pod))
+		r.Log.Info("Check if Pod needs upgrade or not", "pod", utils.GetNamespacedName(pod))
 
 		if ignorablePodNames.Has(pod.Name) {
-			r.Log.Info("Pod found in ignore pod list, skipping", "pod", klog.KObj(pod))
+			r.Log.Info("Pod found in ignore Pod list, skipping", "pod", utils.GetNamespacedName(pod))
 			continue
 		}
 
 		if r.isPodUpgraded(pod) {
-			r.Log.Info("Pod doesn't need upgrade", "pod", klog.KObj(pod))
+			r.Log.Info("Pod doesn't need upgrade", "pod", utils.GetNamespacedName(pod))
 			continue
 		}
 
@@ -815,7 +810,7 @@ func (r *SingleClusterReconciler) upgradeRack(
 
 	if len(failedPods) != 0 {
 		// creating a single batch of all failed pods in a rack, irrespective of batch size
-		r.Log.Info("Skipping batchSize for failed pods")
+		r.Log.Info("Skipping batchSize for failed Pods")
 
 		podsBatchList = make([][]*corev1.Pod, 1)
 		podsBatchList[0] = podsToUpgrade
@@ -893,7 +888,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	}
 
 	r.Log.Info(
-		"ScaleDown AerospikeCluster statefulset", "desiredSize", desiredSize,
+		"ScaleDown AerospikeCluster StatefulSet", "desiredSize", desiredSize,
 		"currentSize", *found.Spec.Replicas, "rackID", rackState.Rack.ID, "rackRevision", rackState.Rack.Revision,
 	)
 	r.Recorder.Eventf(
@@ -907,15 +902,14 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	oldPodList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return found, common.ReconcileError(fmt.Errorf(
-			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"list Pods for rack %d: %w",
+			rackState.Rack.ID, err,
 		))
 	}
 
 	if r.isAnyPodInImageFailedState(oldPodList, ignorablePodNames) {
 		return found, common.ReconcileError(
-			fmt.Errorf("scale down cluster %s rack %d: a pod is already in failed state",
-				utils.GetNamespacedNameString(r.aeroCluster), rackState.Rack.ID))
+			fmt.Errorf("scale down rack %d: a Pod is already in failed state", rackState.Rack.ID))
 	}
 
 	// Code flow will reach this stage only when found.Spec.Replicas > desiredSize
@@ -980,7 +974,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		// The user can override this by raising maxIgnorablePods.
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"pod %s is not ready; waiting for recovery before scale-down to prevent data loss",
+				"check Pod %s: not ready; waiting for recovery before scale-down to prevent data loss",
 				podsBatch[idx].Name,
 			),
 		)
@@ -1014,7 +1008,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		ignorablePodNames,
 	); !res.IsSuccess {
 		if res.Err != nil {
-			res.Err = fmt.Errorf("wait for migrations to complete before deleting pods for rack %d: %w",
+			res.Err = fmt.Errorf("wait for migrations to complete before deleting Pods for rack %d: %w",
 				rackState.Rack.ID, res.Err)
 		}
 
@@ -1042,7 +1036,9 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if isAnyPodRunningAndReady {
 		// Wait for pods to get terminated
 		if err = r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
-			r.Log.Info("Failed to wait for StatefulSet to be ready, will requeue", "statefulSet", klog.KObj(found), "err", err)
+			r.Log.Error(err, "Failed to wait for StatefulSet to be ready, will requeue",
+				"statefulSet", utils.GetNamespacedName(found))
+
 			return found, common.ReconcileRequeueAfter(1)
 		}
 
@@ -1056,9 +1052,9 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			newSize := *found.Spec.Replicas + utils.Len32(podsBatch)
 			found.Spec.Replicas = &newSize
 
-			r.Log.Info(
-				"Cluster validation failed, re-setting AerospikeCluster statefulset to previous size",
-				"statefulSet", klog.KObj(found), "size", newSize, "err", err,
+			r.Log.Error(
+				err, "Cluster validation failed, re-setting AerospikeCluster StatefulSet to previous size",
+				"statefulSet", utils.GetNamespacedName(found), "size", newSize,
 			)
 
 			if err = r.Update(
@@ -1073,9 +1069,9 @@ func (r *SingleClusterReconciler) scaleDownRack(
 			}
 
 			if err = r.waitForSTSToBeReady(ctx, found, ignorablePodNames); err != nil {
-				r.Log.Info(
-					"Failed to wait for StatefulSet to be ready after reset, will requeue",
-					"statefulSet", klog.KObj(found), "err", err,
+				r.Log.Error(
+					err, "Failed to wait for StatefulSet to be ready after reset, will requeue",
+					"statefulSet", utils.GetNamespacedName(found),
 				)
 			}
 
@@ -1088,8 +1084,8 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if err != nil {
 		return found, common.ReconcileError(
 			fmt.Errorf(
-				"get StatefulSet for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+				"get StatefulSet for rack %d: %w",
+				rackState.Rack.ID, err,
 			),
 		)
 	}
@@ -1101,7 +1097,7 @@ func (r *SingleClusterReconciler) scaleDownRack(
 	if err := r.cleanupPods(ctx, podNames, rackState); err != nil {
 		return nFound, common.ReconcileError(
 			fmt.Errorf(
-				"clean up pods %s: %w",
+				"clean up Pods %s: %w",
 				strings.Join(utils.NamespacedNames(r.aeroCluster.Namespace, podNames), ", "), err,
 			),
 		)
@@ -1130,7 +1126,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	ignorablePodNames sets.Set[string], restartTypeMap map[string]RestartType,
 	failedPods []*corev1.Pod,
 ) (*appsv1.StatefulSet, common.ReconcileResult) {
-	r.Log.Info("Rolling restart AerospikeCluster statefulset pods", "statefulSet", klog.KObj(found))
+	r.Log.Info("Rolling restart AerospikeCluster StatefulSet Pods", "statefulSet", utils.GetNamespacedName(found))
 
 	r.Recorder.Eventf(
 		r.aeroCluster, corev1.EventTypeNormal, "RackRollingRestart",
@@ -1154,8 +1150,8 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
 			return found, common.ReconcileError(fmt.Errorf(
-				"list pods for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+				"list Pods for rack %d: %w",
+				rackState.Rack.ID, err,
 			))
 		}
 	}
@@ -1168,7 +1164,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	}
 
 	r.Log.Info(
-		"Statefulset spec updated - doing rolling restart",
+		"StatefulSet spec updated - doing rolling restart",
 	)
 
 	// Find pods which need restart
@@ -1178,13 +1174,13 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 		pod := podList[idx]
 
 		if ignorablePodNames.Has(pod.Name) {
-			r.Log.Info("Pod found in ignore pod list, skipping", "pod", klog.KObj(pod))
+			r.Log.Info("Pod found in ignore Pod list, skipping", "pod", utils.GetNamespacedName(pod))
 			continue
 		}
 
 		restartType := restartTypeMap[pod.Name]
 		if restartType == noRestart || restartType == noRestartUpdateConf {
-			r.Log.Info("This Pod doesn't need rolling restart, Skip this", "pod", klog.KObj(pod))
+			r.Log.Info("This Pod doesn't need rolling restart, Skip this", "pod", utils.GetNamespacedName(pod))
 			continue
 		}
 
@@ -1195,7 +1191,7 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 
 	if len(failedPods) != 0 {
 		// Creating a single batch of all failed pods in a rack, irrespective of batch size
-		r.Log.Info("Skipping batchSize for failed pods")
+		r.Log.Info("Skipping batchSize for failed Pods")
 
 		podsBatchList = make([][]*corev1.Pod, 1)
 		podsBatchList[0] = podsToRestart
@@ -1271,8 +1267,8 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 		podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 		if err != nil {
 			return statefulSet, common.ReconcileError(fmt.Errorf(
-				"list pods for rack %d in cluster %s: %w",
-				rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+				"list Pods for rack %d: %w",
+				rackState.Rack.ID, err,
 			))
 		}
 	}
@@ -1289,7 +1285,7 @@ func (r *SingleClusterReconciler) handleK8sNodeBlockListPods(
 		if blockedK8sNodes.Has(pod.Spec.NodeName) {
 			r.Log.Info(
 				"Pod found in blocked nodes list, migrating to a different node",
-				"pod", klog.KObj(pod),
+				"pod", utils.GetNamespacedName(pod),
 			)
 
 			podsToRestart = append(podsToRestart, pod)
@@ -1373,8 +1369,8 @@ func (r *SingleClusterReconciler) isRackUpgradeNeeded(
 	podList, err := r.getRackPodList(ctx, rackID, rackRevision)
 	if err != nil {
 		return true, fmt.Errorf(
-			"list pods for rack %d in cluster %s: %w",
-			rackID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"list Pods for rack %d: %w",
+			rackID, err,
 		)
 	}
 
@@ -1386,7 +1382,7 @@ func (r *SingleClusterReconciler) isRackUpgradeNeeded(
 		}
 
 		if !r.isPodOnDesiredImage(pod, true) {
-			r.Log.Info("Pod needs upgrade/downgrade", "pod", klog.KObj(pod))
+			r.Log.Info("Pod needs upgrade/downgrade", "pod", utils.GetNamespacedName(pod))
 			return true, nil
 		}
 	}
@@ -1406,7 +1402,7 @@ func (r *SingleClusterReconciler) isRackStorageUpdatedInAeroCluster(
 		if r.isStorageVolumeSourceUpdated(volume, pod) {
 			r.Log.Info(
 				"Volume added or volume source updated in rack storage" +
-					" - pod needs rolling restart",
+					" - Pod needs rolling restart",
 			)
 
 			return true
@@ -1515,7 +1511,7 @@ func (r *SingleClusterReconciler) isStorageVolumeSourceUpdated(volume *asdbv1.Vo
 	if podVolume == nil {
 		// Volume not found in pod.volumes. This is newly added volume.
 		r.Log.Info(
-			"New volume added in rack storage - pod needs rolling" +
+			"New volume added in rack storage - Pod needs rolling" +
 				" restart",
 		)
 
@@ -1843,7 +1839,7 @@ func (r *SingleClusterReconciler) getOrderedRackPodList(ctx context.Context, rac
 
 		if indexInt >= len(podList.Items) {
 			// Happens if we do not get full list of pods due to a crash,
-			return nil, fmt.Errorf("list pods for rack %d revision %s: incomplete pod list", rackID, rackRevision)
+			return nil, fmt.Errorf("list Pods for rack %d revision %s: incomplete Pod list", rackID, rackRevision)
 		}
 
 		sortedList[(len(podList.Items)-1)-indexInt] = &podList.Items[idx]
@@ -1942,8 +1938,8 @@ func (r *SingleClusterReconciler) getPodsWithUpdatedConfigForRack(
 	pods, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"list pods for rack %d in cluster %s: %w",
-			rackState.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"list Pods for rack %d: %w",
+			rackState.Rack.ID, err,
 		)
 	}
 
@@ -2173,7 +2169,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 	if newReplicas > targetSize {
 		r.Log.Info(
 			"Migrating rack to new revisions: reconciling new revision STS to scale down",
-			"statefulSet", klog.KObj(newSts),
+			"statefulSet", utils.GetNamespacedName(newSts),
 		)
 
 		tempState := &RackState{Rack: newRack.Rack, Size: targetSize}
@@ -2215,7 +2211,7 @@ func (r *SingleClusterReconciler) reconcileRevisionChangedRacks(
 		// Scale down old rack
 		podsToScaleDown := min(batchSizeInt32, oldReplicas)
 		r.Log.Info(
-			"Migrating rack: scaling down old revision STS by a batch", "statefulSet", klog.KObj(oldSts),
+			"Migrating rack: scaling down old revision STS by a batch", "statefulSet", utils.GetNamespacedName(oldSts),
 			"batchSize", podsToScaleDown,
 		)
 
@@ -2238,8 +2234,8 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	podList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(
-			fmt.Errorf("list pods for rack %d-%s in cluster %s: %w",
-				rackState.Rack.ID, rackState.Rack.Revision, utils.GetNamespacedNameString(r.aeroCluster), err),
+			fmt.Errorf("list Pods for rack %d-%s: %w",
+				rackState.Rack.ID, rackState.Rack.Revision, err),
 		)
 	}
 
@@ -2248,7 +2244,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	failedPods = getNonIgnorablePods(failedPods, ignorablePodNames)
 
 	if len(failedPods) != 0 {
-		r.Log.Info("Reconcile the failed pods in the Rack",
+		r.Log.Info("Reconcile the failed Pods in the Rack",
 			"rackID", rackState.Rack.ID, "rackRevision", rackState.Rack.Revision,
 			"failedPods", getPodNames(failedPods))
 
@@ -2258,7 +2254,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 			return res
 		}
 
-		r.Log.Info("Reconciled the failed pods in the Rack",
+		r.Log.Info("Reconciled the failed Pods in the Rack",
 			"rackID", rackState.Rack.ID, "rackRevision", rackState.Rack.Revision,
 			"failedPods", getPodNames(failedPods))
 	}
@@ -2270,8 +2266,8 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	podList, err = r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return common.ReconcileError(
-			fmt.Errorf("re-fetch pods for restart check on rack %d-%s in cluster %s: %w",
-				rackState.Rack.ID, rackState.Rack.Revision, utils.GetNamespacedNameString(r.aeroCluster), err),
+			fmt.Errorf("re-fetch Pods for restart check on rack %d-%s: %w",
+				rackState.Rack.ID, rackState.Rack.Revision, err),
 		)
 	}
 
@@ -2280,7 +2276,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 	failedPods = getNonIgnorablePods(failedPods, ignorablePodNames)
 
 	if len(failedPods) != 0 {
-		r.Log.Info("Restart the failed pods in the Rack",
+		r.Log.Info("Restart the failed Pods in the Rack",
 			"rackID", rackState.Rack.ID, "rackRevision", rackState.Rack.Revision,
 			"failedPods", getPodNames(failedPods))
 
@@ -2291,7 +2287,7 @@ func (r *SingleClusterReconciler) handleFailedPodsInRack(
 			return res
 		}
 
-		r.Log.Info("Restarted the failed pods in the Rack",
+		r.Log.Info("Restarted the failed Pods in the Rack",
 			"rackID", rackState.Rack.ID, "rackRevision", rackState.Rack.Revision,
 			"failedPods", getPodNames(failedPods))
 		// Requeue after 1 second to fetch latest CR object with updated pod status

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -214,8 +214,8 @@ func (r *SingleClusterReconciler) createEmptyRack(ctx context.Context, rackState
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "RackCreated",
-		"[rack-%d] Created Rack", rackState.Rack.ID,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackCreated,
+		"[rack-%d] Created rack", rackState.Rack.ID,
 	)
 
 	return found, common.ReconcileSuccess()
@@ -297,9 +297,9 @@ func (r *SingleClusterReconciler) deleteRacks(
 		// Delete sts
 		if err = r.deleteSTS(ctx, found); err != nil {
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, "STSDeleteFailed",
-				"[rack-%d] Failed to delete {STS: %s/%s}", rack.ID,
-				found.Namespace, found.Name,
+				r.aeroCluster, corev1.EventTypeWarning, EventReasonStatefulSetDeleteFailed,
+				"[rack-%d] Failed to delete StatefulSet %s", rack.ID,
+				utils.GetNamespacedNameString(found),
 			)
 
 			return common.ReconcileError(err)
@@ -319,8 +319,8 @@ func (r *SingleClusterReconciler) deleteRacks(
 		}
 
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, "RackDeleted",
-			"[rack-%d] Deleted Rack", rack.ID,
+			r.aeroCluster, corev1.EventTypeNormal, EventReasonRackDeleted,
+			"[rack-%d] Deleted rack", rack.ID,
 		)
 	}
 
@@ -367,9 +367,9 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 			if res.Err != nil {
 				r.Recorder.Eventf(
 					r.aeroCluster, corev1.EventTypeWarning,
-					"RackImageUpdateFailed",
-					"[rack-%d] Failed to update Image {STS: %s/%s}",
-					rackState.Rack.ID, found.Namespace, found.Name,
+					EventReasonRackImageUpdateFailed,
+					"[rack-%d] Failed to update image for StatefulSet %s",
+					rackState.Rack.ID, utils.GetNamespacedNameString(found),
 				)
 			}
 
@@ -389,9 +389,9 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 				if res.Err != nil {
 					r.Recorder.Eventf(
 						r.aeroCluster, corev1.EventTypeWarning,
-						"RackRollingRestartFailed",
-						"[rack-%d] Failed to do rolling restart {STS: %s/%s}",
-						rackState.Rack.ID, found.Namespace, found.Name,
+						EventReasonRackRollingRestartFailed,
+						"[rack-%d] Failed to roll StatefulSet %s",
+						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
 				}
 
@@ -408,9 +408,9 @@ func (r *SingleClusterReconciler) upgradeOrRollingRestartRack(
 				if res.Err != nil {
 					r.Recorder.Eventf(
 						r.aeroCluster, corev1.EventTypeWarning,
-						"RackDynamicConfigUpdateFailed",
-						"[rack-%d] Failed to update aerospike config dynamically {STS: %s/%s}",
-						rackState.Rack.ID, found.Namespace, found.Name,
+						EventReasonRackDynamicConfigFailed,
+						"[rack-%d] Failed to update dynamic config for StatefulSet %s",
+						rackState.Rack.ID, utils.GetNamespacedNameString(found),
 					)
 				}
 
@@ -444,7 +444,7 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	r.Log.Info("Update dynamic config in Aerospike pods")
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "DynamicConfigUpdate",
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonDynamicConfigUpdate,
 		"[rack-%d] Started dynamic config update", rackState.Rack.ID,
 	)
 
@@ -482,8 +482,8 @@ func (r *SingleClusterReconciler) updateDynamicConfig(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "DynamicConfigUpdate",
-		"[rack-%d] Finished Dynamic config update", rackState.Rack.ID,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonDynamicConfigUpdated,
+		"[rack-%d] Finished dynamic config update", rackState.Rack.ID,
 	)
 
 	return common.ReconcileSuccess()
@@ -550,10 +550,11 @@ func (r *SingleClusterReconciler) reconcileRack(
 			if res.Err != nil {
 				r.Recorder.Eventf(
 					r.aeroCluster, corev1.EventTypeWarning,
-					"RackScaleDownFailed",
-					"[rack-%d] Failed to scale-down {STS %s/%s, currentSize: %d desiredSize: %d}: %s",
-					rackState.Rack.ID, found.Namespace, found.Name, currentSize,
-					desiredSize, res.Err,
+					EventReasonRackScaleDownFailed,
+					eventRackScaleFailureMessage(
+						"scale down", rackState.Rack.ID, "StatefulSet",
+						utils.GetNamespacedNameString(found), currentSize, desiredSize,
+					),
 				)
 			}
 
@@ -592,10 +593,11 @@ func (r *SingleClusterReconciler) reconcileRack(
 		found, res = r.scaleUpRack(ctx, found, rackState, ignorablePodNames)
 		if !res.IsSuccess {
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, "RackScaleUpFailed",
-				"[rack-%d] Failed to scale-up {STS %s/%s, currentSize: %d desiredSize: %d}: %s",
-				rackState.Rack.ID, found.Namespace, found.Name, currentSize,
-				desiredSize, res.Err,
+				r.aeroCluster, corev1.EventTypeWarning, EventReasonRackScaleUpFailed,
+				eventRackScaleFailureMessage(
+					"scale up", rackState.Rack.ID, "StatefulSet",
+					utils.GetNamespacedNameString(found), currentSize, desiredSize,
+				),
 			)
 
 			return res
@@ -626,9 +628,11 @@ func (r *SingleClusterReconciler) scaleUpRack(
 
 	r.Log.Info("Scaling up pods", "currentSz", oldSz, "desiredSz", desiredSize)
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "RackScaleUp",
-		"[rack-%d] Scaling-up {STS %s/%s, currentSize: %d desiredSize: %d}",
-		rackState.Rack.ID, found.Namespace, found.Name, oldSz, desiredSize,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaleUp,
+		eventRackScaleMessage(
+			"Scaling up", rackState.Rack.ID, "StatefulSet",
+			utils.GetNamespacedNameString(found), oldSz, desiredSize,
+		),
 	)
 
 	// No need for this? But if the image is bad, then new pod will also come up
@@ -699,10 +703,11 @@ func (r *SingleClusterReconciler) scaleUpRack(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "RackScaledUp",
-		"[rack-%d] Scaled-up {STS: %s/%s, currentSize: %d desiredSize: %d}",
-		rackState.Rack.ID, found.Namespace, found.Name, *found.Spec.Replicas,
-		desiredSize,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaledUp,
+		eventRackScaleMessage(
+			"Scaled up", rackState.Rack.ID, "StatefulSet",
+			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
+		),
 	)
 
 	return found, common.ReconcileSuccess()
@@ -800,8 +805,9 @@ func (r *SingleClusterReconciler) upgradeRack(
 		}
 
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, "PodImageUpdate",
-			"[rack-%d] Updating Containers on Pods %v", rackState.Rack.ID, podNames,
+			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodImageUpdate,
+			"[rack-%d] Updating containers on Pods %s",
+			rackState.Rack.ID, eventNamespacedNames(r.aeroCluster.Namespace, podNames),
 		)
 
 		res := r.safelyDeletePodsAndEnsureImageUpdated(ctx, rackState, podsBatch, ignorablePodNames)
@@ -810,8 +816,9 @@ func (r *SingleClusterReconciler) upgradeRack(
 		}
 
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, "PodImageUpdated",
-			"[rack-%d] Updated Containers on Pods %v", rackState.Rack.ID, podNames,
+			r.aeroCluster, corev1.EventTypeNormal, EventReasonPodImageUpdated,
+			"[rack-%d] Updated containers on Pods %s",
+			rackState.Rack.ID, eventNamespacedNames(r.aeroCluster.Namespace, podNames),
 		)
 
 		// Handle the next batch in subsequent Reconcile.
@@ -827,8 +834,9 @@ func (r *SingleClusterReconciler) upgradeRack(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "RackImageUpdated",
-		"[rack-%d] Image Updated {STS: %s/%s}", rackState.Rack.ID, statefulSet.Namespace, statefulSet.Name,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackImageUpdated,
+		"[rack-%d] Updated image for StatefulSet %s",
+		rackState.Rack.ID, utils.GetNamespacedNameString(statefulSet),
 	)
 
 	return statefulSet, common.ReconcileSuccess()
@@ -850,10 +858,11 @@ func (r *SingleClusterReconciler) scaleDownRack(
 		"currentSize", *found.Spec.Replicas, "rackID", rackState.Rack.ID, "rackRevision", rackState.Rack.Revision,
 	)
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "RackScaleDown",
-		"[rack-%d] Scaling-down {STS:%s/%s, currentSize: %d desiredSize: %d",
-		rackState.Rack.ID, found.Namespace, found.Name, *found.Spec.Replicas,
-		desiredSize,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaleDown,
+		eventRackScaleMessage(
+			"Scaling down", rackState.Rack.ID, "StatefulSet",
+			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
+		),
 	)
 
 	oldPodList, err := r.getOrderedRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
@@ -1054,15 +1063,17 @@ func (r *SingleClusterReconciler) scaleDownRack(
 
 	r.Log.Info("Pod Removed", "podNames", podNames)
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "PodDeleted",
-		"[rack-%d] Deleted Pods %s", rackState.Rack.ID, podNames,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonPodDeleted,
+		"[rack-%d] Deleted Pods %s",
+		rackState.Rack.ID, eventNamespacedNames(r.aeroCluster.Namespace, podNames),
 	)
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "RackScaledDown",
-		"[rack-%d] Scaled-down {STS:%s/%s, currentSize: %d desiredSize: %d",
-		rackState.Rack.ID, found.Namespace, found.Name, *found.Spec.Replicas,
-		desiredSize,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackScaledDown,
+		eventRackScaleMessage(
+			"Scaled down", rackState.Rack.ID, "StatefulSet",
+			utils.GetNamespacedNameString(found), *found.Spec.Replicas, desiredSize,
+		),
 	)
 
 	return found, common.ReconcileRequeueAfter(1)
@@ -1076,8 +1087,8 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	r.Log.Info("Rolling restart AerospikeCluster statefulset pods", "stsName", found.Name)
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "RackRollingRestart",
-		"[rack-%d] Started Rolling restart", rackState.Rack.ID,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackRollingRestart,
+		"[rack-%d] Started rolling restart", rackState.Rack.ID,
 	)
 
 	var (
@@ -1188,8 +1199,8 @@ func (r *SingleClusterReconciler) rollingRestartRack(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "RackRollingRestarted",
-		"[rack-%d] Finished Rolling restart", rackState.Rack.ID,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonRackRollingRestarted,
+		"[rack-%d] Finished rolling restart", rackState.Rack.ID,
 	)
 
 	return found, common.ReconcileSuccess()
@@ -1871,9 +1882,9 @@ func (r *SingleClusterReconciler) handleEnableSecurity(
 	// Setup access control.
 	if err := r.validateAndReconcileAccessControl(ctx, securityEnabledPods, ignorablePodNames); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, "ACLUpdateFailed",
-			"Failed to setup Access Control %s/%s", r.aeroCluster.Namespace,
-			r.aeroCluster.Name,
+			r.aeroCluster, corev1.EventTypeWarning, EventReasonAccessControlUpdateFailed,
+			"Failed to set up access control for AerospikeCluster %s",
+			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
 		return err

--- a/internal/controller/cluster/rack_test.go
+++ b/internal/controller/cluster/rack_test.go
@@ -119,7 +119,7 @@ func TestCreateEmptyRack_NilSTSOnCreateFailure(t *testing.T) {
 	})
 
 	require.NotPanics(t, func() {
-		found, res := r.createEmptyRack(rackState)
+		found, res := r.createEmptyRack(context.TODO(), rackState)
 
 		require.Nil(t, found)
 		require.False(t, res.IsSuccess)
@@ -142,7 +142,7 @@ func TestCreateEmptyRack_NilSTSOnOwnerRefFailure(t *testing.T) {
 	r.Scheme = runtime.NewScheme()
 
 	require.NotPanics(t, func() {
-		found, res := r.createEmptyRack(rackState)
+		found, res := r.createEmptyRack(context.TODO(), rackState)
 
 		require.Nil(t, found)
 		require.False(t, res.IsSuccess)
@@ -186,7 +186,7 @@ func TestCreateEmptyRack_DeletesSTSWhenReadinessFails(t *testing.T) {
 	}
 	require.NoError(t, r.Create(context.TODO(), pod))
 
-	found, res := r.createEmptyRack(rackState)
+	found, res := r.createEmptyRack(context.TODO(), rackState)
 
 	require.Nil(t, found)
 	require.False(t, res.IsSuccess)

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -75,9 +75,9 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		// The cluster is being deleted
 		if err := r.handleClusterDeletion(ctx, finalizerName); err != nil {
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, "DeleteFailed",
-				"Unable to handle AerospikeCluster delete operations %s/%s",
-				r.aeroCluster.Namespace, r.aeroCluster.Name,
+				r.aeroCluster, corev1.EventTypeWarning, EventReasonDeleteFailed,
+				"Failed to delete AerospikeCluster %s",
+				utils.GetNamespacedNameString(r.aeroCluster),
 			)
 
 			recErr = err
@@ -88,9 +88,8 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		r.removeClusterPhaseMetric()
 
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, "Deleted",
-			"Deleted AerospikeCluster %s/%s", r.aeroCluster.Namespace,
-			r.aeroCluster.Name,
+			r.aeroCluster, corev1.EventTypeNormal, EventReasonDeleted,
+			"Deleted AerospikeCluster %s", utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
 		// Stop reconciliation as the cluster is being deleted
@@ -138,9 +137,9 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	if err := r.createOrUpdateSTSHeadlessSvc(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, "ServiceCreateFailed",
-			"Failed to create Service(Headless) %s/%s",
-			r.aeroCluster.Namespace, r.aeroCluster.Name,
+			r.aeroCluster, corev1.EventTypeWarning, EventReasonServiceCreateFailed,
+			"Failed to create headless Service for AerospikeCluster %s",
+			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
 		recErr = err
@@ -152,9 +151,9 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	if res := r.reconcileRacks(ctx); !res.IsSuccess {
 		if res.Err != nil {
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, "UpdateFailed",
-				"Failed to reconcile Racks for cluster %s/%s",
-				r.aeroCluster.Namespace, r.aeroCluster.Name,
+				r.aeroCluster, corev1.EventTypeWarning, EventReasonRackReconcileFailed,
+				"Failed to reconcile racks for AerospikeCluster %s",
+				utils.GetNamespacedNameString(r.aeroCluster),
 			)
 
 			recErr = res.Err
@@ -165,9 +164,9 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	if err := r.reconcilePDB(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, "PodDisruptionBudgetReconcileFailed",
-			"Failed to reconcile PodDisruptionBudget %s/%s",
-			r.aeroCluster.Namespace, r.aeroCluster.Name,
+			r.aeroCluster, corev1.EventTypeWarning, EventReasonPodDisruptionBudgetReconcileFailed,
+			"Failed to reconcile PodDisruptionBudget for AerospikeCluster %s",
+			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
 		recErr = err
@@ -177,9 +176,9 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	if err := r.reconcileSTSLoadBalancerSvc(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, "ServiceCreateFailed",
-			"Failed to create Service(LoadBalancer) %s/%s",
-			r.aeroCluster.Namespace, r.aeroCluster.Name,
+			r.aeroCluster, corev1.EventTypeWarning, EventReasonServiceCreateFailed,
+			"Failed to create LoadBalancer Service for AerospikeCluster %s",
+			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
 		recErr = err
@@ -220,9 +219,9 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	// Assuming all pods must be security enabled or disabled.
 	if err = r.validateAndReconcileAccessControl(ctx, nil, ignorablePodNames); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, "ACLUpdateFailed",
-			"Failed to setup Access Control %s/%s", r.aeroCluster.Namespace,
-			r.aeroCluster.Name,
+			r.aeroCluster, corev1.EventTypeWarning, EventReasonAccessControlUpdateFailed,
+			"Failed to set up access control for AerospikeCluster %s",
+			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
 		recErr = err
@@ -277,9 +276,9 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	// Update the AerospikeCluster status.
 	if err = r.updateStatus(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, "StatusUpdateFailed",
-			"Failed to update AerospikeCluster status %s/%s",
-			r.aeroCluster.Namespace, r.aeroCluster.Name,
+			r.aeroCluster, corev1.EventTypeWarning, EventReasonStatusUpdateFailed,
+			"Failed to update status for AerospikeCluster %s",
+			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
 		recErr = err
@@ -434,17 +433,17 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, "ACLUpdated",
-		"Updated Access Control %s/%s", r.aeroCluster.Namespace,
-		r.aeroCluster.Name,
+		r.aeroCluster, corev1.EventTypeNormal, EventReasonAccessControlUpdated,
+		"Updated access control for AerospikeCluster %s",
+		utils.GetNamespacedNameString(r.aeroCluster),
 	)
 
 	// Update the AerospikeCluster status.
 	if err := r.updateAccessControlStatus(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, "StatusUpdateFailed",
-			"Failed to update AerospikeCluster access control status %s/%s",
-			r.aeroCluster.Namespace, r.aeroCluster.Name,
+			r.aeroCluster, corev1.EventTypeWarning, EventReasonStatusUpdateFailed,
+			"Failed to update access control status for AerospikeCluster %s",
+			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
 		return err

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -351,11 +351,11 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 					return common.ReconcileError(err)
 				}
 
-			if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
-				return common.ReconcileError(fmt.Errorf("delete pod %s: %w", utils.GetNamespacedNameString(&podList.Items[idx]), err))
-			}
+				if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
+					return common.ReconcileError(fmt.Errorf("delete pod %s: %w", utils.GetNamespacedNameString(&podList.Items[idx]), err))
+				}
 
-			r.Log.Info("Deleted pod", "pod", podList.Items[idx].Name)
+				r.Log.Info("Deleted pod", "pod", podList.Items[idx].Name)
 			}
 		}
 	}
@@ -497,7 +497,7 @@ func (r *SingleClusterReconciler) updateStatus(ctx context.Context) error {
 
 	err = r.patchStatus(ctx, newAeroCluster)
 	if err != nil {
-		return fmt.Errorf("updating status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error updating status: %w", err)
 	}
 
 	r.aeroCluster = newAeroCluster
@@ -582,7 +582,7 @@ func (r *SingleClusterReconciler) updateAccessControlStatus(ctx context.Context)
 	newAeroCluster.Status.AerospikeAccessControl = statusAerospikeAccessControl
 
 	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
-		return fmt.Errorf("updating access control status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error updating status: %w", err)
 	}
 
 	r.Log.Info("Updated access control status", "status", newAeroCluster.Status)
@@ -610,7 +610,7 @@ func (r *SingleClusterReconciler) createStatus(ctx context.Context) error {
 	if err := r.Client.Status().Update(
 		ctx, newAeroCluster,
 	); err != nil {
-		return fmt.Errorf("creating status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error creating status: %w", err)
 	}
 
 	return nil
@@ -691,17 +691,17 @@ func (r *SingleClusterReconciler) patchStatus(ctx context.Context, newAeroCluste
 
 	oldJSON, err := json.Marshal(oldAeroCluster)
 	if err != nil {
-		return fmt.Errorf("marshalling old status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error marshalling old status: %w", err)
 	}
 
 	newJSON, err := json.Marshal(newAeroCluster)
 	if err != nil {
-		return fmt.Errorf("marshalling new status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error marshalling new status: %w", err)
 	}
 
 	jsonPatchPatch, err := jsonpatch.CreatePatch(oldJSON, newJSON)
 	if err != nil {
-		return fmt.Errorf("creating json patch for status of cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error creating json patch: %w", err)
 	}
 
 	// Pick changes to the status object only.
@@ -731,7 +731,7 @@ func (r *SingleClusterReconciler) patchStatus(ctx context.Context, newAeroCluste
 
 	jsonPatchJSON, err := json.Marshal(filteredPatch)
 	if err != nil {
-		return fmt.Errorf("marshalling json patch for status of cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error marshalling json patch: %w", err)
 	}
 
 	patch := client.RawPatch(types.JSONPatchType, jsonPatchJSON)
@@ -743,7 +743,7 @@ func (r *SingleClusterReconciler) patchStatus(ctx context.Context, newAeroCluste
 		}}, patch,
 		client.FieldOwner(patchFieldOwner),
 	); err != nil {
-		return fmt.Errorf("patching status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("error patching status: %w", err)
 	}
 
 	// FIXME: Json unmarshal used by above client.Status(),
@@ -774,8 +774,8 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 	statefulSetList, err := r.getClusterSTSList(ctx)
 	if err != nil {
 		return fmt.Errorf(
-			"listing statefulsets while forcing recreate of cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			"error getting statefulsets while forcing recreate of the cluster as status is nil: %w",
+			err,
 		)
 	}
 
@@ -788,8 +788,8 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 		statefulset := &statefulSetList.Items[idx]
 		if err := r.deleteSTS(ctx, statefulset); err != nil {
 			return fmt.Errorf(
-				"deleting statefulset %s while forcing recreate of cluster: %w",
-				utils.GetNamespacedNameString(statefulset), err,
+				"error deleting statefulset while forcing recreate of the cluster as status is nil: %w",
+				err,
 			)
 		}
 	}
@@ -812,10 +812,7 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 
 		pods, err := r.getRackPodList(ctx, state.Rack.ID, state.Rack.Revision)
 		if err != nil {
-			return fmt.Errorf(
-				"listing pods for rack %d while recovering cluster %s after create failure: %w",
-				state.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
-			)
+			return fmt.Errorf("failed recover failed cluster: %w", err)
 		}
 
 		newPodNames := make([]string, 0)
@@ -939,7 +936,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 
 		rackPVCItems, err := r.getRackPVCList(ctx, rack.ID, rack.Revision)
 		if err != nil {
-			return fmt.Errorf("listing pvcs for rack %d in cluster %s: %w", rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
+			return fmt.Errorf("could not find pvc for rack %d in cluster %s: %w", rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 
 		storage := rack.Storage
@@ -951,7 +948,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 	// Delete PVCs for any remaining old removed racks
 	pvcItems, err := r.getClusterPVCList(ctx)
 	if err != nil {
-		return fmt.Errorf("listing pvcs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("could not find pvc for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	// removePVCs should be passed only filtered pvc otherwise rack pvc may be removed using global storage
@@ -1004,7 +1001,7 @@ func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, fin
 func (r *SingleClusterReconciler) checkPreviouslyFailedCluster(ctx context.Context) (bool, common.ReconcileResult) {
 	isNew, err := r.isNewCluster(ctx)
 	if err != nil {
-		return false, common.ReconcileError(fmt.Errorf("determining if cluster %s is new: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+		return false, common.ReconcileError(fmt.Errorf("error determining if cluster is new: %w", err))
 	}
 
 	if isNew {
@@ -1021,7 +1018,7 @@ func (r *SingleClusterReconciler) checkPreviouslyFailedCluster(ctx context.Conte
 
 		hasFailed, inGracePeriod, err := r.hasClusterFailed(ctx)
 		if err != nil {
-			return false, common.ReconcileError(fmt.Errorf("checking cluster %s failure state: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
+			return false, common.ReconcileError(fmt.Errorf("error determining if cluster has failed: %w", err))
 		}
 
 		if hasFailed {
@@ -1068,16 +1065,16 @@ func (r *SingleClusterReconciler) IsStatusEmpty() bool {
 func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, hasFailed bool) error {
 	if !hasFailed {
 		if int(r.aeroCluster.Spec.Size) > len(r.aeroCluster.Status.Pods) {
-			return fmt.Errorf("cluster %s is not ready for migration: pod status is not populated", utils.ClusterNamespacedName(r.aeroCluster))
+			return fmt.Errorf("cluster is not ready for migration, pod status is not populated")
 		}
 
 		if err := r.migrateInitialisedVolumeNames(ctx); err != nil {
-			return fmt.Errorf("migrating initialized volume names for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+			return err
 		}
 	}
 
 	if err := r.AddAPIVersionLabel(ctx); err != nil {
-		return fmt.Errorf("adding api version label to cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return err
 	}
 
 	return nil
@@ -1102,7 +1099,7 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 		pod := &podList.Items[podIdx]
 
 		if _, ok := r.aeroCluster.Status.Pods[pod.Name]; !ok {
-			return fmt.Errorf("empty status found in cluster %s for pod %s", utils.ClusterNamespacedName(r.aeroCluster), utils.GetNamespacedNameString(pod))
+			return fmt.Errorf("empty status found in CR for pod %s", pod.Name)
 		}
 
 		initializedVolumes := r.aeroCluster.Status.Pods[pod.Name].InitializedVolumes
@@ -1126,11 +1123,7 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 				}
 
 				if pvcUID == "" {
-					return fmt.Errorf(
-						"empty pvcUID found for volume %q on pod %s in cluster %s",
-						oldFormatInitVolNames[oldVolIdx], utils.GetNamespacedNameString(pod),
-						utils.ClusterNamespacedName(r.aeroCluster),
-					)
+					return fmt.Errorf("found empty pvcUID for the volume %s", oldFormatInitVolNames[oldVolIdx])
 				}
 
 				// Appending volume name as <vol_name>@<pvcUID> in initializedVolumes list

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -188,7 +188,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("reconcile access control: %w", err)
 	}
 
 	// Use policy from spec after setting up access control
@@ -351,13 +351,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	ctx context.Context,
 	selectedPods []corev1.Pod,
 	ignorablePodNames sets.Set[string],
-) (err error) {
-	defer func() {
-		if err != nil {
-			err = fmt.Errorf("reconcile access control: %w", err)
-		}
-	}()
-
+) error {
 	enabled, err := asdbv1.IsSecurityEnabled(r.aeroCluster.Spec.AerospikeConfig.Value)
 	if err != nil {
 		return fmt.Errorf("get cluster security status: %w", err)
@@ -800,7 +794,7 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 
 		if err := r.cleanupPodMeshAndStatus(ctx, newPodNames); err != nil {
 			return fmt.Errorf(
-				"clean up Pod mesh and status for rack %d after create failure: %w",
+				"clean up Pod mesh and status for rack %d during failed cluster recovery: %w",
 				state.Rack.ID, err,
 			)
 		}
@@ -1066,7 +1060,8 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 		pod := &podList.Items[podIdx]
 
 		if _, ok := r.aeroCluster.Status.Pods[pod.Name]; !ok {
-			return fmt.Errorf("empty status found in CR for Pod %s", pod.Name)
+			return fmt.Errorf("empty status for Pod %s in CR",
+				utils.GetNamespacedNameString(pod))
 		}
 
 		initializedVolumes := r.aeroCluster.Status.Pods[pod.Name].InitializedVolumes
@@ -1090,7 +1085,7 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 				}
 
 				if pvcUID == "" {
-					return fmt.Errorf("found empty pvcUID for the volume %s", oldFormatInitVolNames[oldVolIdx])
+					return fmt.Errorf("volume %s: empty pvcUID", oldFormatInitVolNames[oldVolIdx])
 				}
 
 				// Appending volume name as <vol_name>@<pvcUID> in initializedVolumes list

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -52,21 +52,8 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	// Set the status phase to Error if the recErr is not nil
 	// recErr is only set when reconcile failure should result in Error phase of the cluster
 	defer func() {
-		logValues := reconcileExitLogValues(result, recErr)
-		if recErr != nil {
-			if err := r.setStatusPhase(ctx, asdbv1.AerospikeClusterError); err != nil {
-				recErr = fmt.Errorf(
-					"%w; setting error phase for cluster %s: %w",
-					recErr, utils.ClusterNamespacedName(r.aeroCluster), err,
-				)
-			}
-
-			r.Log.Error(recErr, "Reconcile failed", logValues...)
-
-			return
-		}
-
-		r.Log.Info("Reconcile completed", logValues...)
+		// finishReconcile returns the error to assign here so we avoid *error params; recErr is Reconcile's named return.
+		recErr = r.finishReconcile(ctx, result, recErr)
 	}()
 
 	// Check DeletionTimestamp to see if the cluster is being deleted
@@ -112,7 +99,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	// The cluster is not being deleted, add finalizer if not added already
 	if err := r.addFinalizer(ctx, finalizerName); err != nil {
-		recErr = err
+		recErr = fmt.Errorf(
+			"could not add finalizer for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 
 		return reconcile.Result{}, recErr
 	}
@@ -142,7 +132,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = err
+		recErr = fmt.Errorf(
+			"could not create or update headless Service for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 
 		return reconcile.Result{}, recErr
 	}
@@ -169,7 +162,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = err
+		recErr = fmt.Errorf(
+			"could not reconcile PodDisruptionBudget for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 
 		return reconcile.Result{}, recErr
 	}
@@ -181,14 +177,20 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = err
+		recErr = fmt.Errorf(
+			"could not reconcile LoadBalancer Service for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 
 		return reconcile.Result{}, recErr
 	}
 
 	ignorablePodNames, err := r.getIgnorablePods(ctx, nil, getConfiguredRackStateList(r.aeroCluster), nil)
 	if err != nil {
-		recErr = err
+		recErr = fmt.Errorf(
+			"could not determine pods to be ignored for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 
 		return reconcile.Result{}, recErr
 	}
@@ -210,7 +212,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		r.Log,
 		r.getClientPolicy(ctx), allHostConns,
 	); err != nil {
-		recErr = err
+		recErr = fmt.Errorf(
+			"could not undo quiesce state for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 
 		return reconcile.Result{}, recErr
 	}
@@ -224,7 +229,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = err
+		recErr = fmt.Errorf(
+			"could not reconcile access control for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 
 		return reconcile.Result{}, recErr
 	}
@@ -239,7 +247,12 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		ctx, policy, &r.aeroCluster.Spec.RackConfig.Racks[0].AerospikeConfig,
 		false, ignorablePodNames,
 	); !res.IsSuccess {
-		recErr = res.Err
+		if res.Err != nil {
+			recErr = fmt.Errorf(
+				"could not revert migrate-fill-delay for cluster %s: %w",
+				utils.ClusterNamespacedName(r.aeroCluster), res.Err,
+			)
+		}
 
 		return reconcile.Result{}, recErr
 	}
@@ -250,7 +263,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			r.Log,
 			policy, allHostConns,
 		); err != nil {
-			recErr = err
+			recErr = fmt.Errorf(
+				"could not run recluster for cluster %s: %w",
+				utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 
 			return reconcile.Result{}, recErr
 		}
@@ -267,7 +283,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 		// Setup roster
 		if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
-			recErr = err
+			recErr = fmt.Errorf(
+				"could not set roster for cluster %s: %w",
+				utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 
 			return reconcile.Result{}, recErr
 		}
@@ -281,7 +300,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = err
+		recErr = fmt.Errorf(
+			"could not update AerospikeCluster status for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 
 		return reconcile.Result{}, recErr
 	}
@@ -298,16 +320,37 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	return reconcile.Result{}, nil
 }
 
+// finishReconcile runs at end of Reconcile; return value is assigned to Reconcile's named recErr in defer.
+func (r *SingleClusterReconciler) finishReconcile(ctx context.Context, result ctrl.Result, recErr error) error {
+	logValues := reconcileExitLogValues(result, recErr)
+	if recErr != nil {
+		if err := r.setStatusPhase(ctx, asdbv1.AerospikeClusterError); err != nil {
+			recErr = fmt.Errorf(
+				"%w; setting error phase for cluster %s: %w",
+				recErr, utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
+		}
+
+		r.Log.Error(recErr, "Reconcile failed", logValues...)
+
+		return recErr
+	}
+
+	r.Log.Info("Reconcile completed", logValues...)
+
+	return nil
+}
+
 func reconcileExitLogValues(result ctrl.Result, recErr error) []interface{} {
 	if recErr != nil {
 		return []interface{}{"result", "error"}
 	}
 
 	if result.RequeueAfter > 0 {
-		values := []interface{}{"result", "requeue"}
-		values = append(values, "requeueAfter", result.RequeueAfter.String())
-
-		return values
+		return []interface{}{
+			"result", "requeue",
+			"requeueAfter", result.RequeueAfter.String(),
+		}
 	}
 
 	return []interface{}{"result", "success"}
@@ -317,7 +360,10 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 	ctx context.Context, ignorablePodNames sets.Set[string]) common.ReconcileResult {
 	podList, gErr := r.getClusterPodList(ctx)
 	if gErr != nil {
-		return common.ReconcileError(fmt.Errorf("could not list pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), gErr))
+		return common.ReconcileError(fmt.Errorf(
+			"could not list pods for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), gErr,
+		))
 	}
 
 	r.Log.Info("Try to recover failed/pending pods if any")
@@ -352,7 +398,10 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 				}
 
 				if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
-					return common.ReconcileError(fmt.Errorf("could not delete pod %s: %w", utils.GetNamespacedNameString(&podList.Items[idx]), err))
+					return common.ReconcileError(fmt.Errorf(
+						"could not delete pod %s: %w",
+						utils.GetNamespacedNameString(&podList.Items[idx]), err,
+					))
 				}
 
 				r.Log.Info("Deleted pod", "pod", podList.Items[idx].Name)
@@ -418,7 +467,10 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 
 	aeroClient, err := as.NewClientWithPolicyAndHost(clientPolicy, hosts...)
 	if err != nil {
-		return fmt.Errorf("could not create Aerospike client for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf(
+			"could not create Aerospike client for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	defer aeroClient.Close()
@@ -429,7 +481,10 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 		ctx, aeroClient, pp,
 	)
 	if err != nil {
-		return fmt.Errorf("could not reconcile access control for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf(
+			"could not reconcile access control for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	r.Recorder.Eventf(
@@ -522,7 +577,10 @@ func (r *SingleClusterReconciler) setStatusPhase(ctx context.Context, phase asdb
 			// detached: status update must complete even if the reconcile context is cancelled
 			return r.Client.Status().Update(context.Background(), r.aeroCluster)
 		}); err != nil {
-			return fmt.Errorf("could not set cluster status phase to %s for cluster %s: %w", phase, utils.ClusterNamespacedName(r.aeroCluster), err)
+			return fmt.Errorf(
+				"could not set cluster status phase to %s for cluster %s: %w",
+				phase, utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 		}
 
 		r.addClusterPhaseMetric()
@@ -936,12 +994,18 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 
 		rackPVCItems, err := r.getRackPVCList(ctx, rack.ID, rack.Revision)
 		if err != nil {
-			return fmt.Errorf("could not find pvc for rack %d in cluster %s: %w", rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
+			return fmt.Errorf(
+				"could not find pvc for rack %d in cluster %s: %w",
+				rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 		}
 
 		storage := rack.Storage
 		if _, err := r.removePVCsAsync(ctx, &storage, rackPVCItems); err != nil {
-			return fmt.Errorf("could not remove PVCs for rack %d in cluster %s: %w", rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
+			return fmt.Errorf(
+				"could not remove PVCs for rack %d in cluster %s: %w",
+				rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 		}
 	}
 
@@ -992,7 +1056,10 @@ func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, fin
 
 	// The cluster is being deleted
 	if err := r.cleanUpAndRemoveFinalizer(ctx, finalizerName); err != nil {
-		return fmt.Errorf("could not finish cluster deletion (remove finalizer) for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf(
+			"could not finish cluster deletion (remove finalizer) for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	return nil
@@ -1069,12 +1136,18 @@ func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, h
 		}
 
 		if err := r.migrateInitialisedVolumeNames(ctx); err != nil {
-			return err
+			return fmt.Errorf(
+				"could not patch initialised volumes for cluster %s: %w",
+				utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 		}
 	}
 
 	if err := r.AddAPIVersionLabel(ctx); err != nil {
-		return err
+		return fmt.Errorf(
+			"could not patch API version label for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	return nil

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -186,7 +186,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		return reconcile.Result{}, recErr
 	}
 
-	ignorablePodNames, err := r.getIgnorablePods(ctx, nil, getConfiguredRackStateList(r.aeroCluster), nil)
+	ignorablePodNames, err := r.getIgnorablePods(ctx, nil, getConfiguredRackStateList(r.aeroCluster))
 	if err != nil {
 		recErr = fmt.Errorf(
 			"could not determine pods to be ignored for cluster %s: %w",
@@ -879,9 +879,9 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 			newPodNames = append(newPodNames, pods.Items[podIdx].Name)
 		}
 
-		if err := r.cleanupPods(ctx, newPodNames, &state); err != nil {
+		if err := r.cleanupPodMeshAndStatus(ctx, newPodNames); err != nil {
 			return fmt.Errorf(
-				"cleaning up pods for rack %d while recovering cluster %s after create failure: %w",
+				"cleaning up pod mesh and status for rack %d while recovering cluster %s after create failure: %w",
 				state.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -43,6 +42,10 @@ type SingleClusterReconciler struct {
 	KubeConfig  *rest.Config
 	Scheme      *k8sRuntime.Scheme
 	Log         logr.Logger
+}
+
+func (r *SingleClusterReconciler) asConfigLog() logr.Logger {
+	return r.Log.WithName("lib.asconfig")
 }
 
 func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Result, recErr error) {
@@ -97,10 +100,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	// The cluster is not being deleted, add finalizer if not added already
 	if err := r.addFinalizer(ctx, finalizerName); err != nil {
-		return reconcile.Result{}, fmt.Errorf(
-			"add finalizer for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, fmt.Errorf("add finalizer: %w", err)
 	}
 
 	// Handle previously failed cluster
@@ -124,10 +124,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		return reconcile.Result{}, fmt.Errorf(
-			"create or update headless Service for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, fmt.Errorf("create or update headless Service: %w", err)
 	}
 
 	// Reconcile all racks
@@ -150,10 +147,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		return reconcile.Result{}, fmt.Errorf(
-			"reconcile PodDisruptionBudget for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, fmt.Errorf("reconcile PodDisruptionBudget: %w", err)
 	}
 
 	if err := r.reconcileSTSLoadBalancerSvc(ctx); err != nil {
@@ -163,37 +157,26 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		return reconcile.Result{}, fmt.Errorf(
-			"reconcile LoadBalancer Service for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, fmt.Errorf("reconcile LoadBalancer Service: %w", err)
 	}
 
 	ignorablePodNames, err := r.getIgnorablePods(ctx, nil, getConfiguredRackStateList(r.aeroCluster))
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf(
-			"determine ignorable pods for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, fmt.Errorf("determine ignorable Pods: %w", err)
 	}
 
 	// Check if there is any node with quiesce status. We need to undo that
 	// It may have been left from previous steps
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf(
-			"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, fmt.Errorf("get host connections for cluster nodes: %w", err)
 	}
 
 	if err = deployment.InfoQuiesceUndo(
 		r.Log,
 		r.getClientPolicy(ctx), allHostConns,
 	); err != nil {
-		return reconcile.Result{}, fmt.Errorf(
-			"undo quiesce state for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, fmt.Errorf("undo quiesce state: %w", err)
 	}
 
 	// Setup access control.
@@ -205,10 +188,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		return reconcile.Result{}, fmt.Errorf(
-			"reconcile access control for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, err
 	}
 
 	// Use policy from spec after setting up access control
@@ -222,10 +202,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		false, ignorablePodNames,
 	); !res.IsSuccess {
 		if res.Err != nil {
-			return reconcile.Result{}, fmt.Errorf(
-				"revert migrate-fill-delay for cluster %s: %w",
-				utils.GetNamespacedNameString(r.aeroCluster), res.Err,
-			)
+			return reconcile.Result{}, fmt.Errorf("revert migrate-fill-delay: %w", res.Err)
 		}
 
 		return reconcile.Result{}, nil
@@ -237,10 +214,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			r.Log,
 			policy, allHostConns,
 		); err != nil {
-			return reconcile.Result{}, fmt.Errorf(
-				"run recluster for cluster %s: %w",
-				utils.GetNamespacedNameString(r.aeroCluster), err,
-			)
+			return reconcile.Result{}, fmt.Errorf("run recluster: %w", err)
 		}
 	}
 
@@ -253,10 +227,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 		// Setup roster
 		if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
-			return reconcile.Result{}, fmt.Errorf(
-				"set roster for cluster %s: %w",
-				utils.GetNamespacedNameString(r.aeroCluster), err,
-			)
+			return reconcile.Result{}, fmt.Errorf("set roster: %w", err)
 		}
 	}
 
@@ -268,10 +239,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		return reconcile.Result{}, fmt.Errorf(
-			"update AerospikeCluster status for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return reconcile.Result{}, fmt.Errorf("update AerospikeCluster status: %w", err)
 	}
 
 	// Try to recover pods only if there are any ignorable pods, which may be failed or pending.
@@ -291,10 +259,7 @@ func (r *SingleClusterReconciler) finishReconcile(ctx context.Context, result ct
 		if err := r.setStatusPhase(ctx, asdbv1.AerospikeClusterError); err != nil {
 			recErr = errors.Join(
 				recErr,
-				fmt.Errorf(
-					"setting error phase for cluster %s: %w",
-					utils.GetNamespacedNameString(r.aeroCluster), err,
-				),
+				fmt.Errorf("setting error phase: %w", err),
 			)
 		}
 
@@ -327,13 +292,10 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 	ctx context.Context, ignorablePodNames sets.Set[string]) common.ReconcileResult {
 	podList, gErr := r.getClusterPodList(ctx)
 	if gErr != nil {
-		return common.ReconcileError(fmt.Errorf(
-			"list pods for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), gErr,
-		))
+		return common.ReconcileError(fmt.Errorf("list Pods: %w", gErr))
 	}
 
-	r.Log.Info("Try to recover failed/pending pods if any")
+	r.Log.Info("Try to recover failed/pending Pods if any")
 
 	var (
 		anyPodFailed    bool
@@ -351,7 +313,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 				if podState.State == utils.PodFailedInGrace {
 					r.Log.Info(
 						"Pod is in failed state but within grace period, will not delete",
-						"pod", klog.KObj(&podList.Items[idx]),
+						"pod", utils.GetNamespacedName(&podList.Items[idx]),
 					)
 
 					requeueInterval = asdbv1.RequeueIntervalSeconds10
@@ -366,20 +328,20 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 
 				if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
 					return common.ReconcileError(fmt.Errorf(
-						"delete pod %s: %w",
+						"delete Pod %s: %w",
 						utils.GetNamespacedNameString(&podList.Items[idx]), err,
 					))
 				}
 
-				r.Log.Info("Deleted pod", "pod", klog.KObj(&podList.Items[idx]))
+				r.Log.Info("Deleted Pod", "pod", utils.GetNamespacedName(&podList.Items[idx]))
 			}
 		}
 	}
 
 	if anyPodFailed {
-		r.Log.Info("Found failed/pending pod(s), requeuing")
+		r.Log.Info("Found failed/pending Pod(s), requeuing")
 	} else {
-		r.Log.Info("Found ignorable pod(s), requeuing")
+		r.Log.Info("Found ignorable Pod(s), requeuing")
 	}
 
 	return common.ReconcileRequeueAfter(requeueInterval)
@@ -389,7 +351,13 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	ctx context.Context,
 	selectedPods []corev1.Pod,
 	ignorablePodNames sets.Set[string],
-) error {
+) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("reconcile access control: %w", err)
+		}
+	}()
+
 	enabled, err := asdbv1.IsSecurityEnabled(r.aeroCluster.Spec.AerospikeConfig.Value)
 	if err != nil {
 		return fmt.Errorf("get cluster security status: %w", err)
@@ -406,14 +374,12 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	if selectedPods == nil {
 		conns, err = r.newAllHostConnWithOption(ctx, ignorablePodNames)
 		if err != nil {
-			return fmt.Errorf("get host connections for cluster %s nodes: %w",
-				utils.GetNamespacedNameString(r.aeroCluster), err)
+			return fmt.Errorf("get host connections for cluster nodes: %w", err)
 		}
 	} else {
 		conns, err = r.newPodsHostConnWithOption(selectedPods, ignorablePodNames)
 		if err != nil {
-			return fmt.Errorf("get host connections for selected pods of cluster %s: %w",
-				utils.GetNamespacedNameString(r.aeroCluster), err)
+			return fmt.Errorf("get host connections for selected Pods: %w", err)
 		}
 	}
 
@@ -434,10 +400,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 
 	aeroClient, err := as.NewClientWithPolicyAndHost(clientPolicy, hosts...)
 	if err != nil {
-		return fmt.Errorf(
-			"create Aerospike client for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return fmt.Errorf("create Aerospike client: %w", err)
 	}
 
 	defer aeroClient.Close()
@@ -448,10 +411,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 		ctx, aeroClient, pp,
 	)
 	if err != nil {
-		return fmt.Errorf(
-			"reconcile access control for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return err
 	}
 
 	r.Recorder.Eventf(
@@ -541,13 +501,9 @@ func (r *SingleClusterReconciler) setStatusPhase(ctx context.Context, phase asdb
 
 			r.aeroCluster.Status.Phase = phase
 
-			// detached: status update must complete even if the reconcile context is cancelled
-			return r.Client.Status().Update(context.Background(), r.aeroCluster)
+			return r.Client.Status().Update(ctx, r.aeroCluster)
 		}); err != nil {
-			return fmt.Errorf(
-				"set cluster status phase to %s for cluster %s: %w",
-				phase, utils.GetNamespacedNameString(r.aeroCluster), err,
-			)
+			return fmt.Errorf("set cluster status phase to %s: %w", phase, err)
 		}
 
 		r.addClusterPhaseMetric()
@@ -798,14 +754,11 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 	// Delete all statefulsets and everything related so that it can be properly created and updated in next run.
 	statefulSetList, err := r.getClusterSTSList(ctx)
 	if err != nil {
-		return fmt.Errorf(
-			"get StatefulSets while forcing recreate of cluster %s (status is nil): %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return fmt.Errorf("get StatefulSets while forcing recreate of cluster (status is nil): %w", err)
 	}
 
 	r.Log.V(1).Info(
-		"Found statefulset for cluster. Need to delete them", "nSTS",
+		"Found StatefulSet for cluster. Need to delete them", "nSTS",
 		len(statefulSetList.Items),
 	)
 
@@ -813,8 +766,8 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 		statefulset := &statefulSetList.Items[idx]
 		if err := r.deleteSTS(ctx, statefulset); err != nil {
 			return fmt.Errorf(
-				"delete StatefulSet %s while forcing recreate of cluster %s (status is nil): %w",
-				utils.GetNamespacedNameString(statefulset), utils.GetNamespacedNameString(r.aeroCluster), err,
+				"delete StatefulSet %s while forcing recreate of cluster (status is nil): %w",
+				utils.GetNamespacedNameString(statefulset), err,
 			)
 		}
 	}
@@ -822,10 +775,7 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 	// Delete all PVCs for the cluster unconditionally, regardless of the cascadeDelete flag on
 	// individual volumes. During a failed-create recovery the cluster must start completely fresh.
 	if err := r.deleteAllClusterPVCsForce(ctx); err != nil {
-		return fmt.Errorf(
-			"deleting cluster PVCs while forcing recreate of cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return fmt.Errorf("delete cluster PVCs while forcing recreate: %w", err)
 	}
 
 	// Clear pod status, mesh references, and per-pod services.
@@ -838,8 +788,8 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 		pods, err := r.getRackPodList(ctx, state.Rack.ID, state.Rack.Revision)
 		if err != nil {
 			return fmt.Errorf(
-				"list pods for rack %d in cluster %s during failed cluster recovery: %w",
-				state.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+				"list Pods for rack %d during failed cluster recovery: %w",
+				state.Rack.ID, err,
 			)
 		}
 
@@ -850,8 +800,8 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 
 		if err := r.cleanupPodMeshAndStatus(ctx, newPodNames); err != nil {
 			return fmt.Errorf(
-				"cleaning up pod mesh and status for rack %d while recovering cluster %s after create failure: %w",
-				state.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+				"clean up Pod mesh and status for rack %d after create failure: %w",
+				state.Rack.ID, err,
 			)
 		}
 	}
@@ -863,15 +813,10 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 	// those old credentials on the newly recreated nodes, causing info commands
 	// to fail.
 	if err := r.clearAerospikeAccessControlStatus(ctx); err != nil {
-		return fmt.Errorf(
-			"clearing access control status while recovering cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return fmt.Errorf("clear access control status during cluster recovery: %w", err)
 	}
 
-	return fmt.Errorf(
-		"forcing recreate of cluster %s: status is nil", utils.GetNamespacedNameString(r.aeroCluster),
-	)
+	return fmt.Errorf("forcing recreate of cluster: status is nil")
 }
 
 // clearAerospikeAccessControlStatus sets AerospikeAccessControl to nil in the
@@ -889,19 +834,13 @@ func (r *SingleClusterReconciler) clearAerospikeAccessControlStatus(ctx context.
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, newAeroCluster,
 	); err != nil {
-		return fmt.Errorf(
-			"getting AerospikeCluster %s for access control status clear: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return fmt.Errorf("get AerospikeCluster for access control status clear: %w", err)
 	}
 
 	newAeroCluster.Status.AerospikeAccessControl = nil
 
 	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
-		return fmt.Errorf(
-			"clearing access control status for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return fmt.Errorf("clear access control status: %w", err)
 	}
 
 	r.Log.Info("Cleared access control status for cluster recovery")
@@ -956,7 +895,7 @@ func (r *SingleClusterReconciler) cleanUpAndRemoveFinalizer(ctx context.Context,
 
 func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) error {
 	// Delete should be idempotent
-	r.Log.Info("Removing pvc for removed cluster")
+	r.Log.Info("Removing PVC for removed cluster")
 
 	// Delete pvc for all rack storage
 	for idx := range r.aeroCluster.Spec.RackConfig.Racks {
@@ -964,25 +903,19 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 
 		rackPVCItems, err := r.getRackPVCList(ctx, rack.ID, rack.Revision)
 		if err != nil {
-			return fmt.Errorf(
-				"find PVCs for rack %d in cluster %s: %w",
-				rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
-			)
+			return fmt.Errorf("find PVCs for rack %d: %w", rack.ID, err)
 		}
 
 		storage := rack.Storage
 		if _, err := r.removePVCsAsync(ctx, &storage, rackPVCItems); err != nil {
-			return fmt.Errorf(
-				"remove PVCs for rack %d in cluster %s: %w",
-				rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
-			)
+			return fmt.Errorf("remove PVCs for rack %d: %w", rack.ID, err)
 		}
 	}
 
 	// Delete PVCs for any remaining old removed racks
 	pvcItems, err := r.getClusterPVCList(ctx)
 	if err != nil {
-		return fmt.Errorf("find PVC for cluster %s: %w", utils.GetNamespacedNameString(r.aeroCluster), err)
+		return fmt.Errorf("find PVC for cluster: %w", err)
 	}
 
 	// removePVCs should be passed only filtered pvc otherwise rack pvc may be removed using global storage
@@ -1015,7 +948,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 	if _, err := r.removePVCsAsync(
 		ctx, &r.aeroCluster.Spec.Storage, filteredPVCItems,
 	); err != nil {
-		return fmt.Errorf("remove PVCs for cluster %s: %w", utils.GetNamespacedNameString(r.aeroCluster), err)
+		return fmt.Errorf("remove cluster PVCs: %w", err)
 	}
 
 	return nil
@@ -1026,10 +959,7 @@ func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, fin
 
 	// The cluster is being deleted
 	if err := r.cleanUpAndRemoveFinalizer(ctx, finalizerName); err != nil {
-		return fmt.Errorf(
-			"remove finalizer for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return fmt.Errorf("remove finalizer: %w", err)
 	}
 
 	return nil
@@ -1102,22 +1032,16 @@ func (r *SingleClusterReconciler) IsStatusEmpty() bool {
 func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, hasFailed bool) error {
 	if !hasFailed {
 		if int(r.aeroCluster.Spec.Size) > len(r.aeroCluster.Status.Pods) {
-			return fmt.Errorf("cluster is not ready for migration, pod status is not populated")
+			return fmt.Errorf("cluster is not ready for migration, Pod status is not populated")
 		}
 
 		if err := r.migrateInitialisedVolumeNames(ctx); err != nil {
-			return fmt.Errorf(
-				"patch initialised volumes for cluster %s: %w",
-				utils.GetNamespacedNameString(r.aeroCluster), err,
-			)
+			return fmt.Errorf("patch initialised volumes: %w", err)
 		}
 	}
 
 	if err := r.AddAPIVersionLabel(ctx); err != nil {
-		return fmt.Errorf(
-			"patch API version label for cluster %s: %w",
-			utils.GetNamespacedNameString(r.aeroCluster), err,
-		)
+		return fmt.Errorf("patch API version label: %w", err)
 	}
 
 	return nil
@@ -1142,7 +1066,7 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 		pod := &podList.Items[podIdx]
 
 		if _, ok := r.aeroCluster.Status.Pods[pod.Name]; !ok {
-			return fmt.Errorf("empty status found in CR for pod %s", pod.Name)
+			return fmt.Errorf("empty status found in CR for Pod %s", pod.Name)
 		}
 
 		initializedVolumes := r.aeroCluster.Status.Pods[pod.Name].InitializedVolumes
@@ -1177,7 +1101,8 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 		}
 
 		if len(initializedVolumes) > len(r.aeroCluster.Status.Pods[pod.Name].InitializedVolumes) {
-			r.Log.Info("Got updated initialised volumes list", "initVolumes", initializedVolumes, "pod", klog.KObj(pod))
+			r.Log.Info("Got updated initialised volumes list",
+				"initVolumes", initializedVolumes, "pod", utils.GetNamespacedName(pod))
 
 			patch1 := jsonpatch.PatchOperation{
 				Operation: "replace",

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -3,13 +3,14 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
@@ -46,7 +47,7 @@ type SingleClusterReconciler struct {
 
 func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Result, recErr error) {
 	r.Log.V(1).Info(
-		"AerospikeCluster", "Spec", r.aeroCluster.Spec, "Status",
+		"AerospikeCluster", "spec", r.aeroCluster.Spec, "status",
 		r.aeroCluster.Status,
 	)
 
@@ -98,7 +99,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	if err := r.addFinalizer(ctx, finalizerName); err != nil {
 		return reconcile.Result{}, fmt.Errorf(
 			"add finalizer for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -125,7 +126,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 		return reconcile.Result{}, fmt.Errorf(
 			"create or update headless Service for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -151,7 +152,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 		return reconcile.Result{}, fmt.Errorf(
 			"reconcile PodDisruptionBudget for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -164,7 +165,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 		return reconcile.Result{}, fmt.Errorf(
 			"reconcile LoadBalancer Service for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -172,7 +173,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf(
 			"determine ignorable pods for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -181,7 +182,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf(
-			"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+			"get host connections for cluster %s nodes: %w", utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -191,7 +192,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	); err != nil {
 		return reconcile.Result{}, fmt.Errorf(
 			"undo quiesce state for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -206,7 +207,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 		return reconcile.Result{}, fmt.Errorf(
 			"reconcile access control for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -223,7 +224,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		if res.Err != nil {
 			return reconcile.Result{}, fmt.Errorf(
 				"revert migrate-fill-delay for cluster %s: %w",
-				utils.ClusterNamespacedName(r.aeroCluster), res.Err,
+				utils.GetNamespacedNameString(r.aeroCluster), res.Err,
 			)
 		}
 
@@ -238,7 +239,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		); err != nil {
 			return reconcile.Result{}, fmt.Errorf(
 				"run recluster for cluster %s: %w",
-				utils.ClusterNamespacedName(r.aeroCluster), err,
+				utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 	}
@@ -254,7 +255,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
 			return reconcile.Result{}, fmt.Errorf(
 				"set roster for cluster %s: %w",
-				utils.ClusterNamespacedName(r.aeroCluster), err,
+				utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 	}
@@ -269,14 +270,14 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 		return reconcile.Result{}, fmt.Errorf(
 			"update AerospikeCluster status for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
 	// Try to recover pods only if there are any ignorable pods, which may be failed or pending.
 	if len(ignorablePodNames) > 0 {
 		if res := r.recoverIgnorablePods(ctx, ignorablePodNames); !res.IsSuccess {
-			return res.Result, res.Err
+			return res.GetResult()
 		}
 	}
 
@@ -288,9 +289,12 @@ func (r *SingleClusterReconciler) finishReconcile(ctx context.Context, result ct
 	logValues := reconcileExitLogValues(result, recErr)
 	if recErr != nil {
 		if err := r.setStatusPhase(ctx, asdbv1.AerospikeClusterError); err != nil {
-			recErr = fmt.Errorf(
-				"%w; setting error phase for cluster %s: %w",
-				recErr, utils.ClusterNamespacedName(r.aeroCluster), err,
+			recErr = errors.Join(
+				recErr,
+				fmt.Errorf(
+					"setting error phase for cluster %s: %w",
+					utils.GetNamespacedNameString(r.aeroCluster), err,
+				),
 			)
 		}
 
@@ -325,7 +329,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 	if gErr != nil {
 		return common.ReconcileError(fmt.Errorf(
 			"list pods for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), gErr,
+			utils.GetNamespacedNameString(r.aeroCluster), gErr,
 		))
 	}
 
@@ -403,13 +407,13 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 		conns, err = r.newAllHostConnWithOption(ctx, ignorablePodNames)
 		if err != nil {
 			return fmt.Errorf("get host connections for cluster %s nodes: %w",
-				utils.ClusterNamespacedName(r.aeroCluster), err)
+				utils.GetNamespacedNameString(r.aeroCluster), err)
 		}
 	} else {
 		conns, err = r.newPodsHostConnWithOption(selectedPods, ignorablePodNames)
 		if err != nil {
 			return fmt.Errorf("get host connections for selected pods of cluster %s: %w",
-				utils.ClusterNamespacedName(r.aeroCluster), err)
+				utils.GetNamespacedNameString(r.aeroCluster), err)
 		}
 	}
 
@@ -432,7 +436,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	if err != nil {
 		return fmt.Errorf(
 			"create Aerospike client for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -445,8 +449,8 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	)
 	if err != nil {
 		return fmt.Errorf(
-			"could not reconcile access control for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			"reconcile access control for cluster %s: %w",
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -523,7 +527,7 @@ func (r *SingleClusterReconciler) updateStatus(ctx context.Context) error {
 	// Add the cluster phase metric
 	r.addClusterPhaseMetric()
 
-	r.Log.V(2).Info("Updated status", "status", newAeroCluster.Status)
+	r.Log.V(1).Info("Updated status", "status", newAeroCluster.Status)
 
 	return nil
 }
@@ -542,7 +546,7 @@ func (r *SingleClusterReconciler) setStatusPhase(ctx context.Context, phase asdb
 		}); err != nil {
 			return fmt.Errorf(
 				"set cluster status phase to %s for cluster %s: %w",
-				phase, utils.ClusterNamespacedName(r.aeroCluster), err,
+				phase, utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 
@@ -606,7 +610,7 @@ func (r *SingleClusterReconciler) updateAccessControlStatus(ctx context.Context)
 		return fmt.Errorf("update access control status: %w", err)
 	}
 
-	r.Log.V(2).Info("Updated access control status", "status", newAeroCluster.Status)
+	r.Log.V(1).Info("Updated access control status", "status", newAeroCluster.Status)
 
 	return nil
 }
@@ -746,8 +750,8 @@ func (r *SingleClusterReconciler) patchStatus(ctx context.Context, newAeroCluste
 	}
 
 	r.Log.V(1).Info(
-		"Filtered status patch ", "patch", filteredPatch, "oldObj.status",
-		oldAeroCluster.Status, "newObj.status", newAeroCluster.Status,
+		"Filtered status patch ", "patch", filteredPatch, "oldStatus",
+		oldAeroCluster.Status, "newStatus", newAeroCluster.Status,
 	)
 
 	jsonPatchJSON, err := json.Marshal(filteredPatch)
@@ -795,8 +799,8 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 	statefulSetList, err := r.getClusterSTSList(ctx)
 	if err != nil {
 		return fmt.Errorf(
-			"error getting statefulsets while forcing recreate of the cluster as status is nil: %w",
-			err,
+			"get StatefulSets while forcing recreate of cluster %s (status is nil): %w",
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -809,8 +813,8 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 		statefulset := &statefulSetList.Items[idx]
 		if err := r.deleteSTS(ctx, statefulset); err != nil {
 			return fmt.Errorf(
-				"error deleting statefulset while forcing recreate of the cluster as status is nil: %w",
-				err,
+				"delete StatefulSet %s while forcing recreate of cluster %s (status is nil): %w",
+				utils.GetNamespacedNameString(statefulset), utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 	}
@@ -820,7 +824,7 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 	if err := r.deleteAllClusterPVCsForce(ctx); err != nil {
 		return fmt.Errorf(
 			"deleting cluster PVCs while forcing recreate of cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -833,7 +837,10 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 
 		pods, err := r.getRackPodList(ctx, state.Rack.ID, state.Rack.Revision)
 		if err != nil {
-			return fmt.Errorf("failed recover failed cluster: %w", err)
+			return fmt.Errorf(
+				"list pods for rack %d in cluster %s during failed cluster recovery: %w",
+				state.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			)
 		}
 
 		newPodNames := make([]string, 0)
@@ -844,7 +851,7 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 		if err := r.cleanupPodMeshAndStatus(ctx, newPodNames); err != nil {
 			return fmt.Errorf(
 				"cleaning up pod mesh and status for rack %d while recovering cluster %s after create failure: %w",
-				state.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				state.Rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 	}
@@ -858,12 +865,12 @@ func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error
 	if err := r.clearAerospikeAccessControlStatus(ctx); err != nil {
 		return fmt.Errorf(
 			"clearing access control status while recovering cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
 	return fmt.Errorf(
-		"forcing recreate of cluster %s: status is nil", utils.ClusterNamespacedName(r.aeroCluster),
+		"forcing recreate of cluster %s: status is nil", utils.GetNamespacedNameString(r.aeroCluster),
 	)
 }
 
@@ -884,7 +891,7 @@ func (r *SingleClusterReconciler) clearAerospikeAccessControlStatus(ctx context.
 	); err != nil {
 		return fmt.Errorf(
 			"getting AerospikeCluster %s for access control status clear: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -893,7 +900,7 @@ func (r *SingleClusterReconciler) clearAerospikeAccessControlStatus(ctx context.
 	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
 		return fmt.Errorf(
 			"clearing access control status for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -959,7 +966,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 		if err != nil {
 			return fmt.Errorf(
 				"find PVCs for rack %d in cluster %s: %w",
-				rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 
@@ -967,7 +974,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 		if _, err := r.removePVCsAsync(ctx, &storage, rackPVCItems); err != nil {
 			return fmt.Errorf(
 				"remove PVCs for rack %d in cluster %s: %w",
-				rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 	}
@@ -975,7 +982,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 	// Delete PVCs for any remaining old removed racks
 	pvcItems, err := r.getClusterPVCList(ctx)
 	if err != nil {
-		return fmt.Errorf("find PVC for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("find PVC for cluster %s: %w", utils.GetNamespacedNameString(r.aeroCluster), err)
 	}
 
 	// removePVCs should be passed only filtered pvc otherwise rack pvc may be removed using global storage
@@ -1008,7 +1015,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 	if _, err := r.removePVCsAsync(
 		ctx, &r.aeroCluster.Spec.Storage, filteredPVCItems,
 	); err != nil {
-		return fmt.Errorf("remove PVCs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("remove PVCs for cluster %s: %w", utils.GetNamespacedNameString(r.aeroCluster), err)
 	}
 
 	return nil
@@ -1021,7 +1028,7 @@ func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, fin
 	if err := r.cleanUpAndRemoveFinalizer(ctx, finalizerName); err != nil {
 		return fmt.Errorf(
 			"remove finalizer for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -1101,7 +1108,7 @@ func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, h
 		if err := r.migrateInitialisedVolumeNames(ctx); err != nil {
 			return fmt.Errorf(
 				"patch initialised volumes for cluster %s: %w",
-				utils.ClusterNamespacedName(r.aeroCluster), err,
+				utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 	}
@@ -1109,7 +1116,7 @@ func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, h
 	if err := r.AddAPIVersionLabel(ctx); err != nil {
 		return fmt.Errorf(
 			"patch API version label for cluster %s: %w",
-			utils.ClusterNamespacedName(r.aeroCluster), err,
+			utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -1121,7 +1128,7 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 
 	podList, err := r.getClusterPodList(ctx)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Request objects not found.
 			return nil
 		}

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -101,7 +101,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	// The cluster is not being deleted, add finalizer if not added already
 	if err := r.addFinalizer(ctx, finalizerName); err != nil {
 		recErr = fmt.Errorf(
-			"could not add finalizer for cluster %s: %w",
+			"add finalizer for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
@@ -134,7 +134,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		)
 
 		recErr = fmt.Errorf(
-			"could not create or update headless Service for cluster %s: %w",
+			"create or update headless Service for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
@@ -164,7 +164,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		)
 
 		recErr = fmt.Errorf(
-			"could not reconcile PodDisruptionBudget for cluster %s: %w",
+			"reconcile PodDisruptionBudget for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
@@ -179,7 +179,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		)
 
 		recErr = fmt.Errorf(
-			"could not reconcile LoadBalancer Service for cluster %s: %w",
+			"reconcile LoadBalancer Service for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
@@ -189,7 +189,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	ignorablePodNames, err := r.getIgnorablePods(ctx, nil, getConfiguredRackStateList(r.aeroCluster))
 	if err != nil {
 		recErr = fmt.Errorf(
-			"could not determine pods to be ignored for cluster %s: %w",
+			"determine ignorable pods for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
@@ -201,7 +201,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		e := fmt.Errorf(
-			"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+			"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
 		recErr = e
@@ -214,7 +214,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		r.getClientPolicy(ctx), allHostConns,
 	); err != nil {
 		recErr = fmt.Errorf(
-			"could not undo quiesce state for cluster %s: %w",
+			"undo quiesce state for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
@@ -231,7 +231,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		)
 
 		recErr = fmt.Errorf(
-			"could not reconcile access control for cluster %s: %w",
+			"reconcile access control for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
@@ -250,7 +250,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	); !res.IsSuccess {
 		if res.Err != nil {
 			recErr = fmt.Errorf(
-				"could not revert migrate-fill-delay for cluster %s: %w",
+				"revert migrate-fill-delay for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), res.Err,
 			)
 		}
@@ -265,7 +265,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			policy, allHostConns,
 		); err != nil {
 			recErr = fmt.Errorf(
-				"could not run recluster for cluster %s: %w",
+				"run recluster for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 
@@ -285,7 +285,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		// Setup roster
 		if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
 			recErr = fmt.Errorf(
-				"could not set roster for cluster %s: %w",
+				"set roster for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 
@@ -302,7 +302,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		)
 
 		recErr = fmt.Errorf(
-			"could not update AerospikeCluster status for cluster %s: %w",
+			"update AerospikeCluster status for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
@@ -362,7 +362,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 	podList, gErr := r.getClusterPodList(ctx)
 	if gErr != nil {
 		return common.ReconcileError(fmt.Errorf(
-			"could not list pods for cluster %s: %w",
+			"list pods for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), gErr,
 		))
 	}
@@ -400,7 +400,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 
 				if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
 					return common.ReconcileError(fmt.Errorf(
-						"could not delete pod %s: %w",
+						"delete pod %s: %w",
 						utils.GetNamespacedNameString(&podList.Items[idx]), err,
 					))
 				}
@@ -469,7 +469,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	aeroClient, err := as.NewClientWithPolicyAndHost(clientPolicy, hosts...)
 	if err != nil {
 		return fmt.Errorf(
-			"could not create Aerospike client for cluster %s: %w",
+			"create Aerospike client for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -553,7 +553,7 @@ func (r *SingleClusterReconciler) updateStatus(ctx context.Context) error {
 
 	err = r.patchStatus(ctx, newAeroCluster)
 	if err != nil {
-		return fmt.Errorf("error updating status: %w", err)
+		return fmt.Errorf("update status: %w", err)
 	}
 
 	r.aeroCluster = newAeroCluster
@@ -579,7 +579,7 @@ func (r *SingleClusterReconciler) setStatusPhase(ctx context.Context, phase asdb
 			return r.Client.Status().Update(context.Background(), r.aeroCluster)
 		}); err != nil {
 			return fmt.Errorf(
-				"could not set cluster status phase to %s for cluster %s: %w",
+				"set cluster status phase to %s for cluster %s: %w",
 				phase, utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -641,7 +641,7 @@ func (r *SingleClusterReconciler) updateAccessControlStatus(ctx context.Context)
 	newAeroCluster.Status.AerospikeAccessControl = statusAerospikeAccessControl
 
 	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
-		return fmt.Errorf("error updating status: %w", err)
+		return fmt.Errorf("update access control status: %w", err)
 	}
 
 	r.Log.V(2).Info("Updated access control status", "status", newAeroCluster.Status)
@@ -669,7 +669,7 @@ func (r *SingleClusterReconciler) createStatus(ctx context.Context) error {
 	if err := r.Client.Status().Update(
 		ctx, newAeroCluster,
 	); err != nil {
-		return fmt.Errorf("error creating status: %w", err)
+		return fmt.Errorf("create status: %w", err)
 	}
 
 	return nil
@@ -750,17 +750,17 @@ func (r *SingleClusterReconciler) patchStatus(ctx context.Context, newAeroCluste
 
 	oldJSON, err := json.Marshal(oldAeroCluster)
 	if err != nil {
-		return fmt.Errorf("error marshalling old status: %w", err)
+		return fmt.Errorf("marshal old status: %w", err)
 	}
 
 	newJSON, err := json.Marshal(newAeroCluster)
 	if err != nil {
-		return fmt.Errorf("error marshalling new status: %w", err)
+		return fmt.Errorf("marshal new status: %w", err)
 	}
 
 	jsonPatchPatch, err := jsonpatch.CreatePatch(oldJSON, newJSON)
 	if err != nil {
-		return fmt.Errorf("error creating json patch: %w", err)
+		return fmt.Errorf("create JSON patch: %w", err)
 	}
 
 	// Pick changes to the status object only.
@@ -790,7 +790,7 @@ func (r *SingleClusterReconciler) patchStatus(ctx context.Context, newAeroCluste
 
 	jsonPatchJSON, err := json.Marshal(filteredPatch)
 	if err != nil {
-		return fmt.Errorf("error marshalling json patch: %w", err)
+		return fmt.Errorf("marshal JSON patch: %w", err)
 	}
 
 	patch := client.RawPatch(types.JSONPatchType, jsonPatchJSON)
@@ -802,7 +802,7 @@ func (r *SingleClusterReconciler) patchStatus(ctx context.Context, newAeroCluste
 		}}, patch,
 		client.FieldOwner(patchFieldOwner),
 	); err != nil {
-		return fmt.Errorf("error patching status: %w", err)
+		return fmt.Errorf("patch status: %w", err)
 	}
 
 	// FIXME: Json unmarshal used by above client.Status(),
@@ -996,7 +996,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 		rackPVCItems, err := r.getRackPVCList(ctx, rack.ID, rack.Revision)
 		if err != nil {
 			return fmt.Errorf(
-				"could not find pvc for rack %d in cluster %s: %w",
+				"find PVCs for rack %d in cluster %s: %w",
 				rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -1004,7 +1004,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 		storage := rack.Storage
 		if _, err := r.removePVCsAsync(ctx, &storage, rackPVCItems); err != nil {
 			return fmt.Errorf(
-				"could not remove PVCs for rack %d in cluster %s: %w",
+				"remove PVCs for rack %d in cluster %s: %w",
 				rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -1058,7 +1058,7 @@ func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, fin
 	// The cluster is being deleted
 	if err := r.cleanUpAndRemoveFinalizer(ctx, finalizerName); err != nil {
 		return fmt.Errorf(
-			"could not finish cluster deletion (remove finalizer) for cluster %s: %w",
+			"remove finalizer for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -1069,7 +1069,7 @@ func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, fin
 func (r *SingleClusterReconciler) checkPreviouslyFailedCluster(ctx context.Context) (bool, common.ReconcileResult) {
 	isNew, err := r.isNewCluster(ctx)
 	if err != nil {
-		return false, common.ReconcileError(fmt.Errorf("error determining if cluster is new: %w", err))
+		return false, common.ReconcileError(fmt.Errorf("determine if cluster is new: %w", err))
 	}
 
 	if isNew {
@@ -1086,7 +1086,7 @@ func (r *SingleClusterReconciler) checkPreviouslyFailedCluster(ctx context.Conte
 
 		hasFailed, inGracePeriod, err := r.hasClusterFailed(ctx)
 		if err != nil {
-			return false, common.ReconcileError(fmt.Errorf("error determining if cluster has failed: %w", err))
+			return false, common.ReconcileError(fmt.Errorf("determine if cluster has failed: %w", err))
 		}
 
 		if hasFailed {
@@ -1138,7 +1138,7 @@ func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, h
 
 		if err := r.migrateInitialisedVolumeNames(ctx); err != nil {
 			return fmt.Errorf(
-				"could not patch initialised volumes for cluster %s: %w",
+				"patch initialised volumes for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -1146,7 +1146,7 @@ func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, h
 
 	if err := r.AddAPIVersionLabel(ctx); err != nil {
 		return fmt.Errorf(
-			"could not patch API version label for cluster %s: %w",
+			"patch API version label for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -63,7 +63,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		// The cluster is being deleted
 		if err := r.handleClusterDeletion(ctx, finalizerName); err != nil {
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, EventReasonDeleteFailed,
+				r.aeroCluster, corev1.EventTypeWarning, "DeleteFailed",
 				"Failed to delete AerospikeCluster %s",
 				utils.GetNamespacedNameString(r.aeroCluster),
 			)
@@ -76,7 +76,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		r.removeClusterPhaseMetric()
 
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeNormal, EventReasonDeleted,
+			r.aeroCluster, corev1.EventTypeNormal, "Deleted",
 			"Deleted AerospikeCluster %s", utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
@@ -128,7 +128,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	if err := r.createOrUpdateSTSHeadlessSvc(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, EventReasonServiceCreateFailed,
+			r.aeroCluster, corev1.EventTypeWarning, ReasonServiceCreateFailed,
 			"Failed to create headless Service for AerospikeCluster %s",
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
@@ -145,7 +145,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	if res := r.reconcileRacks(ctx); !res.IsSuccess {
 		if res.Err != nil {
 			r.Recorder.Eventf(
-				r.aeroCluster, corev1.EventTypeWarning, EventReasonRackReconcileFailed,
+				r.aeroCluster, corev1.EventTypeWarning, "UpdateFailed",
 				"Failed to reconcile racks for AerospikeCluster %s",
 				utils.GetNamespacedNameString(r.aeroCluster),
 			)
@@ -158,7 +158,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	if err := r.reconcilePDB(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, EventReasonPodDisruptionBudgetReconcileFailed,
+			r.aeroCluster, corev1.EventTypeWarning, "PodDisruptionBudgetReconcileFailed",
 			"Failed to reconcile PodDisruptionBudget for AerospikeCluster %s",
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
@@ -173,7 +173,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	if err := r.reconcileSTSLoadBalancerSvc(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, EventReasonServiceCreateFailed,
+			r.aeroCluster, corev1.EventTypeWarning, ReasonServiceCreateFailed,
 			"Failed to create LoadBalancer Service for AerospikeCluster %s",
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
@@ -225,7 +225,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	// Assuming all pods must be security enabled or disabled.
 	if err = r.validateAndReconcileAccessControl(ctx, nil, ignorablePodNames); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, EventReasonAccessControlUpdateFailed,
+			r.aeroCluster, corev1.EventTypeWarning, ReasonACLUpdateFailed,
 			"Failed to set up access control for AerospikeCluster %s",
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
@@ -296,7 +296,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	// Update the AerospikeCluster status.
 	if err = r.updateStatus(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, EventReasonStatusUpdateFailed,
+			r.aeroCluster, corev1.EventTypeWarning, ReasonStatusUpdateFailed,
 			"Failed to update status for AerospikeCluster %s",
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
@@ -489,7 +489,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	}
 
 	r.Recorder.Eventf(
-		r.aeroCluster, corev1.EventTypeNormal, EventReasonAccessControlUpdated,
+		r.aeroCluster, corev1.EventTypeNormal, "ACLUpdated",
 		"Updated access control for AerospikeCluster %s",
 		utils.GetNamespacedNameString(r.aeroCluster),
 	)
@@ -497,7 +497,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	// Update the AerospikeCluster status.
 	if err := r.updateAccessControlStatus(ctx); err != nil {
 		r.Recorder.Eventf(
-			r.aeroCluster, corev1.EventTypeWarning, EventReasonStatusUpdateFailed,
+			r.aeroCluster, corev1.EventTypeWarning, ReasonStatusUpdateFailed,
 			"Failed to update access control status for AerospikeCluster %s",
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -198,7 +198,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		e := fmt.Errorf(
-			"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
+			"could not get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
 		recErr = e
@@ -317,7 +317,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 	ctx context.Context, ignorablePodNames sets.Set[string]) common.ReconcileResult {
 	podList, gErr := r.getClusterPodList(ctx)
 	if gErr != nil {
-		return common.ReconcileError(fmt.Errorf("list pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), gErr))
+		return common.ReconcileError(fmt.Errorf("could not list pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), gErr))
 	}
 
 	r.Log.Info("Try to recover failed/pending pods if any")
@@ -352,7 +352,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 				}
 
 				if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
-					return common.ReconcileError(fmt.Errorf("delete pod %s: %w", utils.GetNamespacedNameString(&podList.Items[idx]), err))
+					return common.ReconcileError(fmt.Errorf("could not delete pod %s: %w", utils.GetNamespacedNameString(&podList.Items[idx]), err))
 				}
 
 				r.Log.Info("Deleted pod", "pod", podList.Items[idx].Name)
@@ -376,7 +376,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 ) error {
 	enabled, err := asdbv1.IsSecurityEnabled(r.aeroCluster.Spec.AerospikeConfig.Value)
 	if err != nil {
-		return fmt.Errorf("getting cluster security status: %w", err)
+		return fmt.Errorf("could not get cluster security status: %w", err)
 	}
 
 	if !enabled {
@@ -390,13 +390,13 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	if selectedPods == nil {
 		conns, err = r.newAllHostConnWithOption(ctx, ignorablePodNames)
 		if err != nil {
-			return fmt.Errorf("getting host connections for cluster %s nodes: %w",
+			return fmt.Errorf("could not get host connections for cluster %s nodes: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	} else {
 		conns, err = r.newPodsHostConnWithOption(selectedPods, ignorablePodNames)
 		if err != nil {
-			return fmt.Errorf("getting host connections for selected pods of cluster %s: %w",
+			return fmt.Errorf("could not get host connections for selected pods of cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	}
@@ -418,7 +418,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 
 	aeroClient, err := as.NewClientWithPolicyAndHost(clientPolicy, hosts...)
 	if err != nil {
-		return fmt.Errorf("creating aerospike client for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("could not create Aerospike client for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	defer aeroClient.Close()
@@ -429,7 +429,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 		ctx, aeroClient, pp,
 	)
 	if err != nil {
-		return fmt.Errorf("reconciling access control for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("could not reconcile access control for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	r.Recorder.Eventf(
@@ -486,7 +486,7 @@ func (r *SingleClusterReconciler) updateStatus(ctx context.Context) error {
 	if !newAeroCluster.Status.IsReadinessProbeEnabled {
 		clusterReadinessEnable, gErr := r.getClusterReadinessStatus(ctx)
 		if gErr != nil {
-			return fmt.Errorf("getting cluster readiness status: %w", gErr)
+			return fmt.Errorf("could not get cluster readiness status: %w", gErr)
 		}
 
 		newAeroCluster.Status.IsReadinessProbeEnabled = clusterReadinessEnable
@@ -522,7 +522,7 @@ func (r *SingleClusterReconciler) setStatusPhase(ctx context.Context, phase asdb
 			// detached: status update must complete even if the reconcile context is cancelled
 			return r.Client.Status().Update(context.Background(), r.aeroCluster)
 		}); err != nil {
-			return fmt.Errorf("set status to %s for cluster %s: %w", phase, utils.ClusterNamespacedName(r.aeroCluster), err)
+			return fmt.Errorf("could not set cluster status phase to %s for cluster %s: %w", phase, utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 
 		r.addClusterPhaseMetric()
@@ -941,7 +941,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 
 		storage := rack.Storage
 		if _, err := r.removePVCsAsync(ctx, &storage, rackPVCItems); err != nil {
-			return fmt.Errorf("removing pvcs for rack %d in cluster %s: %w", rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
+			return fmt.Errorf("could not remove PVCs for rack %d in cluster %s: %w", rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	}
 
@@ -981,7 +981,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 	if _, err := r.removePVCsAsync(
 		ctx, &r.aeroCluster.Spec.Storage, filteredPVCItems,
 	); err != nil {
-		return fmt.Errorf("removing pvcs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("could not remove PVCs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	return nil
@@ -992,7 +992,7 @@ func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, fin
 
 	// The cluster is being deleted
 	if err := r.cleanUpAndRemoveFinalizer(ctx, finalizerName); err != nil {
-		return fmt.Errorf("clean up and remove finalizer for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("could not finish cluster deletion (remove finalizer) for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	return nil

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -426,7 +426,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 ) error {
 	enabled, err := asdbv1.IsSecurityEnabled(r.aeroCluster.Spec.AerospikeConfig.Value)
 	if err != nil {
-		return fmt.Errorf("could not get cluster security status: %w", err)
+		return fmt.Errorf("get cluster security status: %w", err)
 	}
 
 	if !enabled {
@@ -440,13 +440,13 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	if selectedPods == nil {
 		conns, err = r.newAllHostConnWithOption(ctx, ignorablePodNames)
 		if err != nil {
-			return fmt.Errorf("could not get host connections for cluster %s nodes: %w",
+			return fmt.Errorf("get host connections for cluster %s nodes: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	} else {
 		conns, err = r.newPodsHostConnWithOption(selectedPods, ignorablePodNames)
 		if err != nil {
-			return fmt.Errorf("could not get host connections for selected pods of cluster %s: %w",
+			return fmt.Errorf("get host connections for selected pods of cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	}
@@ -542,7 +542,7 @@ func (r *SingleClusterReconciler) updateStatus(ctx context.Context) error {
 	if !newAeroCluster.Status.IsReadinessProbeEnabled {
 		clusterReadinessEnable, gErr := r.getClusterReadinessStatus(ctx)
 		if gErr != nil {
-			return fmt.Errorf("could not get cluster readiness status: %w", gErr)
+			return fmt.Errorf("get cluster readiness status: %w", gErr)
 		}
 
 		newAeroCluster.Status.IsReadinessProbeEnabled = clusterReadinessEnable
@@ -1013,7 +1013,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 	// Delete PVCs for any remaining old removed racks
 	pvcItems, err := r.getClusterPVCList(ctx)
 	if err != nil {
-		return fmt.Errorf("could not find pvc for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("find PVC for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	// removePVCs should be passed only filtered pvc otherwise rack pvc may be removed using global storage
@@ -1046,7 +1046,7 @@ func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) e
 	if _, err := r.removePVCsAsync(
 		ctx, &r.aeroCluster.Spec.Storage, filteredPVCItems,
 	); err != nil {
-		return fmt.Errorf("could not remove PVCs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
+		return fmt.Errorf("remove PVCs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	return nil

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -384,7 +385,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 				if podState.State == utils.PodFailedInGrace {
 					r.Log.Info(
 						"Pod is in failed state but within grace period, will not delete",
-						"pod", podList.Items[idx].Name,
+						"pod", klog.KObj(&podList.Items[idx]),
 					)
 
 					requeueInterval = asdbv1.RequeueIntervalSeconds10
@@ -404,7 +405,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 					))
 				}
 
-				r.Log.Info("Deleted pod", "pod", podList.Items[idx].Name)
+				r.Log.Info("Deleted pod", "pod", klog.KObj(&podList.Items[idx]))
 			}
 		}
 	}
@@ -560,7 +561,7 @@ func (r *SingleClusterReconciler) updateStatus(ctx context.Context) error {
 	// Add the cluster phase metric
 	r.addClusterPhaseMetric()
 
-	r.Log.Info("Updated status", "status", newAeroCluster.Status)
+	r.Log.V(2).Info("Updated status", "status", newAeroCluster.Status)
 
 	return nil
 }
@@ -643,7 +644,7 @@ func (r *SingleClusterReconciler) updateAccessControlStatus(ctx context.Context)
 		return fmt.Errorf("error updating status: %w", err)
 	}
 
-	r.Log.Info("Updated access control status", "status", newAeroCluster.Status)
+	r.Log.V(2).Info("Updated access control status", "status", newAeroCluster.Status)
 
 	return nil
 }
@@ -1207,7 +1208,7 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 		}
 
 		if len(initializedVolumes) > len(r.aeroCluster.Status.Pods[pod.Name].InitializedVolumes) {
-			r.Log.Info("Got updated initialised volumes list", "initVolumes", initializedVolumes, "podName", pod.Name)
+			r.Log.Info("Got updated initialised volumes list", "initVolumes", initializedVolumes, "pod", klog.KObj(pod))
 
 			patch1 := jsonpatch.PatchOperation{
 				Operation: "replace",

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -68,9 +68,7 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 				utils.GetNamespacedNameString(r.aeroCluster),
 			)
 
-			recErr = err
-
-			return reconcile.Result{}, recErr
+			return reconcile.Result{}, err
 		}
 
 		r.removeClusterPhaseMetric()
@@ -93,36 +91,28 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 
 	// Set the status to AerospikeClusterInProgress before starting any operations
 	if err := r.setStatusPhase(ctx, asdbv1.AerospikeClusterInProgress); err != nil {
-		recErr = err
-
-		return reconcile.Result{}, recErr
+		return reconcile.Result{}, err
 	}
 
 	// The cluster is not being deleted, add finalizer if not added already
 	if err := r.addFinalizer(ctx, finalizerName); err != nil {
-		recErr = fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"add finalizer for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		return reconcile.Result{}, recErr
 	}
 
 	// Handle previously failed cluster
 	hasFailed, res := r.checkPreviouslyFailedCluster(ctx)
 	if !res.IsSuccess {
-		recErr = res.Err
-
-		return res.Result, recErr
+		return res.Result, res.Err
 	}
 
 	if r.aeroCluster.Labels[asdbv1.AerospikeAPIVersionLabel] == asdbv1.AerospikeAPIVersion {
 		r.Log.Info("cluster migration is not needed")
 	} else {
 		if err := r.migrateAerospikeCluster(ctx, hasFailed); err != nil {
-			recErr = err
-
-			return reconcile.Result{}, recErr
+			return reconcile.Result{}, err
 		}
 	}
 
@@ -133,12 +123,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"create or update headless Service for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		return reconcile.Result{}, recErr
 	}
 
 	// Reconcile all racks
@@ -149,11 +137,9 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 				"Failed to reconcile racks for AerospikeCluster %s",
 				utils.GetNamespacedNameString(r.aeroCluster),
 			)
-
-			recErr = res.Err
 		}
 
-		return res.Result, recErr
+		return res.Result, res.Err
 	}
 
 	if err := r.reconcilePDB(ctx); err != nil {
@@ -163,12 +149,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"reconcile PodDisruptionBudget for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		return reconcile.Result{}, recErr
 	}
 
 	if err := r.reconcileSTSLoadBalancerSvc(ctx); err != nil {
@@ -178,47 +162,37 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"reconcile LoadBalancer Service for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		return reconcile.Result{}, recErr
 	}
 
 	ignorablePodNames, err := r.getIgnorablePods(ctx, nil, getConfiguredRackStateList(r.aeroCluster))
 	if err != nil {
-		recErr = fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"determine ignorable pods for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		return reconcile.Result{}, recErr
 	}
 
 	// Check if there is any node with quiesce status. We need to undo that
 	// It may have been left from previous steps
 	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
-		e := fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"get host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		recErr = e
-
-		return reconcile.Result{}, recErr
 	}
 
 	if err = deployment.InfoQuiesceUndo(
 		r.Log,
 		r.getClientPolicy(ctx), allHostConns,
 	); err != nil {
-		recErr = fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"undo quiesce state for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		return reconcile.Result{}, recErr
 	}
 
 	// Setup access control.
@@ -230,12 +204,10 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"reconcile access control for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		return reconcile.Result{}, recErr
 	}
 
 	// Use policy from spec after setting up access control
@@ -249,13 +221,13 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 		false, ignorablePodNames,
 	); !res.IsSuccess {
 		if res.Err != nil {
-			recErr = fmt.Errorf(
+			return reconcile.Result{}, fmt.Errorf(
 				"revert migrate-fill-delay for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), res.Err,
 			)
 		}
 
-		return reconcile.Result{}, recErr
+		return reconcile.Result{}, nil
 	}
 
 	// Doing recluster before setting up roster to get the latest observed node list from server.
@@ -264,32 +236,26 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			r.Log,
 			policy, allHostConns,
 		); err != nil {
-			recErr = fmt.Errorf(
+			return reconcile.Result{}, fmt.Errorf(
 				"run recluster for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
-
-			return reconcile.Result{}, recErr
 		}
 	}
 
 	if asdbv1.IsClusterSCEnabled(r.aeroCluster) {
 		if !r.IsStatusEmpty() {
 			if res := r.waitForClusterStability(policy, allHostConns); !res.IsSuccess {
-				recErr = res.Err
-
-				return res.Result, recErr
+				return res.Result, res.Err
 			}
 		}
 
 		// Setup roster
 		if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
-			recErr = fmt.Errorf(
+			return reconcile.Result{}, fmt.Errorf(
 				"set roster for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
-
-			return reconcile.Result{}, recErr
 		}
 	}
 
@@ -301,20 +267,16 @@ func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Re
 			utils.GetNamespacedNameString(r.aeroCluster),
 		)
 
-		recErr = fmt.Errorf(
+		return reconcile.Result{}, fmt.Errorf(
 			"update AerospikeCluster status for cluster %s: %w",
 			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
-
-		return reconcile.Result{}, recErr
 	}
 
 	// Try to recover pods only if there are any ignorable pods, which may be failed or pending.
 	if len(ignorablePodNames) > 0 {
 		if res := r.recoverIgnorablePods(ctx, ignorablePodNames); !res.IsSuccess {
-			recErr = res.Err
-
-			return res.Result, recErr
+			return res.Result, res.Err
 		}
 	}
 

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -43,7 +43,7 @@ type SingleClusterReconciler struct {
 	Log         logr.Logger
 }
 
-func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error) {
+func (r *SingleClusterReconciler) Reconcile(ctx context.Context) (result ctrl.Result, recErr error) {
 	r.Log.V(1).Info(
 		"AerospikeCluster", "Spec", r.aeroCluster.Spec, "Status",
 		r.aeroCluster.Status,
@@ -52,27 +52,37 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 	// Set the status phase to Error if the recErr is not nil
 	// recErr is only set when reconcile failure should result in Error phase of the cluster
 	defer func() {
+		logValues := reconcileExitLogValues(result, recErr)
 		if recErr != nil {
-			r.Log.Error(recErr, "Reconcile failed")
-
-			if err := r.setStatusPhase(asdbv1.AerospikeClusterError); err != nil {
-				recErr = err
+			if err := r.setStatusPhase(ctx, asdbv1.AerospikeClusterError); err != nil {
+				recErr = fmt.Errorf(
+					"%w; setting error phase for cluster %s: %w",
+					recErr, utils.ClusterNamespacedName(r.aeroCluster), err,
+				)
 			}
+
+			r.Log.Error(recErr, "Reconcile failed", logValues...)
+
+			return
 		}
+
+		r.Log.Info("Reconcile completed", logValues...)
 	}()
 
 	// Check DeletionTimestamp to see if the cluster is being deleted
 	if !r.aeroCluster.DeletionTimestamp.IsZero() {
 		r.Log.V(1).Info("Deleting AerospikeCluster")
 		// The cluster is being deleted
-		if err := r.handleClusterDeletion(finalizerName); err != nil {
+		if err := r.handleClusterDeletion(ctx, finalizerName); err != nil {
 			r.Recorder.Eventf(
 				r.aeroCluster, corev1.EventTypeWarning, "DeleteFailed",
 				"Unable to handle AerospikeCluster delete operations %s/%s",
 				r.aeroCluster.Namespace, r.aeroCluster.Name,
 			)
 
-			return reconcile.Result{}, err
+			recErr = err
+
+			return reconcile.Result{}, recErr
 		}
 
 		r.removeClusterPhaseMetric()
@@ -95,32 +105,38 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 	}
 
 	// Set the status to AerospikeClusterInProgress before starting any operations
-	if err := r.setStatusPhase(asdbv1.AerospikeClusterInProgress); err != nil {
-		return reconcile.Result{}, err
+	if err := r.setStatusPhase(ctx, asdbv1.AerospikeClusterInProgress); err != nil {
+		recErr = err
+
+		return reconcile.Result{}, recErr
 	}
 
 	// The cluster is not being deleted, add finalizer if not added already
-	if err := r.addFinalizer(finalizerName); err != nil {
-		r.Log.Error(err, "Failed to add finalizer")
-		return reconcile.Result{}, err
+	if err := r.addFinalizer(ctx, finalizerName); err != nil {
+		recErr = err
+
+		return reconcile.Result{}, recErr
 	}
 
 	// Handle previously failed cluster
-	hasFailed, res := r.checkPreviouslyFailedCluster()
+	hasFailed, res := r.checkPreviouslyFailedCluster(ctx)
 	if !res.IsSuccess {
-		return res.Result, nil
+		recErr = res.Err
+
+		return res.Result, recErr
 	}
 
 	if r.aeroCluster.Labels[asdbv1.AerospikeAPIVersionLabel] == asdbv1.AerospikeAPIVersion {
 		r.Log.Info("cluster migration is not needed")
 	} else {
-		if err := r.migrateAerospikeCluster(context.TODO(), hasFailed); err != nil {
-			return reconcile.Result{Requeue: true}, err
+		if err := r.migrateAerospikeCluster(ctx, hasFailed); err != nil {
+			recErr = err
+
+			return reconcile.Result{}, recErr
 		}
 	}
 
-	if err := r.createOrUpdateSTSHeadlessSvc(); err != nil {
-		r.Log.Error(err, "Failed to create headless service")
+	if err := r.createOrUpdateSTSHeadlessSvc(ctx); err != nil {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeWarning, "ServiceCreateFailed",
 			"Failed to create Service(Headless) %s/%s",
@@ -133,7 +149,7 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 	}
 
 	// Reconcile all racks
-	if res := r.reconcileRacks(); !res.IsSuccess {
+	if res := r.reconcileRacks(ctx); !res.IsSuccess {
 		if res.Err != nil {
 			r.Recorder.Eventf(
 				r.aeroCluster, corev1.EventTypeWarning, "UpdateFailed",
@@ -147,8 +163,7 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 		return res.Result, recErr
 	}
 
-	if err := r.reconcilePDB(); err != nil {
-		r.Log.Error(err, "Failed to reconcile PodDisruptionBudget")
+	if err := r.reconcilePDB(ctx); err != nil {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeWarning, "PodDisruptionBudgetReconcileFailed",
 			"Failed to reconcile PodDisruptionBudget %s/%s",
@@ -160,8 +175,7 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 		return reconcile.Result{}, recErr
 	}
 
-	if err := r.reconcileSTSLoadBalancerSvc(); err != nil {
-		r.Log.Error(err, "Failed to create LoadBalancer service")
+	if err := r.reconcileSTSLoadBalancerSvc(ctx); err != nil {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeWarning, "ServiceCreateFailed",
 			"Failed to create Service(LoadBalancer) %s/%s",
@@ -173,32 +187,30 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 		return reconcile.Result{}, recErr
 	}
 
-	ignorablePodNames, err := r.getIgnorablePods(nil, getConfiguredRackStateList(r.aeroCluster))
+	ignorablePodNames, err := r.getIgnorablePods(ctx, nil, getConfiguredRackStateList(r.aeroCluster), nil)
 	if err != nil {
-		r.Log.Error(err, "Failed to determine pods to be ignored")
+		recErr = err
 
-		return reconcile.Result{}, err
+		return reconcile.Result{}, recErr
 	}
 
 	// Check if there is any node with quiesce status. We need to undo that
 	// It may have been left from previous steps
-	allHostConns, err := r.newAllHostConnWithOption(ignorablePodNames)
+	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		e := fmt.Errorf(
-			"failed to get hostConn for aerospike cluster nodes: %v", err,
+			"getting host connections for cluster %s nodes: %w", utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 
-		r.Log.Error(err, "Failed to get hostConn for aerospike cluster nodes")
+		recErr = e
 
-		return reconcile.Result{}, e
+		return reconcile.Result{}, recErr
 	}
 
 	if err = deployment.InfoQuiesceUndo(
 		r.Log,
-		r.getClientPolicy(), allHostConns,
+		r.getClientPolicy(ctx), allHostConns,
 	); err != nil {
-		r.Log.Error(err, "Failed to check for Quiesced nodes")
-
 		recErr = err
 
 		return reconcile.Result{}, recErr
@@ -206,8 +218,7 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 
 	// Setup access control.
 	// Assuming all pods must be security enabled or disabled.
-	if err = r.validateAndReconcileAccessControl(nil, ignorablePodNames); err != nil {
-		r.Log.Error(err, "Failed to Reconcile access control")
+	if err = r.validateAndReconcileAccessControl(ctx, nil, ignorablePodNames); err != nil {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeWarning, "ACLUpdateFailed",
 			"Failed to setup Access Control %s/%s", r.aeroCluster.Namespace,
@@ -220,17 +231,15 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 	}
 
 	// Use policy from spec after setting up access control
-	policy := r.getClientPolicy()
+	policy := r.getClientPolicy(ctx)
 
 	// Revert migrate-fill-delay to the original value if it was set to a different value while processing racks.
 	// Passing the first rack from the list as all the racks will have the same migrate-fill-delay
 	// Redundant safe check to revert migrate-fill-delay if the previous revert operation missed/skipped somehow
 	if res := r.setMigrateFillDelay(
-		policy, &r.aeroCluster.Spec.RackConfig.Racks[0].AerospikeConfig,
+		ctx, policy, &r.aeroCluster.Spec.RackConfig.Racks[0].AerospikeConfig,
 		false, ignorablePodNames,
 	); !res.IsSuccess {
-		r.Log.Error(res.Err, "Failed to revert migrate-fill-delay")
-
 		recErr = res.Err
 
 		return reconcile.Result{}, recErr
@@ -242,8 +251,9 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 			r.Log,
 			policy, allHostConns,
 		); err != nil {
-			r.Log.Error(err, "Failed to do recluster")
-			return reconcile.Result{}, err
+			recErr = err
+
+			return reconcile.Result{}, recErr
 		}
 	}
 
@@ -257,8 +267,7 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 		}
 
 		// Setup roster
-		if err = r.getAndSetRoster(policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
-			r.Log.Error(err, "Failed to set roster for cluster")
+		if err = r.getAndSetRoster(ctx, policy, r.aeroCluster.Spec.RosterNodeBlockList, ignorablePodNames); err != nil {
 			recErr = err
 
 			return reconcile.Result{}, recErr
@@ -266,33 +275,49 @@ func (r *SingleClusterReconciler) Reconcile() (result ctrl.Result, recErr error)
 	}
 
 	// Update the AerospikeCluster status.
-	if err = r.updateStatus(); err != nil {
-		r.Log.Error(err, "Failed to update AerospikeCluster status")
+	if err = r.updateStatus(ctx); err != nil {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeWarning, "StatusUpdateFailed",
 			"Failed to update AerospikeCluster status %s/%s",
 			r.aeroCluster.Namespace, r.aeroCluster.Name,
 		)
 
-		return reconcile.Result{}, err
+		recErr = err
+
+		return reconcile.Result{}, recErr
 	}
 
 	// Try to recover pods only if there are any ignorable pods, which may be failed or pending.
 	if len(ignorablePodNames) > 0 {
-		if res := r.recoverIgnorablePods(ignorablePodNames); !res.IsSuccess {
-			return res.GetResult()
+		if res := r.recoverIgnorablePods(ctx, ignorablePodNames); !res.IsSuccess {
+			recErr = res.Err
+
+			return res.Result, recErr
 		}
 	}
-
-	r.Log.Info("Reconcile completed successfully")
 
 	return reconcile.Result{}, nil
 }
 
-func (r *SingleClusterReconciler) recoverIgnorablePods(ignorablePodNames sets.Set[string]) common.ReconcileResult {
-	podList, gErr := r.getClusterPodList()
+func reconcileExitLogValues(result ctrl.Result, recErr error) []interface{} {
+	if recErr != nil {
+		return []interface{}{"result", "error"}
+	}
+
+	if result.RequeueAfter > 0 {
+		values := []interface{}{"result", "requeue"}
+		values = append(values, "requeueAfter", result.RequeueAfter.String())
+
+		return values
+	}
+
+	return []interface{}{"result", "success"}
+}
+
+func (r *SingleClusterReconciler) recoverIgnorablePods(
+	ctx context.Context, ignorablePodNames sets.Set[string]) common.ReconcileResult {
+	podList, gErr := r.getClusterPodList(ctx)
 	if gErr != nil {
-		r.Log.Error(gErr, "Failed to get cluster pod list")
 		return common.ReconcileError(gErr)
 	}
 
@@ -323,12 +348,11 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(ignorablePodNames sets.Se
 				}
 
 				// Pod has failed and grace period is over
-				if err := r.createOrUpdatePodServiceIfNeeded([]string{podList.Items[idx].Name}); err != nil {
+				if err := r.createOrUpdatePodServiceIfNeeded(ctx, []string{podList.Items[idx].Name}); err != nil {
 					return common.ReconcileError(err)
 				}
 
-				if err := r.Delete(context.TODO(), &podList.Items[idx]); err != nil {
-					r.Log.Error(err, "Failed to delete pod", "pod", podList.Items[idx].Name)
+				if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
 					return common.ReconcileError(err)
 				}
 
@@ -347,12 +371,13 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(ignorablePodNames sets.Se
 }
 
 func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
+	ctx context.Context,
 	selectedPods []corev1.Pod,
 	ignorablePodNames sets.Set[string],
 ) error {
 	enabled, err := asdbv1.IsSecurityEnabled(r.aeroCluster.Spec.AerospikeConfig.Value)
 	if err != nil {
-		return fmt.Errorf("failed to get cluster security status: %v", err)
+		return fmt.Errorf("getting cluster security status: %w", err)
 	}
 
 	if !enabled {
@@ -364,14 +389,16 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 
 	// Create client
 	if selectedPods == nil {
-		conns, err = r.newAllHostConnWithOption(ignorablePodNames)
+		conns, err = r.newAllHostConnWithOption(ctx, ignorablePodNames)
 		if err != nil {
-			return fmt.Errorf("failed to get host info: %v", err)
+			return fmt.Errorf("getting host connections for cluster %s nodes: %w",
+				utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	} else {
 		conns, err = r.newPodsHostConnWithOption(selectedPods, ignorablePodNames)
 		if err != nil {
-			return fmt.Errorf("failed to get host info: %v", err)
+			return fmt.Errorf("getting host connections for selected pods of cluster %s: %w",
+				utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	}
 
@@ -388,11 +415,11 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	}
 
 	// Create policy using status, status has current connection info
-	clientPolicy := r.getClientPolicy()
+	clientPolicy := r.getClientPolicy(ctx)
 
 	aeroClient, err := as.NewClientWithPolicyAndHost(clientPolicy, hosts...)
 	if err != nil {
-		return fmt.Errorf("failed to create aerospike cluster client: %v", err)
+		return fmt.Errorf("creating aerospike client for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	defer aeroClient.Close()
@@ -400,10 +427,10 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	pp := r.getPasswordProvider()
 
 	err = r.reconcileAccessControl(
-		aeroClient, pp,
+		ctx, aeroClient, pp,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to reconcile access control: %v", err)
+		return fmt.Errorf("reconciling access control for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	r.Recorder.Eventf(
@@ -413,8 +440,7 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	)
 
 	// Update the AerospikeCluster status.
-	if err := r.updateAccessControlStatus(); err != nil {
-		r.Log.Error(err, "Failed to update AerospikeCluster access control status")
+	if err := r.updateAccessControlStatus(ctx); err != nil {
 		r.Recorder.Eventf(
 			r.aeroCluster, corev1.EventTypeWarning, "StatusUpdateFailed",
 			"Failed to update AerospikeCluster access control status %s/%s",
@@ -427,13 +453,13 @@ func (r *SingleClusterReconciler) validateAndReconcileAccessControl(
 	return nil
 }
 
-func (r *SingleClusterReconciler) updateStatus() error {
+func (r *SingleClusterReconciler) updateStatus(ctx context.Context) error {
 	r.Log.Info("Update status for AerospikeCluster")
 
 	// Get the old object, it may have been updated in between.
 	newAeroCluster := &asdbv1.AerospikeCluster{}
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, newAeroCluster,
 	); err != nil {
@@ -459,9 +485,9 @@ func (r *SingleClusterReconciler) updateStatus() error {
 	// If IsReadinessProbeEnabled is not enabled, then only check for cluster readiness.
 	// This is to avoid checking cluster readiness for every reconcile as once it is enabled, it will not be disabled.
 	if !newAeroCluster.Status.IsReadinessProbeEnabled {
-		clusterReadinessEnable, gErr := r.getClusterReadinessStatus()
+		clusterReadinessEnable, gErr := r.getClusterReadinessStatus(ctx)
 		if gErr != nil {
-			return fmt.Errorf("failed to get cluster readiness status: %v", gErr)
+			return fmt.Errorf("getting cluster readiness status: %w", gErr)
 		}
 
 		newAeroCluster.Status.IsReadinessProbeEnabled = clusterReadinessEnable
@@ -470,9 +496,9 @@ func (r *SingleClusterReconciler) updateStatus() error {
 	selector := labels.SelectorFromSet(utils.LabelsForAerospikeCluster(newAeroCluster.Name))
 	newAeroCluster.Status.Selector = selector.String()
 
-	err = r.patchStatus(newAeroCluster)
+	err = r.patchStatus(ctx, newAeroCluster)
 	if err != nil {
-		return fmt.Errorf("error updating status: %w", err)
+		return fmt.Errorf("updating status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	r.aeroCluster = newAeroCluster
@@ -485,18 +511,18 @@ func (r *SingleClusterReconciler) updateStatus() error {
 	return nil
 }
 
-func (r *SingleClusterReconciler) setStatusPhase(phase asdbv1.AerospikeClusterPhase) error {
+func (r *SingleClusterReconciler) setStatusPhase(ctx context.Context, phase asdbv1.AerospikeClusterPhase) error {
 	if r.aeroCluster.Status.Phase != phase {
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := r.Get(context.TODO(), utils.GetNamespacedName(r.aeroCluster), r.aeroCluster); err != nil {
+			if err := r.Get(ctx, utils.GetNamespacedName(r.aeroCluster), r.aeroCluster); err != nil {
 				return err
 			}
 
 			r.aeroCluster.Status.Phase = phase
 
+			// detached: status update must complete even if the reconcile context is cancelled
 			return r.Client.Status().Update(context.Background(), r.aeroCluster)
 		}); err != nil {
-			r.Log.Error(err, fmt.Sprintf("Failed to set cluster status to %s", phase))
 			return err
 		}
 
@@ -506,8 +532,8 @@ func (r *SingleClusterReconciler) setStatusPhase(phase asdbv1.AerospikeClusterPh
 	return nil
 }
 
-func (r *SingleClusterReconciler) getClusterReadinessStatus() (bool, error) {
-	podList, err := r.getClusterPodList()
+func (r *SingleClusterReconciler) getClusterReadinessStatus(ctx context.Context) (bool, error) {
+	podList, err := r.getClusterPodList(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -529,7 +555,7 @@ func (r *SingleClusterReconciler) getClusterReadinessStatus() (bool, error) {
 	return true, nil
 }
 
-func (r *SingleClusterReconciler) updateAccessControlStatus() error {
+func (r *SingleClusterReconciler) updateAccessControlStatus(ctx context.Context) error {
 	if r.aeroCluster.Spec.AerospikeAccessControl == nil {
 		return nil
 	}
@@ -539,7 +565,7 @@ func (r *SingleClusterReconciler) updateAccessControlStatus() error {
 	// Get the old object, it may have been updated in between.
 	newAeroCluster := &asdbv1.AerospikeCluster{}
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, newAeroCluster,
 	); err != nil {
@@ -556,8 +582,8 @@ func (r *SingleClusterReconciler) updateAccessControlStatus() error {
 
 	newAeroCluster.Status.AerospikeAccessControl = statusAerospikeAccessControl
 
-	if err := r.patchStatus(newAeroCluster); err != nil {
-		return fmt.Errorf("error updating status: %w", err)
+	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
+		return fmt.Errorf("updating access control status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	r.Log.Info("Updated access control status", "status", newAeroCluster.Status)
@@ -565,13 +591,13 @@ func (r *SingleClusterReconciler) updateAccessControlStatus() error {
 	return nil
 }
 
-func (r *SingleClusterReconciler) createStatus() error {
+func (r *SingleClusterReconciler) createStatus(ctx context.Context) error {
 	r.Log.Info("Creating status for AerospikeCluster")
 
 	// Get the old object, it may have been updated in between.
 	newAeroCluster := &asdbv1.AerospikeCluster{}
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, newAeroCluster,
 	); err != nil {
@@ -583,21 +609,21 @@ func (r *SingleClusterReconciler) createStatus() error {
 	}
 
 	if err := r.Client.Status().Update(
-		context.TODO(), newAeroCluster,
+		ctx, newAeroCluster,
 	); err != nil {
-		return fmt.Errorf("error creating status: %v", err)
+		return fmt.Errorf("creating status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	return nil
 }
 
-func (r *SingleClusterReconciler) isNewCluster() (bool, error) {
+func (r *SingleClusterReconciler) isNewCluster(ctx context.Context) (bool, error) {
 	if !r.IsStatusEmpty() {
 		// We have valid status, cluster cannot be new.
 		return false, nil
 	}
 
-	statefulSetList, err := r.getClusterSTSList()
+	statefulSetList, err := r.getClusterSTSList(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -611,8 +637,8 @@ func (r *SingleClusterReconciler) isNewCluster() (bool, error) {
 // failed: true if cluster has truly failed and needs recovery
 // inGracePeriod: true if cluster has failed pods but within grace period
 // error: any error during the check
-func (r *SingleClusterReconciler) hasClusterFailed() (failed, inGracePeriod bool, err error) {
-	isNew, err := r.isNewCluster()
+func (r *SingleClusterReconciler) hasClusterFailed(ctx context.Context) (failed, inGracePeriod bool, err error) {
+	isNew, err := r.isNewCluster(ctx)
 	if err != nil {
 		// Checking cluster status failed.
 		return failed, inGracePeriod, err
@@ -624,7 +650,7 @@ func (r *SingleClusterReconciler) hasClusterFailed() (failed, inGracePeriod bool
 	}
 
 	// Check if there are any pods running
-	pods, err := r.getClusterPodList()
+	pods, err := r.getClusterPodList(ctx)
 	if err != nil {
 		return failed, inGracePeriod, err
 	}
@@ -661,22 +687,22 @@ func (r *SingleClusterReconciler) hasClusterFailed() (failed, inGracePeriod bool
 	return failed, inGracePeriod, nil
 }
 
-func (r *SingleClusterReconciler) patchStatus(newAeroCluster *asdbv1.AerospikeCluster) error {
+func (r *SingleClusterReconciler) patchStatus(ctx context.Context, newAeroCluster *asdbv1.AerospikeCluster) error {
 	oldAeroCluster := r.aeroCluster
 
 	oldJSON, err := json.Marshal(oldAeroCluster)
 	if err != nil {
-		return fmt.Errorf("error marshalling old status: %v", err)
+		return fmt.Errorf("marshalling old status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	newJSON, err := json.Marshal(newAeroCluster)
 	if err != nil {
-		return fmt.Errorf("error marshalling new status: %v", err)
+		return fmt.Errorf("marshalling new status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	jsonPatchPatch, err := jsonpatch.CreatePatch(oldJSON, newJSON)
 	if err != nil {
-		return fmt.Errorf("error creating json patch: %v", err)
+		return fmt.Errorf("creating json patch for status of cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	// Pick changes to the status object only.
@@ -706,19 +732,19 @@ func (r *SingleClusterReconciler) patchStatus(newAeroCluster *asdbv1.AerospikeCl
 
 	jsonPatchJSON, err := json.Marshal(filteredPatch)
 	if err != nil {
-		return fmt.Errorf("error marshalling json patch: %v", err)
+		return fmt.Errorf("marshalling json patch for status of cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	patch := client.RawPatch(types.JSONPatchType, jsonPatchJSON)
 
 	if err = r.Client.Status().Patch(
-		context.TODO(), &asdbv1.AerospikeCluster{ObjectMeta: metav1.ObjectMeta{
+		ctx, &asdbv1.AerospikeCluster{ObjectMeta: metav1.ObjectMeta{
 			Name:      oldAeroCluster.Name,
 			Namespace: oldAeroCluster.Namespace,
 		}}, patch,
 		client.FieldOwner(patchFieldOwner),
 	); err != nil {
-		return fmt.Errorf("error patching status: %v", err)
+		return fmt.Errorf("patching status for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	// FIXME: Json unmarshal used by above client.Status(),
@@ -742,15 +768,15 @@ func (r *SingleClusterReconciler) patchStatus(newAeroCluster *asdbv1.AerospikeCl
 // validation for ip and port.
 //
 // Such cases warrant a cluster recreate to recover after the user corrects the configuration.
-func (r *SingleClusterReconciler) recoverFailedCreate() error {
+func (r *SingleClusterReconciler) recoverFailedCreate(ctx context.Context) error {
 	r.Log.Info("Forcing a cluster recreate as status is nil. The cluster could be unreachable due to bad configuration.")
 
 	// Delete all statefulsets and everything related so that it can be properly created and updated in next run.
-	statefulSetList, err := r.getClusterSTSList()
+	statefulSetList, err := r.getClusterSTSList(ctx)
 	if err != nil {
 		return fmt.Errorf(
-			"error getting statefulsets while forcing recreate of the cluster as status is nil: %v",
-			err,
+			"listing statefulsets while forcing recreate of cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
 
@@ -761,18 +787,21 @@ func (r *SingleClusterReconciler) recoverFailedCreate() error {
 
 	for idx := range statefulSetList.Items {
 		statefulset := &statefulSetList.Items[idx]
-		if err := r.deleteSTS(statefulset); err != nil {
+		if err := r.deleteSTS(ctx, statefulset); err != nil {
 			return fmt.Errorf(
-				"error deleting statefulset while forcing recreate of the cluster as status is nil: %v",
-				err,
+				"deleting statefulset %s while forcing recreate of cluster: %w",
+				utils.GetNamespacedNameString(statefulset), err,
 			)
 		}
 	}
 
 	// Delete all PVCs for the cluster unconditionally, regardless of the cascadeDelete flag on
 	// individual volumes. During a failed-create recovery the cluster must start completely fresh.
-	if err := r.deleteAllClusterPVCsForce(); err != nil {
-		return fmt.Errorf("failed to delete cluster PVCs during recover: %v", err)
+	if err := r.deleteAllClusterPVCsForce(ctx); err != nil {
+		return fmt.Errorf(
+			"deleting cluster PVCs while forcing recreate of cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	// Clear pod status, mesh references, and per-pod services.
@@ -782,9 +811,12 @@ func (r *SingleClusterReconciler) recoverFailedCreate() error {
 	for rackIdx := range rackStateList {
 		state := rackStateList[rackIdx]
 
-		pods, err := r.getRackPodList(state.Rack.ID, state.Rack.Revision)
+		pods, err := r.getRackPodList(ctx, state.Rack.ID, state.Rack.Revision)
 		if err != nil {
-			return fmt.Errorf("failed recover failed cluster: %v", err)
+			return fmt.Errorf(
+				"listing pods for rack %d while recovering cluster %s after create failure: %w",
+				state.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 		}
 
 		newPodNames := make([]string, 0)
@@ -792,8 +824,11 @@ func (r *SingleClusterReconciler) recoverFailedCreate() error {
 			newPodNames = append(newPodNames, pods.Items[podIdx].Name)
 		}
 
-		if err := r.cleanupPodMeshAndStatus(newPodNames); err != nil {
-			return fmt.Errorf("failed recover failed cluster: %v", err)
+		if err := r.cleanupPods(ctx, newPodNames, &state); err != nil {
+			return fmt.Errorf(
+				"cleaning up pods for rack %d while recovering cluster %s after create failure: %w",
+				state.Rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			)
 		}
 	}
 
@@ -803,35 +838,46 @@ func (r *SingleClusterReconciler) recoverFailedCreate() error {
 	// ACL status is left intact, the operator would attempt to authenticate with
 	// those old credentials on the newly recreated nodes, causing info commands
 	// to fail.
-	if err := r.clearAerospikeAccessControlStatus(); err != nil {
-		return fmt.Errorf("failed to clear access control status during cluster recovery: %v", err)
+	if err := r.clearAerospikeAccessControlStatus(ctx); err != nil {
+		return fmt.Errorf(
+			"clearing access control status while recovering cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
-	return fmt.Errorf("forcing recreate of the cluster as status is nil")
+	return fmt.Errorf(
+		"forcing recreate of cluster %s: status is nil", utils.ClusterNamespacedName(r.aeroCluster),
+	)
 }
 
 // clearAerospikeAccessControlStatus sets AerospikeAccessControl to nil in the
 // CR status. This is called during recoverFailedCreate so that the operator
 // does not attempt to authenticate with stale credentials against freshly
 // recreated Aerospike nodes that have no user data.
-func (r *SingleClusterReconciler) clearAerospikeAccessControlStatus() error {
+func (r *SingleClusterReconciler) clearAerospikeAccessControlStatus(ctx context.Context) error {
 	if r.aeroCluster.Status.AerospikeAccessControl == nil {
 		return nil
 	}
 
 	newAeroCluster := &asdbv1.AerospikeCluster{}
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: r.aeroCluster.Name, Namespace: r.aeroCluster.Namespace,
 		}, newAeroCluster,
 	); err != nil {
-		return err
+		return fmt.Errorf(
+			"getting AerospikeCluster %s for access control status clear: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	newAeroCluster.Status.AerospikeAccessControl = nil
 
-	if err := r.patchStatus(newAeroCluster); err != nil {
-		return fmt.Errorf("error clearing access control status: %w", err)
+	if err := r.patchStatus(ctx, newAeroCluster); err != nil {
+		return fmt.Errorf(
+			"clearing access control status for cluster %s: %w",
+			utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	r.Log.Info("Cleared access control status for cluster recovery")
@@ -839,7 +885,7 @@ func (r *SingleClusterReconciler) clearAerospikeAccessControlStatus() error {
 	return nil
 }
 
-func (r *SingleClusterReconciler) addFinalizer(finalizerName string) error {
+func (r *SingleClusterReconciler) addFinalizer(ctx context.Context, finalizerName string) error {
 	// The object is not being deleted, so if it does not have our finalizer,
 	// then lets add the finalizer and update the object. This is equivalent
 	// registering our finalizer.
@@ -850,7 +896,7 @@ func (r *SingleClusterReconciler) addFinalizer(finalizerName string) error {
 			r.aeroCluster.Finalizers, finalizerName,
 		)
 
-		if err := r.Update(context.TODO(), r.aeroCluster); err != nil {
+		if err := r.Update(ctx, r.aeroCluster); err != nil {
 			return err
 		}
 	}
@@ -858,13 +904,13 @@ func (r *SingleClusterReconciler) addFinalizer(finalizerName string) error {
 	return nil
 }
 
-func (r *SingleClusterReconciler) cleanUpAndRemoveFinalizer(finalizerName string) error {
+func (r *SingleClusterReconciler) cleanUpAndRemoveFinalizer(ctx context.Context, finalizerName string) error {
 	// The object is being deleted
 	if utils.ContainsString(
 		r.aeroCluster.Finalizers, finalizerName,
 	) {
 		// Handle any external dependency
-		if err := r.deleteExternalResources(); err != nil {
+		if err := r.deleteExternalResources(ctx); err != nil {
 			// If fail to delete the external dependency here, return with error
 			// so that it can be retried
 			return err
@@ -875,7 +921,7 @@ func (r *SingleClusterReconciler) cleanUpAndRemoveFinalizer(finalizerName string
 			r.aeroCluster.Finalizers, finalizerName,
 		)
 
-		if err := r.Update(context.TODO(), r.aeroCluster); err != nil {
+		if err := r.Update(ctx, r.aeroCluster); err != nil {
 			return err
 		}
 	}
@@ -884,7 +930,7 @@ func (r *SingleClusterReconciler) cleanUpAndRemoveFinalizer(finalizerName string
 	return nil
 }
 
-func (r *SingleClusterReconciler) deleteExternalResources() error {
+func (r *SingleClusterReconciler) deleteExternalResources(ctx context.Context) error {
 	// Delete should be idempotent
 	r.Log.Info("Removing pvc for removed cluster")
 
@@ -892,21 +938,21 @@ func (r *SingleClusterReconciler) deleteExternalResources() error {
 	for idx := range r.aeroCluster.Spec.RackConfig.Racks {
 		rack := &r.aeroCluster.Spec.RackConfig.Racks[idx]
 
-		rackPVCItems, err := r.getRackPVCList(rack.ID, rack.Revision)
+		rackPVCItems, err := r.getRackPVCList(ctx, rack.ID, rack.Revision)
 		if err != nil {
-			return fmt.Errorf("could not find pvc for rack: %v", err)
+			return fmt.Errorf("listing pvcs for rack %d in cluster %s: %w", rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 
 		storage := rack.Storage
-		if _, err := r.removePVCsAsync(&storage, rackPVCItems); err != nil {
-			return fmt.Errorf("failed to remove cluster PVCs: %v", err)
+		if _, err := r.removePVCsAsync(ctx, &storage, rackPVCItems); err != nil {
+			return fmt.Errorf("removing pvcs for rack %d in cluster %s: %w", rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	}
 
 	// Delete PVCs for any remaining old removed racks
-	pvcItems, err := r.getClusterPVCList()
+	pvcItems, err := r.getClusterPVCList(ctx)
 	if err != nil {
-		return fmt.Errorf("could not find pvc for cluster: %v", err)
+		return fmt.Errorf("listing pvcs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	// removePVCs should be passed only filtered pvc otherwise rack pvc may be removed using global storage
@@ -937,36 +983,35 @@ func (r *SingleClusterReconciler) deleteExternalResources() error {
 
 	// Delete pvc for common storage.
 	if _, err := r.removePVCsAsync(
-		&r.aeroCluster.Spec.Storage, filteredPVCItems,
+		ctx, &r.aeroCluster.Spec.Storage, filteredPVCItems,
 	); err != nil {
-		return fmt.Errorf("failed to remove cluster PVCs: %v", err)
+		return fmt.Errorf("removing pvcs for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	return nil
 }
 
-func (r *SingleClusterReconciler) handleClusterDeletion(finalizerName string) error {
+func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, finalizerName string) error {
 	r.Log.Info("Handle cluster deletion")
 
 	// The cluster is being deleted
-	if err := r.cleanUpAndRemoveFinalizer(finalizerName); err != nil {
-		r.Log.Error(err, "Failed to remove finalizer")
+	if err := r.cleanUpAndRemoveFinalizer(ctx, finalizerName); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (r *SingleClusterReconciler) checkPreviouslyFailedCluster() (bool, common.ReconcileResult) {
-	isNew, err := r.isNewCluster()
+func (r *SingleClusterReconciler) checkPreviouslyFailedCluster(ctx context.Context) (bool, common.ReconcileResult) {
+	isNew, err := r.isNewCluster(ctx)
 	if err != nil {
-		return false, common.ReconcileError(fmt.Errorf("error determining if cluster is new: %v", err))
+		return false, common.ReconcileError(fmt.Errorf("determining if cluster %s is new: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 	}
 
 	if isNew {
 		r.Log.V(1).Info("It's a new cluster, create empty status object")
 
-		if err := r.createStatus(); err != nil {
+		if err := r.createStatus(ctx); err != nil {
 			return false, common.ReconcileError(err)
 		}
 	} else {
@@ -975,13 +1020,13 @@ func (r *SingleClusterReconciler) checkPreviouslyFailedCluster() (bool, common.R
 				"checking if it is failed and needs recovery",
 		)
 
-		hasFailed, inGracePeriod, err := r.hasClusterFailed()
+		hasFailed, inGracePeriod, err := r.hasClusterFailed(ctx)
 		if err != nil {
-			return false, common.ReconcileError(fmt.Errorf("error determining if cluster has failed: %v", err))
+			return false, common.ReconcileError(fmt.Errorf("checking cluster %s failure state: %w", utils.ClusterNamespacedName(r.aeroCluster), err))
 		}
 
 		if hasFailed {
-			if err = r.recoverFailedCreate(); err != nil {
+			if err = r.recoverFailedCreate(ctx); err != nil {
 				return hasFailed, common.ReconcileError(err)
 			}
 
@@ -1024,18 +1069,16 @@ func (r *SingleClusterReconciler) IsStatusEmpty() bool {
 func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, hasFailed bool) error {
 	if !hasFailed {
 		if int(r.aeroCluster.Spec.Size) > len(r.aeroCluster.Status.Pods) {
-			return fmt.Errorf("cluster is not ready for migration, pod status is not populated")
+			return fmt.Errorf("cluster %s is not ready for migration: pod status is not populated", utils.ClusterNamespacedName(r.aeroCluster))
 		}
 
 		if err := r.migrateInitialisedVolumeNames(ctx); err != nil {
-			r.Log.Error(err, "Problem patching Initialised volumes")
-			return err
+			return fmt.Errorf("migrating initialized volume names for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 	}
 
 	if err := r.AddAPIVersionLabel(ctx); err != nil {
-		r.Log.Error(err, "Problem patching label")
-		return err
+		return fmt.Errorf("adding api version label to cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	return nil
@@ -1044,7 +1087,7 @@ func (r *SingleClusterReconciler) migrateAerospikeCluster(ctx context.Context, h
 func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Context) error {
 	r.Log.Info("Migrating Initialised Volumes name to new format")
 
-	podList, err := r.getClusterPodList()
+	podList, err := r.getClusterPodList(ctx)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request objects not found.
@@ -1060,7 +1103,7 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 		pod := &podList.Items[podIdx]
 
 		if _, ok := r.aeroCluster.Status.Pods[pod.Name]; !ok {
-			return fmt.Errorf("empty status found in CR for pod %s", pod.Name)
+			return fmt.Errorf("empty status found in cluster %s for pod %s", utils.ClusterNamespacedName(r.aeroCluster), utils.GetNamespacedNameString(pod))
 		}
 
 		initializedVolumes := r.aeroCluster.Status.Pods[pod.Name].InitializedVolumes
@@ -1084,7 +1127,11 @@ func (r *SingleClusterReconciler) migrateInitialisedVolumeNames(ctx context.Cont
 				}
 
 				if pvcUID == "" {
-					return fmt.Errorf("found empty pvcUID for the volume %s", oldFormatInitVolNames[oldVolIdx])
+					return fmt.Errorf(
+						"empty pvcUID found for volume %q on pod %s in cluster %s",
+						oldFormatInitVolNames[oldVolIdx], utils.GetNamespacedNameString(pod),
+						utils.ClusterNamespacedName(r.aeroCluster),
+					)
 				}
 
 				// Appending volume name as <vol_name>@<pvcUID> in initializedVolumes list

--- a/internal/controller/cluster/reconciler.go
+++ b/internal/controller/cluster/reconciler.go
@@ -317,7 +317,7 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 	ctx context.Context, ignorablePodNames sets.Set[string]) common.ReconcileResult {
 	podList, gErr := r.getClusterPodList(ctx)
 	if gErr != nil {
-		return common.ReconcileError(gErr)
+		return common.ReconcileError(fmt.Errorf("list pods for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), gErr))
 	}
 
 	r.Log.Info("Try to recover failed/pending pods if any")
@@ -351,11 +351,11 @@ func (r *SingleClusterReconciler) recoverIgnorablePods(
 					return common.ReconcileError(err)
 				}
 
-				if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
-					return common.ReconcileError(err)
-				}
+			if err := r.Delete(ctx, &podList.Items[idx]); err != nil {
+				return common.ReconcileError(fmt.Errorf("delete pod %s: %w", utils.GetNamespacedNameString(&podList.Items[idx]), err))
+			}
 
-				r.Log.Info("Deleted pod", "pod", podList.Items[idx].Name)
+			r.Log.Info("Deleted pod", "pod", podList.Items[idx].Name)
 			}
 		}
 	}
@@ -522,7 +522,7 @@ func (r *SingleClusterReconciler) setStatusPhase(ctx context.Context, phase asdb
 			// detached: status update must complete even if the reconcile context is cancelled
 			return r.Client.Status().Update(context.Background(), r.aeroCluster)
 		}); err != nil {
-			return err
+			return fmt.Errorf("set status to %s for cluster %s: %w", phase, utils.ClusterNamespacedName(r.aeroCluster), err)
 		}
 
 		r.addClusterPhaseMetric()
@@ -995,7 +995,7 @@ func (r *SingleClusterReconciler) handleClusterDeletion(ctx context.Context, fin
 
 	// The cluster is being deleted
 	if err := r.cleanUpAndRemoveFinalizer(ctx, finalizerName); err != nil {
-		return err
+		return fmt.Errorf("clean up and remove finalizer for cluster %s: %w", utils.ClusterNamespacedName(r.aeroCluster), err)
 	}
 
 	return nil

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -84,7 +84,7 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Conte
 			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"could not create headless Service for cluster %s: %w",
+				"could not create headless Service for statefulset %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -178,7 +178,7 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
 		return fmt.Errorf(
-			"loadbalancer service %s exists but is not created/owned by the operator",
+			"could not update LoadBalancer service: service is not created/owned by operator, name: %s",
 			utils.NamespacedName(service.Namespace, service.Name),
 		)
 	}

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -42,7 +43,8 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Conte
 			return err
 		}
 
-		r.Log.Info("Creating headless service for statefulSet")
+		r.Log.Info("Creating headless service for statefulSet",
+			"service", klog.KRef(r.aeroCluster.Namespace, serviceName))
 
 		if specHeadlessSvc.Metadata.Annotations != nil {
 			if defaultMetadata.Annotations == nil {
@@ -90,13 +92,13 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Conte
 		}
 
 		r.Log.Info("Created new headless service",
-			"name", utils.NamespacedName(service.Namespace, service.Name))
+			"service", klog.KObj(service))
 
 		return nil
 	}
 
 	r.Log.Info("Headless service already exist, checking for update",
-		"name", utils.NamespacedName(service.Namespace, service.Name))
+		"service", klog.KObj(service))
 
 	return r.updateService(
 		ctx,
@@ -124,7 +126,8 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 		}, service,
 	); err != nil {
 		if errors.IsNotFound(err) {
-			r.Log.Info("Creating LoadBalancer service for cluster")
+			r.Log.Info("Creating LoadBalancer service for cluster",
+				"service", klog.KRef(r.aeroCluster.Namespace, serviceName))
 			ls := utils.LabelsForAerospikeCluster(r.aeroCluster.Name)
 
 			service = &corev1.Service{
@@ -165,7 +168,7 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 			}
 
 			r.Log.Info("Created new LoadBalancer service",
-				"name", service.GetName())
+				"service", klog.KObj(service))
 
 			return nil
 		}
@@ -174,7 +177,7 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 	}
 
 	r.Log.Info("LoadBalancer service already exist for cluster, checking for update",
-		"name", utils.NamespacedName(service.Namespace, service.Name))
+		"service", klog.KObj(service))
 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
 		return fmt.Errorf(
@@ -208,7 +211,7 @@ func (r *SingleClusterReconciler) deleteLBServiceIfPresent(ctx context.Context, 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
 		r.Log.Info(
 			"LoadBalancer service is not created/owned by operator. Skipping delete",
-			"name", utils.NamespacedName(service.Namespace, service.Name),
+			"service", klog.KObj(service),
 		)
 
 		return nil
@@ -258,13 +261,13 @@ func (r *SingleClusterReconciler) updateLBService(ctx context.Context, service *
 		}
 	} else {
 		r.Log.Info("LoadBalancer service update not required, skipping",
-			"name", utils.NamespacedName(service.Namespace, service.Name))
+			"service", klog.KObj(service))
 
 		return nil
 	}
 
 	r.Log.Info("LoadBalancer service updated",
-		"name", utils.NamespacedName(service.Namespace, service.Name))
+		"service", klog.KObj(service))
 
 	return nil
 }
@@ -297,7 +300,8 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(ctx context.Context, 
 			return err
 		}
 
-		r.Log.Info("Creating new service for pod")
+		r.Log.Info("Creating new service for pod",
+			"pod", klog.KRef(pNamespace, pName))
 		// NodePort will be allocated automatically
 		service = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -335,13 +339,14 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(ctx context.Context, 
 		}
 
 		r.Log.Info("Created new service for pod",
-			"name", utils.NamespacedName(service.Namespace, service.Name))
+			"service", klog.KObj(service),
+			"pod", klog.KRef(pNamespace, pName))
 
 		return nil
 	}
 
 	r.Log.Info("Service already exist, checking for update",
-		"name", utils.NamespacedName(service.Namespace, service.Name))
+		"service", klog.KObj(service))
 
 	return r.updateService(
 		ctx,
@@ -362,7 +367,7 @@ func (r *SingleClusterReconciler) deletePodService(ctx context.Context, pName, p
 		if errors.IsNotFound(err) {
 			r.Log.Info(
 				"Pod service not found for deletion. Skipping...",
-				"service", serviceName,
+				"service", klog.KRef(serviceName.Namespace, serviceName.Name),
 			)
 
 			return nil
@@ -598,13 +603,13 @@ func (r *SingleClusterReconciler) updateService(
 		}
 
 		r.Log.Info("Service updated",
-			"name", utils.NamespacedName(service.Namespace, service.Name))
+			"service", klog.KObj(service))
 
 		return nil
 	}
 
 	r.Log.Info("Service update not required, skipping",
-		"name", utils.NamespacedName(service.Namespace, service.Name))
+		"service", klog.KObj(service))
 
 	return nil
 }

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -373,7 +373,7 @@ func (r *SingleClusterReconciler) deletePodService(ctx context.Context, pName, p
 			return nil
 		}
 
-		return fmt.Errorf("could not delete Service for pod %s: %w", serviceName, err)
+		return fmt.Errorf("delete Service for pod %s: %w", serviceName, err)
 	}
 
 	return nil

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/internal/controller/common"
@@ -178,10 +177,10 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 		"name", utils.NamespacedName(service.Namespace, service.Name))
 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
-		return reconcile.TerminalError(fmt.Errorf(
+		return fmt.Errorf(
 			"loadbalancer service %s exists but is not created/owned by the operator",
 			utils.NamespacedName(service.Namespace, service.Name),
-		))
+		)
 	}
 
 	return r.updateLBService(ctx, service, &servicePort, loadBalancer)

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -84,7 +84,7 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Conte
 			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"creating headless service for cluster %s: %w",
+				"could not create headless Service for cluster %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -252,7 +252,7 @@ func (r *SingleClusterReconciler) updateLBService(ctx context.Context, service *
 			ctx, service, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"updating loadbalancer service %s: %w",
+				"could not update LoadBalancer Service %s: %w",
 				utils.NamespacedName(service.Namespace, service.Name), err,
 			)
 		}
@@ -330,7 +330,7 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(ctx context.Context, 
 			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"creating service for pod %s: %w", utils.NamespacedName(pNamespace, pName), err,
+				"could not create Service for pod %s: %w", utils.NamespacedName(pNamespace, pName), err,
 			)
 		}
 
@@ -368,7 +368,7 @@ func (r *SingleClusterReconciler) deletePodService(ctx context.Context, pName, p
 			return nil
 		}
 
-		return fmt.Errorf("deleting service for pod %s: %w", serviceName, err)
+		return fmt.Errorf("could not delete Service for pod %s: %w", serviceName, err)
 	}
 
 	return nil
@@ -592,7 +592,7 @@ func (r *SingleClusterReconciler) updateService(
 			ctx, service, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"updating service %s: %w",
+				"could not update Service %s: %w",
 				utils.NamespacedName(service.Namespace, service.Name), err,
 			)
 		}

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/internal/controller/common"
@@ -23,7 +24,7 @@ func getSTSHeadLessSvcName(aeroCluster *asdbv1.AerospikeCluster) string {
 	return aeroCluster.Name
 }
 
-func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc() error {
+func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Context) error {
 	specHeadlessSvc := &r.aeroCluster.Spec.HeadlessService
 	serviceName := getSTSHeadLessSvcName(r.aeroCluster)
 	service := &corev1.Service{}
@@ -33,7 +34,7 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc() error {
 	}
 
 	err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: serviceName, Namespace: r.aeroCluster.Namespace,
 		}, service,
 	)
@@ -81,11 +82,11 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc() error {
 		}
 
 		if err = r.Create(
-			context.TODO(), service, common.CreateOption,
+			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"failed to create headless service for statefulset: %v",
-				err,
+				"creating headless service for cluster %s: %w",
+				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
 
@@ -99,6 +100,7 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc() error {
 		"name", utils.NamespacedName(service.Namespace, service.Name))
 
 	return r.updateService(
+		ctx,
 		service,
 		r.aeroCluster.Status.HeadlessService.Metadata,
 		specHeadlessSvc.Metadata,
@@ -106,19 +108,19 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc() error {
 	)
 }
 
-func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc() error {
+func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Context) error {
 	loadBalancer := r.aeroCluster.Spec.SeedsFinderServices.LoadBalancer
 	serviceName := r.aeroCluster.Name + "-lb"
 
 	if loadBalancer == nil {
-		return r.deleteLBServiceIfPresent(serviceName, r.aeroCluster.Namespace)
+		return r.deleteLBServiceIfPresent(ctx, serviceName, r.aeroCluster.Namespace)
 	}
 
 	service := &corev1.Service{}
 	servicePort := r.getLBServicePort(loadBalancer)
 
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: serviceName, Namespace: r.aeroCluster.Namespace,
 		}, service,
 	); err != nil {
@@ -158,7 +160,7 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc() error {
 			}
 
 			if nErr := r.Create(
-				context.TODO(), service, common.CreateOption,
+				ctx, service, common.CreateOption,
 			); nErr != nil {
 				return nErr
 			}
@@ -176,23 +178,23 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc() error {
 		"name", utils.NamespacedName(service.Namespace, service.Name))
 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
-		return fmt.Errorf(
-			"failed to update LoadBalancer service, service is not "+
-				"created/owned by operator. name: %s", utils.NamespacedName(service.Namespace, service.Name),
-		)
+		return reconcile.TerminalError(fmt.Errorf(
+			"loadbalancer service %s exists but is not created/owned by the operator",
+			utils.NamespacedName(service.Namespace, service.Name),
+		))
 	}
 
-	return r.updateLBService(service, &servicePort, loadBalancer)
+	return r.updateLBService(ctx, service, &servicePort, loadBalancer)
 }
 
-func (r *SingleClusterReconciler) deleteLBServiceIfPresent(svcName, svcNamespace string) error {
+func (r *SingleClusterReconciler) deleteLBServiceIfPresent(ctx context.Context, svcName, svcNamespace string) error {
 	service := &corev1.Service{}
 	service.Name = svcName
 	service.Namespace = svcNamespace
 
 	// Get the LB service
 	if err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: svcName, Namespace: svcNamespace,
 		}, service,
 	); err != nil {
@@ -214,10 +216,11 @@ func (r *SingleClusterReconciler) deleteLBServiceIfPresent(svcName, svcNamespace
 	}
 
 	// Delete the LB service
-	return r.Delete(context.TODO(), service)
+	return r.Delete(ctx, service)
 }
 
-func (r *SingleClusterReconciler) updateLBService(service *corev1.Service, servicePort *corev1.ServicePort,
+func (r *SingleClusterReconciler) updateLBService(ctx context.Context, service *corev1.Service,
+	servicePort *corev1.ServicePort,
 	loadBalancer *asdbv1.LoadBalancerSpec) error {
 	updateLBService := false
 
@@ -247,10 +250,11 @@ func (r *SingleClusterReconciler) updateLBService(service *corev1.Service, servi
 
 	if updateLBService {
 		if err := r.Update(
-			context.TODO(), service, common.UpdateOption,
+			ctx, service, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"failed to update service %s: %v", service.Name, err,
+				"updating loadbalancer service %s: %w",
+				utils.NamespacedName(service.Namespace, service.Name), err,
 			)
 		}
 	} else {
@@ -266,7 +270,7 @@ func (r *SingleClusterReconciler) updateLBService(service *corev1.Service, servi
 	return nil
 }
 
-func (r *SingleClusterReconciler) reconcilePodService(rackState *RackState) error {
+func (r *SingleClusterReconciler) reconcilePodService(ctx context.Context, rackState *RackState) error {
 	// PodService is only created if MultiPodPerHost is enabled
 	if !asdbv1.GetBool(r.aeroCluster.Spec.PodSpec.MultiPodPerHost) {
 		return nil
@@ -274,18 +278,18 @@ func (r *SingleClusterReconciler) reconcilePodService(rackState *RackState) erro
 
 	// Safe check to delete all dangling pod services which are no longer required
 	if !podServiceNeeded(r.aeroCluster.Spec.PodSpec.MultiPodPerHost, &r.aeroCluster.Spec.AerospikeNetworkPolicy) {
-		return r.cleanupDanglingPodServices(rackState)
+		return r.cleanupDanglingPodServices(ctx, rackState)
 	}
 
-	return r.createOrUpdatePodServiceIfNeeded(r.getRackPodNames(rackState))
+	return r.createOrUpdatePodServiceIfNeeded(ctx, r.getRackPodNames(rackState))
 }
 
-func (r *SingleClusterReconciler) createOrUpdatePodService(pName, pNamespace string) error {
+func (r *SingleClusterReconciler) createOrUpdatePodService(ctx context.Context, pName, pNamespace string) error {
 	podService := &r.aeroCluster.Spec.PodService
 	service := &corev1.Service{}
 
 	err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: pName, Namespace: pNamespace,
 		}, service,
 	)
@@ -324,10 +328,10 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(pName, pNamespace str
 		}
 
 		if err := r.Create(
-			context.TODO(), service, common.CreateOption,
+			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"failed to create new service for pod %s: %v", pName, err,
+				"creating service for pod %s: %w", utils.NamespacedName(pNamespace, pName), err,
 			)
 		}
 
@@ -341,6 +345,7 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(pName, pNamespace str
 		"name", utils.NamespacedName(service.Namespace, service.Name))
 
 	return r.updateService(
+		ctx,
 		service,
 		r.aeroCluster.Status.PodService.Metadata,
 		podService.Metadata,
@@ -348,13 +353,13 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(pName, pNamespace str
 	)
 }
 
-func (r *SingleClusterReconciler) deletePodService(pName, pNamespace string) error {
+func (r *SingleClusterReconciler) deletePodService(ctx context.Context, pName, pNamespace string) error {
 	service := &corev1.Service{}
 	service.Name = pName
 	service.Namespace = pNamespace
 	serviceName := types.NamespacedName{Name: pName, Namespace: pNamespace}
 
-	if err := r.Delete(context.TODO(), service); err != nil {
+	if err := r.Delete(ctx, service); err != nil {
 		if errors.IsNotFound(err) {
 			r.Log.Info(
 				"Pod service not found for deletion. Skipping...",
@@ -364,7 +369,7 @@ func (r *SingleClusterReconciler) deletePodService(pName, pNamespace string) err
 			return nil
 		}
 
-		return fmt.Errorf("failed to delete service for pod %s: %v", pName, err)
+		return fmt.Errorf("deleting service for pod %s: %w", serviceName, err)
 	}
 
 	return nil
@@ -472,14 +477,14 @@ func (r *SingleClusterReconciler) getLBServicePort(loadBalancer *asdbv1.LoadBala
 	}
 }
 
-func (r *SingleClusterReconciler) cleanupDanglingPodServices(rackState *RackState) error {
-	podList, err := r.getRackPodList(rackState.Rack.ID, rackState.Rack.Revision)
+func (r *SingleClusterReconciler) cleanupDanglingPodServices(ctx context.Context, rackState *RackState) error {
+	podList, err := r.getRackPodList(ctx, rackState.Rack.ID, rackState.Rack.Revision)
 	if err != nil {
 		return err
 	}
 
 	for idx := range podList.Items {
-		if err := r.deletePodService(podList.Items[idx].Name, podList.Items[idx].Namespace); err != nil {
+		if err := r.deletePodService(ctx, podList.Items[idx].Name, podList.Items[idx].Namespace); err != nil {
 			return err
 		}
 	}
@@ -506,14 +511,14 @@ func podServiceNeeded(multiPodPerHost *bool, networkPolicy *asdbv1.AerospikeNetw
 	return networkSet.Len() > 2
 }
 
-func (r *SingleClusterReconciler) createOrUpdatePodServiceIfNeeded(pods []string) error {
+func (r *SingleClusterReconciler) createOrUpdatePodServiceIfNeeded(ctx context.Context, pods []string) error {
 	if !podServiceNeeded(r.aeroCluster.Spec.PodSpec.MultiPodPerHost, &r.aeroCluster.Spec.AerospikeNetworkPolicy) {
 		return nil
 	}
 	// Create services for all pods if the network policy is changed and rely on nodePort service
 	for idx := range pods {
 		if err := r.createOrUpdatePodService(
-			pods[idx], r.aeroCluster.Namespace,
+			ctx, pods[idx], r.aeroCluster.Namespace,
 		); err != nil {
 			return err
 		}
@@ -567,6 +572,7 @@ func (r *SingleClusterReconciler) isServiceMetadataUpdated(
 }
 
 func (r *SingleClusterReconciler) updateService(
+	ctx context.Context,
 	service *corev1.Service,
 	statusMetadata,
 	specMetadata,
@@ -584,10 +590,11 @@ func (r *SingleClusterReconciler) updateService(
 
 	if needsUpdate {
 		if err := r.Update(
-			context.TODO(), service, common.UpdateOption,
+			ctx, service, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"failed to update service %s: %v", service.Name, err,
+				"updating service %s: %w",
+				utils.NamespacedName(service.Namespace, service.Name), err,
 			)
 		}
 

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -87,7 +87,7 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Conte
 		); err != nil {
 			return fmt.Errorf(
 				"create headless Service for StatefulSet %s: %w",
-				utils.ClusterNamespacedName(r.aeroCluster), err,
+				utils.GetNamespacedNameString(r.aeroCluster), err,
 			)
 		}
 

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -180,7 +180,7 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
 		return fmt.Errorf(
-			"update LoadBalancer Service %s: not created/owned by operator",
+			"existing LoadBalancer Service %s: not created/owned by operator",
 			utils.NamespacedName(service.Namespace, service.Name),
 		)
 	}

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
@@ -43,8 +42,8 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Conte
 			return err
 		}
 
-		r.Log.Info("Creating headless service for statefulSet",
-			"service", klog.KRef(r.aeroCluster.Namespace, serviceName))
+		r.Log.Info("Creating headless Service for cluster",
+			"service", utils.NewNamespacedName(r.aeroCluster.Namespace, serviceName))
 
 		if specHeadlessSvc.Metadata.Annotations != nil {
 			if defaultMetadata.Annotations == nil {
@@ -86,19 +85,19 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Conte
 			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"create headless Service for StatefulSet %s: %w",
-				utils.GetNamespacedNameString(r.aeroCluster), err,
+				"create headless Service %s for cluster: %w",
+				utils.NamespacedName(service.Namespace, service.Name), err,
 			)
 		}
 
-		r.Log.Info("Created new headless service",
-			"service", klog.KObj(service))
+		r.Log.Info("Created new headless Service",
+			"service", utils.GetNamespacedName(service))
 
 		return nil
 	}
 
-	r.Log.Info("Headless service already exist, checking for update",
-		"service", klog.KObj(service))
+	r.Log.Info("Headless Service already exist, checking for update",
+		"service", utils.GetNamespacedName(service))
 
 	return r.updateService(
 		ctx,
@@ -126,8 +125,8 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 		}, service,
 	); err != nil {
 		if errors.IsNotFound(err) {
-			r.Log.Info("Creating LoadBalancer service for cluster",
-				"service", klog.KRef(r.aeroCluster.Namespace, serviceName))
+			r.Log.Info("Creating LoadBalancer Service for cluster",
+				"service", utils.NewNamespacedName(r.aeroCluster.Namespace, serviceName))
 			ls := utils.LabelsForAerospikeCluster(r.aeroCluster.Name)
 
 			service = &corev1.Service{
@@ -167,8 +166,8 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 				return nErr
 			}
 
-			r.Log.Info("Created new LoadBalancer service",
-				"service", klog.KObj(service))
+			r.Log.Info("Created new LoadBalancer Service",
+				"service", utils.GetNamespacedName(service))
 
 			return nil
 		}
@@ -176,8 +175,8 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 		return err
 	}
 
-	r.Log.Info("LoadBalancer service already exist for cluster, checking for update",
-		"service", klog.KObj(service))
+	r.Log.Info("LoadBalancer Service already exist for cluster, checking for update",
+		"service", utils.GetNamespacedName(service))
 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
 		return fmt.Errorf(
@@ -210,8 +209,8 @@ func (r *SingleClusterReconciler) deleteLBServiceIfPresent(ctx context.Context, 
 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
 		r.Log.Info(
-			"LoadBalancer service is not created/owned by operator. Skipping delete",
-			"service", klog.KObj(service),
+			"LoadBalancer Service is not created/owned by operator. Skipping delete",
+			"service", utils.GetNamespacedName(service),
 		)
 
 		return nil
@@ -260,14 +259,14 @@ func (r *SingleClusterReconciler) updateLBService(ctx context.Context, service *
 			)
 		}
 	} else {
-		r.Log.Info("LoadBalancer service update not required, skipping",
-			"service", klog.KObj(service))
+		r.Log.Info("LoadBalancer Service update not required, skipping",
+			"service", utils.GetNamespacedName(service))
 
 		return nil
 	}
 
-	r.Log.Info("LoadBalancer service updated",
-		"service", klog.KObj(service))
+	r.Log.Info("LoadBalancer Service updated",
+		"service", utils.GetNamespacedName(service))
 
 	return nil
 }
@@ -300,8 +299,9 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(ctx context.Context, 
 			return err
 		}
 
-		r.Log.Info("Creating new service for pod",
-			"pod", klog.KRef(pNamespace, pName))
+		r.Log.Info("Creating new Service for Pod",
+			"service", utils.NewNamespacedName(pNamespace, pName),
+			"pod", utils.NewNamespacedName(pNamespace, pName))
 		// NodePort will be allocated automatically
 		service = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -334,19 +334,19 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(ctx context.Context, 
 			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"create Service for pod %s: %w", utils.NamespacedName(pNamespace, pName), err,
+				"create Service for Pod %s: %w", utils.NamespacedName(pNamespace, pName), err,
 			)
 		}
 
-		r.Log.Info("Created new service for pod",
-			"service", klog.KObj(service),
-			"pod", klog.KRef(pNamespace, pName))
+		r.Log.Info("Created new Service for Pod",
+			"service", utils.GetNamespacedName(service),
+			"pod", utils.NewNamespacedName(pNamespace, pName))
 
 		return nil
 	}
 
 	r.Log.Info("Service already exist, checking for update",
-		"service", klog.KObj(service))
+		"service", utils.GetNamespacedName(service))
 
 	return r.updateService(
 		ctx,
@@ -366,14 +366,15 @@ func (r *SingleClusterReconciler) deletePodService(ctx context.Context, pName, p
 	if err := r.Delete(ctx, service); err != nil {
 		if errors.IsNotFound(err) {
 			r.Log.Info(
-				"Pod service not found for deletion. Skipping...",
-				"service", klog.KRef(serviceName.Namespace, serviceName.Name),
+				"Pod Service not found for deletion. Skipping...",
+				"service", utils.NewNamespacedName(serviceName.Namespace, serviceName.Name),
+				"pod", utils.NewNamespacedName(pNamespace, pName),
 			)
 
 			return nil
 		}
 
-		return fmt.Errorf("delete Service for pod %s: %w", serviceName, err)
+		return fmt.Errorf("delete Service for Pod %s: %w", serviceName, err)
 	}
 
 	return nil
@@ -603,13 +604,13 @@ func (r *SingleClusterReconciler) updateService(
 		}
 
 		r.Log.Info("Service updated",
-			"service", klog.KObj(service))
+			"service", utils.GetNamespacedName(service))
 
 		return nil
 	}
 
 	r.Log.Info("Service update not required, skipping",
-		"service", klog.KObj(service))
+		"service", utils.GetNamespacedName(service))
 
 	return nil
 }

--- a/internal/controller/cluster/service.go
+++ b/internal/controller/cluster/service.go
@@ -86,7 +86,7 @@ func (r *SingleClusterReconciler) createOrUpdateSTSHeadlessSvc(ctx context.Conte
 			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"could not create headless Service for statefulset %s: %w",
+				"create headless Service for StatefulSet %s: %w",
 				utils.ClusterNamespacedName(r.aeroCluster), err,
 			)
 		}
@@ -181,7 +181,7 @@ func (r *SingleClusterReconciler) reconcileSTSLoadBalancerSvc(ctx context.Contex
 
 	if !utils.IsOwnedBy(service, r.aeroCluster) {
 		return fmt.Errorf(
-			"could not update LoadBalancer service: service is not created/owned by operator, name: %s",
+			"update LoadBalancer Service %s: not created/owned by operator",
 			utils.NamespacedName(service.Namespace, service.Name),
 		)
 	}
@@ -255,7 +255,7 @@ func (r *SingleClusterReconciler) updateLBService(ctx context.Context, service *
 			ctx, service, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"could not update LoadBalancer Service %s: %w",
+				"update LoadBalancer Service %s: %w",
 				utils.NamespacedName(service.Namespace, service.Name), err,
 			)
 		}
@@ -334,7 +334,7 @@ func (r *SingleClusterReconciler) createOrUpdatePodService(ctx context.Context, 
 			ctx, service, common.CreateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"could not create Service for pod %s: %w", utils.NamespacedName(pNamespace, pName), err,
+				"create Service for pod %s: %w", utils.NamespacedName(pNamespace, pName), err,
 			)
 		}
 
@@ -597,7 +597,7 @@ func (r *SingleClusterReconciler) updateService(
 			ctx, service, common.UpdateOption,
 		); err != nil {
 			return fmt.Errorf(
-				"could not update Service %s: %w",
+				"update Service %s: %w",
 				utils.NamespacedName(service.Namespace, service.Name), err,
 			)
 		}

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -94,7 +94,7 @@ var defaultContainerPorts = map[string]PortInfo{
 }
 
 func (r *SingleClusterReconciler) createSTS(
-	namespacedName types.NamespacedName, rackState *RackState,
+	ctx context.Context, namespacedName types.NamespacedName, rackState *RackState,
 ) (*appsv1.StatefulSet, error) {
 	replicas := rackState.Size
 
@@ -198,8 +198,8 @@ func (r *SingleClusterReconciler) createSTS(
 		return nil, err
 	}
 
-	if err := r.Create(context.TODO(), st, common.CreateOption); err != nil {
-		return nil, fmt.Errorf("failed to create new StatefulSet: %v", err)
+	if err := r.Create(ctx, st, common.CreateOption); err != nil {
+		return nil, fmt.Errorf("creating statefulset %s: %w", utils.GetNamespacedNameString(st), err)
 	}
 
 	r.Log.Info(
@@ -207,13 +207,13 @@ func (r *SingleClusterReconciler) createSTS(
 		"StatefulSet.Name", st.Name,
 	)
 
-	if err := r.waitForSTSToBeReady(st, nil); err != nil {
+	if err := r.waitForSTSToBeReady(ctx, st, nil); err != nil {
 		return st, fmt.Errorf(
-			"failed to wait for statefulset to be ready: %v", err,
+			"waiting for statefulset %s to be ready: %w", utils.GetNamespacedNameString(st), err,
 		)
 	}
 
-	return r.getSTS(rackState)
+	return r.getSTS(ctx, rackState)
 }
 
 func (r *SingleClusterReconciler) getReadinessProbe() *corev1.Probe {
@@ -239,16 +239,16 @@ func (r *SingleClusterReconciler) getReadinessProbe() *corev1.Probe {
 	}
 }
 
-func (r *SingleClusterReconciler) deleteSTS(st *appsv1.StatefulSet) error {
+func (r *SingleClusterReconciler) deleteSTS(ctx context.Context, st *appsv1.StatefulSet) error {
 	r.Log.Info("Delete statefulset", "namespace", st.Namespace, "name", st.Name)
 	// No need to do cleanup pods after deleting sts
 	// It is only deleted while its creation is failed
 	// While doing rackRemove, we call scaleDown to 0 so that will do cleanup
-	return r.Delete(context.TODO(), st)
+	return r.Delete(ctx, st)
 }
 
 func (r *SingleClusterReconciler) waitForSTSToBeReady(
-	st *appsv1.StatefulSet, ignorablePodNames sets.Set[string],
+	ctx context.Context, st *appsv1.StatefulSet, ignorablePodNames sets.Set[string],
 ) error {
 	const (
 		podStatusMaxRetry      = 18
@@ -274,7 +274,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 		// Wait for 10 sec to pod to get started
 		for i := 0; i < 5; i++ {
 			if err := r.Get(
-				context.TODO(),
+				ctx,
 				types.NamespacedName{Name: podName, Namespace: st.Namespace},
 				pod,
 			); err == nil {
@@ -291,17 +291,17 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 			)
 
 			if err := r.Get(
-				context.TODO(),
+				ctx,
 				types.NamespacedName{Name: podName, Namespace: st.Namespace},
 				pod,
 			); err != nil {
 				return fmt.Errorf(
-					"failed to get statefulSet pod %s: %v", podName, err,
+					"getting statefulset pod %s: %w", utils.NamespacedName(st.Namespace, podName), err,
 				)
 			}
 
 			if err := utils.CheckPodFailed(pod); err != nil {
-				return fmt.Errorf("statefulSet pod %s failed: %v", podName, err)
+				return fmt.Errorf("checking statefulset pod %s health: %w", utils.NamespacedName(st.Namespace, podName), err)
 			}
 
 			if utils.IsPodRunningAndReady(pod) {
@@ -317,10 +317,9 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 
 		if !isReady {
 			statusErr := fmt.Errorf(
-				"statefulSet pod is not ready. Status: %v",
-				pod.Status.Conditions,
+				"statefulset pod %s is not ready, status conditions: %s",
+				utils.NamespacedName(st.Namespace, podName), formatPodConditionStatuses(pod.Status.Conditions),
 			)
-			r.Log.Error(statusErr, "Statefulset Not ready")
 
 			return statusErr
 		}
@@ -341,7 +340,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 		r.Log.V(1).Info("Check statefulSet status is updated or not")
 
 		if err := r.Get(
-			context.TODO(),
+			ctx,
 			types.NamespacedName{Name: st.Name, Namespace: st.Namespace}, st,
 		); err != nil {
 			return err
@@ -359,7 +358,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 	}
 
 	if !updated {
-		return fmt.Errorf("statefulset status is not updated")
+		return fmt.Errorf("statefulset %s status not updated to desired replicas", utils.GetNamespacedNameString(st))
 	}
 
 	r.Log.Info("StatefulSet is ready")
@@ -367,10 +366,26 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 	return nil
 }
 
-func (r *SingleClusterReconciler) getSTS(rackState *RackState) (*appsv1.StatefulSet, error) {
+func formatPodConditionStatuses(conditions []corev1.PodCondition) string {
+	if len(conditions) == 0 {
+		return "none"
+	}
+
+	parts := make([]string, 0, len(conditions))
+	for _, condition := range conditions {
+		parts = append(parts, fmt.Sprintf(
+			"%s=%s(reason=%s)",
+			condition.Type, condition.Status, condition.Reason,
+		))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+func (r *SingleClusterReconciler) getSTS(ctx context.Context, rackState *RackState) (*appsv1.StatefulSet, error) {
 	found := &appsv1.StatefulSet{}
 	if err := r.Get(
-		context.TODO(),
+		ctx,
 		utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster,
 			utils.GetRackIdentifier(rackState.Rack.ID, rackState.Rack.Revision)),
 		found,
@@ -382,14 +397,14 @@ func (r *SingleClusterReconciler) getSTS(rackState *RackState) (*appsv1.Stateful
 }
 
 func (r *SingleClusterReconciler) createSTSConfigMap(
-	namespacedName types.NamespacedName, rack *asdbv1.Rack,
+	ctx context.Context, namespacedName types.NamespacedName, rack *asdbv1.Rack,
 ) error {
 	r.Log.Info("Creating a new ConfigMap for statefulSet")
 
 	confMap := &corev1.ConfigMap{}
 
 	err := r.Get(
-		context.TODO(), types.NamespacedName{
+		ctx, types.NamespacedName{
 			Name: namespacedName.Name, Namespace: namespacedName.Namespace,
 		}, confMap,
 	)
@@ -398,9 +413,12 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 			// build the aerospike config file based on the current spec
 			var configMapData map[string]string
 
-			configMapData, err = r.createConfigMapData(rack)
+			configMapData, err = r.createConfigMapData(ctx, rack)
 			if err != nil {
-				return fmt.Errorf("failed to build dotConfig from map: %v", err)
+				return fmt.Errorf(
+					"building config map data for rack %d in cluster %s: %w",
+					rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+				)
 			}
 
 			ls := utils.LabelsForAerospikeCluster(r.aeroCluster.Name)
@@ -424,10 +442,10 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 			}
 
 			if err = r.Create(
-				context.TODO(), confMap, common.CreateOption,
+				ctx, confMap, common.CreateOption,
 			); err != nil {
 				return fmt.Errorf(
-					"failed to create new confMap for StatefulSet: %v", err,
+					"creating configmap %s: %w", namespacedName, err,
 				)
 			}
 
@@ -448,9 +466,12 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	)
 
 	// Update existing configmap as it might not be current.
-	configMapData, err := r.createConfigMapData(rack)
+	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
-		return fmt.Errorf("failed to build config map data: %v", err)
+		return fmt.Errorf(
+			"building config map data for rack %d in cluster %s: %w",
+			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	// Replace config map data if differs since we are supposed to create a new config map.
@@ -466,28 +487,31 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	confMap.Data = configMapData
 
 	if err := r.Update(
-		context.TODO(), confMap, common.UpdateOption,
+		ctx, confMap, common.UpdateOption,
 	); err != nil {
-		return fmt.Errorf("failed to update ConfigMap for StatefulSet: %v", err)
+		return fmt.Errorf("updating configmap %s: %w", utils.NamespacedName(confMap.Namespace, confMap.Name), err)
 	}
 
 	return nil
 }
 
 func (r *SingleClusterReconciler) updateSTSConfigMap(
-	namespacedName types.NamespacedName, rack *asdbv1.Rack,
+	ctx context.Context, namespacedName types.NamespacedName, rack *asdbv1.Rack,
 ) error {
 	r.Log.Info("Updating ConfigMap", "ConfigMap", namespacedName)
 
 	confMap := &corev1.ConfigMap{}
-	if err := r.Get(context.TODO(), namespacedName, confMap); err != nil {
+	if err := r.Get(ctx, namespacedName, confMap); err != nil {
 		return err
 	}
 
 	// build the aerospike config file based on the current spec
-	configMapData, err := r.createConfigMapData(rack)
+	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
-		return fmt.Errorf("failed to build dotConfig from map: %v", err)
+		return fmt.Errorf(
+			"building config map data for rack %d in cluster %s: %w",
+			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+		)
 	}
 
 	// Overwrite only spec based keys. Do not touch other keys like pod metadata.
@@ -496,9 +520,9 @@ func (r *SingleClusterReconciler) updateSTSConfigMap(
 	}
 
 	if err := r.Update(
-		context.TODO(), confMap, common.UpdateOption,
+		ctx, confMap, common.UpdateOption,
 	); err != nil {
-		return fmt.Errorf("failed to update confMap for StatefulSet: %v", err)
+		return fmt.Errorf("updating configmap %s: %w", namespacedName, err)
 	}
 
 	return nil
@@ -623,7 +647,7 @@ func sortContainerVolumeAttachments(containers []corev1.Container) {
 
 // updateSTS updates the statefulset to match the spec. It is idempotent.
 func (r *SingleClusterReconciler) updateSTS(
-	statefulSet *appsv1.StatefulSet, rackState *RackState,
+	ctx context.Context, statefulSet *appsv1.StatefulSet, rackState *RackState,
 ) error {
 	// Update settings from pod spec.
 	r.updateSTSFromPodSpec(statefulSet, rackState)
@@ -646,7 +670,7 @@ func (r *SingleClusterReconciler) updateSTS(
 	r.updateSTSStorage(statefulSet, rackState)
 
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		found, err := r.getSTS(rackState)
+		found, err := r.getSTS(ctx, rackState)
 		if err != nil {
 			return err
 		}
@@ -654,11 +678,11 @@ func (r *SingleClusterReconciler) updateSTS(
 		// Save the updated stateful set.
 		found.Spec = statefulSet.Spec
 
-		return r.Update(context.TODO(), found, common.UpdateOption)
+		return r.Update(ctx, found, common.UpdateOption)
 	}); err != nil {
 		return fmt.Errorf(
-			"failed to update StatefulSet %s: %v",
-			statefulSet.Name,
+			"updating statefulset %s: %w",
+			utils.GetNamespacedNameString(statefulSet),
 			err,
 		)
 	}
@@ -1078,7 +1102,8 @@ func updateSTSContainers(
 	return finalContainers
 }
 
-func (r *SingleClusterReconciler) waitForAllSTSToBeReady(ignorablePodNames sets.Set[string]) error {
+func (r *SingleClusterReconciler) waitForAllSTSToBeReady(
+	ctx context.Context, ignorablePodNames sets.Set[string]) error {
 	r.Log.Info("Waiting for all cluster STSs to be ready")
 
 	allRackIdentifiers := sets.NewString()
@@ -1098,7 +1123,7 @@ func (r *SingleClusterReconciler) waitForAllSTSToBeReady(ignorablePodNames sets.
 		st := &appsv1.StatefulSet{}
 		stsName := utils.GetNamespacedNameForSTSOrConfigMap(r.aeroCluster, rackIdentifier)
 
-		if err := r.Get(context.TODO(), stsName, st); err != nil {
+		if err := r.Get(ctx, stsName, st); err != nil {
 			if !errors.IsNotFound(err) {
 				return err
 			}
@@ -1107,7 +1132,7 @@ func (r *SingleClusterReconciler) waitForAllSTSToBeReady(ignorablePodNames sets.
 			continue
 		}
 
-		if err := r.waitForSTSToBeReady(st, ignorablePodNames); err != nil {
+		if err := r.waitForSTSToBeReady(ctx, st, ignorablePodNames); err != nil {
 			return err
 		}
 	}
@@ -1115,7 +1140,7 @@ func (r *SingleClusterReconciler) waitForAllSTSToBeReady(ignorablePodNames sets.
 	return nil
 }
 
-func (r *SingleClusterReconciler) getClusterSTSList() (
+func (r *SingleClusterReconciler) getClusterSTSList(ctx context.Context) (
 	*appsv1.StatefulSetList, error,
 ) {
 	// List the pods for this aeroCluster's statefulset
@@ -1126,7 +1151,7 @@ func (r *SingleClusterReconciler) getClusterSTSList() (
 	}
 
 	if err := r.List(
-		context.TODO(), statefulSetList, listOps,
+		ctx, statefulSetList, listOps,
 	); err != nil {
 		return nil, err
 	}
@@ -1179,7 +1204,8 @@ func (r *SingleClusterReconciler) updateReadinessProbe(statefulSet *appsv1.State
 	}
 }
 
-func (r *SingleClusterReconciler) updateAerospikeInitContainerImage(statefulSet *appsv1.StatefulSet) error {
+func (r *SingleClusterReconciler) updateAerospikeInitContainerImage(
+	ctx context.Context, statefulSet *appsv1.StatefulSet) error {
 	for idx := range statefulSet.Spec.Template.Spec.InitContainers {
 		container := &statefulSet.Spec.Template.Spec.InitContainers[idx]
 		if container.Name != asdbv1.AerospikeInitContainerName {
@@ -1203,10 +1229,10 @@ func (r *SingleClusterReconciler) updateAerospikeInitContainerImage(statefulSet 
 
 			statefulSet.Spec.Template.Spec.InitContainers[idx].Image = desiredImage
 
-			if err := r.Update(context.TODO(), statefulSet, common.UpdateOption); err != nil {
+			if err := r.Update(ctx, statefulSet, common.UpdateOption); err != nil {
 				return fmt.Errorf(
-					"failed to update StatefulSet %s: %v",
-					statefulSet.Name,
+					"updating statefulset %s: %w",
+					utils.GetNamespacedNameString(statefulSet),
 					err,
 				)
 			}

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -287,7 +288,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 		// Wait for pod to get ready
 		for i := 0; i < podStatusMaxRetry; i++ {
 			r.Log.V(1).Info(
-				"Check statefulSet pod running and ready", "pod", podName,
+				"Check statefulSet pod running and ready", "pod", klog.KRef(st.Namespace, podName),
 			)
 
 			if err := r.Get(
@@ -309,7 +310,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 			if utils.IsPodRunningAndReady(pod) {
 				isReady = true
 
-				r.Log.Info("Pod is running and ready", "pod", podName)
+				r.Log.Info("Pod is running and ready", "pod", klog.KObj(pod))
 
 				break
 			}
@@ -668,7 +669,7 @@ func (r *SingleClusterReconciler) updateSTS(
 	}
 
 	r.Log.V(1).Info(
-		"Saved StatefulSet", "statefulSet", *statefulSet,
+		"Saved StatefulSet", "statefulSet", klog.KObj(statefulSet),
 	)
 
 	return nil
@@ -1218,7 +1219,7 @@ func (r *SingleClusterReconciler) updateAerospikeInitContainerImage(
 			}
 
 			r.Log.V(1).Info(
-				"Saved StatefulSet", "statefulSet", *statefulSet,
+				"Saved StatefulSet", "statefulSet", klog.KObj(statefulSet),
 			)
 		}
 

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -200,7 +200,7 @@ func (r *SingleClusterReconciler) createSTS(
 	}
 
 	if err := r.Create(ctx, st, common.CreateOption); err != nil {
-		return nil, fmt.Errorf("could not create StatefulSet %s: %w", utils.GetNamespacedNameString(st), err)
+		return nil, fmt.Errorf("create StatefulSet %s: %w", utils.GetNamespacedNameString(st), err)
 	}
 
 	r.Log.Info(
@@ -452,7 +452,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	// Update existing configmap as it might not be current.
 	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
-		return fmt.Errorf("unable to build config map data: %w", err)
+		return fmt.Errorf("build ConfigMap data: %w", err)
 	}
 
 	// Replace config map data if differs since we are supposed to create a new config map.
@@ -470,7 +470,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	if err := r.Update(
 		ctx, confMap, common.UpdateOption,
 	); err != nil {
-		return fmt.Errorf("could not update ConfigMap %s: %w", utils.NamespacedName(confMap.Namespace, confMap.Name), err)
+		return fmt.Errorf("update ConfigMap %s: %w", utils.NamespacedName(confMap.Namespace, confMap.Name), err)
 	}
 
 	return nil
@@ -503,7 +503,7 @@ func (r *SingleClusterReconciler) updateSTSConfigMap(
 	if err := r.Update(
 		ctx, confMap, common.UpdateOption,
 	); err != nil {
-		return fmt.Errorf("could not update ConfigMap %s: %w", namespacedName, err)
+		return fmt.Errorf("update ConfigMap %s: %w", namespacedName, err)
 	}
 
 	return nil

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -301,7 +301,9 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 			}
 
 			if err := utils.CheckPodFailed(pod); err != nil {
-				return fmt.Errorf("checking statefulset pod %s health: %w", utils.NamespacedName(st.Namespace, podName), err)
+				return fmt.Errorf(
+					"statefulset pod %s failed: %w", utils.NamespacedName(st.Namespace, podName), err,
+				)
 			}
 
 			if utils.IsPodRunningAndReady(pod) {
@@ -317,8 +319,8 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 
 		if !isReady {
 			statusErr := fmt.Errorf(
-				"statefulset pod %s is not ready, status conditions: %s",
-				utils.NamespacedName(st.Namespace, podName), formatPodConditionStatuses(pod.Status.Conditions),
+				"statefulSet pod is not ready. Status: %v",
+				pod.Status.Conditions,
 			)
 
 			return statusErr
@@ -358,28 +360,12 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 	}
 
 	if !updated {
-		return fmt.Errorf("statefulset %s status not updated to desired replicas", utils.GetNamespacedNameString(st))
+		return fmt.Errorf("statefulset status is not updated")
 	}
 
 	r.Log.Info("StatefulSet is ready")
 
 	return nil
-}
-
-func formatPodConditionStatuses(conditions []corev1.PodCondition) string {
-	if len(conditions) == 0 {
-		return "none"
-	}
-
-	parts := make([]string, 0, len(conditions))
-	for _, condition := range conditions {
-		parts = append(parts, fmt.Sprintf(
-			"%s=%s(reason=%s)",
-			condition.Type, condition.Status, condition.Reason,
-		))
-	}
-
-	return strings.Join(parts, ", ")
 }
 
 func (r *SingleClusterReconciler) getSTS(ctx context.Context, rackState *RackState) (*appsv1.StatefulSet, error) {
@@ -415,10 +401,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 
 			configMapData, err = r.createConfigMapData(ctx, rack)
 			if err != nil {
-				return fmt.Errorf(
-					"building config map data for rack %d in cluster %s: %w",
-					rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
-				)
+				return fmt.Errorf("failed to build dotConfig from map: %w", err)
 			}
 
 			ls := utils.LabelsForAerospikeCluster(r.aeroCluster.Name)
@@ -468,10 +451,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	// Update existing configmap as it might not be current.
 	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
-		return fmt.Errorf(
-			"building config map data for rack %d in cluster %s: %w",
-			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
-		)
+		return fmt.Errorf("failed to build dotConfig from map: %w", err)
 	}
 
 	// Replace config map data if differs since we are supposed to create a new config map.

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -451,7 +451,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	// Update existing configmap as it might not be current.
 	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
-		return fmt.Errorf("failed to build dotConfig from map: %w", err)
+		return fmt.Errorf("unable to build config map data: %w", err)
 	}
 
 	// Replace config map data if differs since we are supposed to create a new config map.
@@ -489,7 +489,7 @@ func (r *SingleClusterReconciler) updateSTSConfigMap(
 	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
 		return fmt.Errorf(
-			"could not build ConfigMap data for rack %d in cluster %s: %w",
+			"unable to build dotConfig from map for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -199,7 +199,7 @@ func (r *SingleClusterReconciler) createSTS(
 	}
 
 	if err := r.Create(ctx, st, common.CreateOption); err != nil {
-		return nil, fmt.Errorf("creating statefulset %s: %w", utils.GetNamespacedNameString(st), err)
+		return nil, fmt.Errorf("could not create StatefulSet %s: %w", utils.GetNamespacedNameString(st), err)
 	}
 
 	r.Log.Info(
@@ -209,7 +209,7 @@ func (r *SingleClusterReconciler) createSTS(
 
 	if err := r.waitForSTSToBeReady(ctx, st, nil); err != nil {
 		return st, fmt.Errorf(
-			"waiting for statefulset %s to be ready: %w", utils.GetNamespacedNameString(st), err,
+			"could not wait until StatefulSet %s is ready: %w", utils.GetNamespacedNameString(st), err,
 		)
 	}
 
@@ -296,7 +296,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 				pod,
 			); err != nil {
 				return fmt.Errorf(
-					"getting statefulset pod %s: %w", utils.NamespacedName(st.Namespace, podName), err,
+					"could not get StatefulSet pod %s: %w", utils.NamespacedName(st.Namespace, podName), err,
 				)
 			}
 
@@ -428,7 +428,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 				ctx, confMap, common.CreateOption,
 			); err != nil {
 				return fmt.Errorf(
-					"creating configmap %s: %w", namespacedName, err,
+					"could not create ConfigMap %s: %w", namespacedName, err,
 				)
 			}
 
@@ -469,7 +469,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	if err := r.Update(
 		ctx, confMap, common.UpdateOption,
 	); err != nil {
-		return fmt.Errorf("updating configmap %s: %w", utils.NamespacedName(confMap.Namespace, confMap.Name), err)
+		return fmt.Errorf("could not update ConfigMap %s: %w", utils.NamespacedName(confMap.Namespace, confMap.Name), err)
 	}
 
 	return nil
@@ -489,7 +489,7 @@ func (r *SingleClusterReconciler) updateSTSConfigMap(
 	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
 		return fmt.Errorf(
-			"building config map data for rack %d in cluster %s: %w",
+			"could not build ConfigMap data for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -502,7 +502,7 @@ func (r *SingleClusterReconciler) updateSTSConfigMap(
 	if err := r.Update(
 		ctx, confMap, common.UpdateOption,
 	); err != nil {
-		return fmt.Errorf("updating configmap %s: %w", namespacedName, err)
+		return fmt.Errorf("could not update ConfigMap %s: %w", namespacedName, err)
 	}
 
 	return nil
@@ -661,7 +661,7 @@ func (r *SingleClusterReconciler) updateSTS(
 		return r.Update(ctx, found, common.UpdateOption)
 	}); err != nil {
 		return fmt.Errorf(
-			"updating statefulset %s: %w",
+			"could not update StatefulSet %s: %w",
 			utils.GetNamespacedNameString(statefulSet),
 			err,
 		)
@@ -1211,7 +1211,7 @@ func (r *SingleClusterReconciler) updateAerospikeInitContainerImage(
 
 			if err := r.Update(ctx, statefulSet, common.UpdateOption); err != nil {
 				return fmt.Errorf(
-					"updating statefulset %s: %w",
+					"could not update StatefulSet %s: %w",
 					utils.GetNamespacedNameString(statefulSet),
 					err,
 				)

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -99,7 +98,7 @@ func (r *SingleClusterReconciler) createSTS(
 ) (*appsv1.StatefulSet, error) {
 	replicas := rackState.Size
 
-	r.Log.Info("Create statefulset for AerospikeCluster", "size", replicas)
+	r.Log.Info("Create StatefulSet for AerospikeCluster", "size", replicas)
 
 	ports := getSTSContainerPort(
 		r.aeroCluster.Spec.PodSpec.MultiPodPerHost,
@@ -204,7 +203,7 @@ func (r *SingleClusterReconciler) createSTS(
 	}
 
 	r.Log.Info(
-		"Created new StatefulSet", "statefulSet", klog.KObj(st),
+		"Created new StatefulSet", "statefulSet", utils.GetNamespacedName(st),
 	)
 
 	if err := r.waitForSTSToBeReady(ctx, st, nil); err != nil {
@@ -240,7 +239,7 @@ func (r *SingleClusterReconciler) getReadinessProbe() *corev1.Probe {
 }
 
 func (r *SingleClusterReconciler) deleteSTS(ctx context.Context, st *appsv1.StatefulSet) error {
-	r.Log.Info("Delete statefulset", "namespace", st.Namespace, "name", st.Name)
+	r.Log.Info("Delete StatefulSet", "namespace", st.Namespace, "name", st.Name)
 	// No need to do cleanup pods after deleting sts
 	// It is only deleted while its creation is failed
 	// While doing rackRemove, we call scaleDown to 0 so that will do cleanup
@@ -256,7 +255,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 	)
 
 	r.Log.Info(
-		"Waiting for statefulset to be ready", "waitTimePerPod",
+		"Waiting for StatefulSet to be ready", "waitTimePerPod",
 		podStatusRetryInterval*time.Duration(podStatusMaxRetry),
 	)
 
@@ -287,7 +286,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 		// Wait for pod to get ready
 		for i := 0; i < podStatusMaxRetry; i++ {
 			r.Log.V(1).Info(
-				"Check statefulSet pod running and ready", "pod", klog.KRef(st.Namespace, podName),
+				"Check StatefulSet Pod running and ready", "pod", utils.NewNamespacedName(st.Namespace, podName),
 			)
 
 			if err := r.Get(
@@ -309,7 +308,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 			if utils.IsPodRunningAndReady(pod) {
 				isReady = true
 
-				r.Log.Info("Pod is running and ready", "pod", klog.KObj(pod))
+				r.Log.Info("Pod is running and ready", "pod", utils.GetNamespacedName(pod))
 
 				break
 			}
@@ -319,7 +318,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 
 		if !isReady {
 			statusErr := fmt.Errorf(
-				"statefulSet pod is not ready. Status: %v",
+				"StatefulSet Pod is not ready. Status: %v",
 				pod.Status.Conditions,
 			)
 
@@ -339,7 +338,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 	for i := 0; i < stsStatusMaxRetry; i++ {
 		time.Sleep(stsStatusRetryInterval)
 
-		r.Log.V(1).Info("Check statefulSet status is updated or not")
+		r.Log.V(1).Info("Check StatefulSet status is updated or not")
 
 		if err := r.Get(
 			ctx,
@@ -360,7 +359,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 	}
 
 	if !updated {
-		return fmt.Errorf("statefulset status is not updated")
+		return fmt.Errorf("StatefulSet status is not updated")
 	}
 
 	r.Log.Info("StatefulSet is ready")
@@ -385,7 +384,7 @@ func (r *SingleClusterReconciler) getSTS(ctx context.Context, rackState *RackSta
 func (r *SingleClusterReconciler) createSTSConfigMap(
 	ctx context.Context, namespacedName types.NamespacedName, rack *asdbv1.Rack,
 ) error {
-	r.Log.Info("Creating a new ConfigMap for statefulSet")
+	r.Log.Info("Creating a new ConfigMap for StatefulSet")
 
 	confMap := &corev1.ConfigMap{}
 
@@ -433,7 +432,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 			}
 
 			r.Log.Info(
-				"Created new ConfigMap", "configMap", klog.KObj(confMap),
+				"Created new ConfigMap", "configMap", utils.GetNamespacedName(confMap),
 			)
 
 			return nil
@@ -443,7 +442,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	}
 
 	r.Log.Info(
-		"Configmap already exists for statefulSet - using existing configmap",
+		"ConfigMap already exists for StatefulSet - using existing ConfigMap",
 		"name", utils.NamespacedName(confMap.Namespace, confMap.Name),
 	)
 
@@ -459,7 +458,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 	}
 
 	r.Log.Info(
-		"Updating existed configmap",
+		"Updating existed ConfigMap",
 		"name", utils.NamespacedName(confMap.Namespace, confMap.Name),
 	)
 
@@ -477,7 +476,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 func (r *SingleClusterReconciler) updateSTSConfigMap(
 	ctx context.Context, namespacedName types.NamespacedName, rack *asdbv1.Rack,
 ) error {
-	r.Log.Info("Updating ConfigMap", "configMap", klog.KRef(namespacedName.Namespace, namespacedName.Name))
+	r.Log.Info("Updating ConfigMap", "configMap", utils.NewNamespacedName(namespacedName.Namespace, namespacedName.Name))
 
 	confMap := &corev1.ConfigMap{}
 	if err := r.Get(ctx, namespacedName, confMap); err != nil {
@@ -488,8 +487,8 @@ func (r *SingleClusterReconciler) updateSTSConfigMap(
 	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
 		return fmt.Errorf(
-			"build dotConfig from map for rack %d in cluster %s: %w",
-			rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
+			"build dotConfig from map for rack %d: %w",
+			rack.ID, err,
 		)
 	}
 
@@ -568,7 +567,7 @@ func (r *SingleClusterReconciler) allContainersAreOnDesiredImages(
 
 			if logChanges {
 				r.Log.Info(
-					"Found container for upgrading/downgrading in pod", "pod",
+					"Found container for upgrading/downgrading in Pod", "pod",
 					podName, "container", container.Name, "currentImage",
 					container.Image, "desiredImage", desiredImage,
 				)
@@ -667,7 +666,7 @@ func (r *SingleClusterReconciler) updateSTS(
 	}
 
 	r.Log.V(1).Info(
-		"Saved StatefulSet", "statefulSet", klog.KObj(statefulSet),
+		"Saved StatefulSet", "statefulSet", utils.GetNamespacedName(statefulSet),
 	)
 
 	return nil
@@ -793,7 +792,7 @@ func (r *SingleClusterReconciler) updateSTSPVStorage(
 			)
 
 			r.Log.V(1).Info("Added PVC for volume",
-				"persistentVolumeClaim", klog.KObj(&pvc),
+				"persistentVolumeClaim", utils.GetNamespacedName(&pvc),
 				"volume", volume.Name,
 			)
 		}
@@ -822,7 +821,7 @@ func (r *SingleClusterReconciler) updateSTSNonPVStorage(
 		initContainerAttachments, containerAttachments := getFinalVolumeAttachmentsForVolume(volume, workDir)
 
 		r.Log.V(1).Info(
-			"Added volume mount in statefulSet pod containers for volume",
+			"Added volume mount in StatefulSet Pod containers for volume",
 			"volume", volume,
 		)
 
@@ -865,7 +864,7 @@ func (r *SingleClusterReconciler) updateSTSSchedulingPolicy(
 
 		antiAffinityLabels := utils.LabelsForPodAntiAffinity(r.aeroCluster.Name)
 
-		r.Log.Info("Adding pod affinity rules for statefulSet pod")
+		r.Log.Info("Adding pod affinity rules for StatefulSet Pod")
 
 		antiAffinity := &corev1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -1158,7 +1157,7 @@ func (r *SingleClusterReconciler) updateContainerImages(statefulset *appsv1.Stat
 
 			if !utils.IsImageEqual(container.Image, desiredImage) {
 				r.Log.Info(
-					"Updating image in statefulset spec", "container",
+					"Updating image in StatefulSet spec", "container",
 					container.Name, "desiredImage", desiredImage,
 					"currentImage", container.Image,
 				)
@@ -1203,7 +1202,7 @@ func (r *SingleClusterReconciler) updateAerospikeInitContainerImage(
 
 		if !utils.IsImageEqual(container.Image, desiredImage) {
 			r.Log.Info(
-				"Updating image in statefulset spec", "container",
+				"Updating image in StatefulSet spec", "container",
 				container.Name, "desiredImage", desiredImage,
 				"currentImage",
 				container.Image,
@@ -1220,7 +1219,7 @@ func (r *SingleClusterReconciler) updateAerospikeInitContainerImage(
 			}
 
 			r.Log.V(1).Info(
-				"Saved StatefulSet", "statefulSet", klog.KObj(statefulSet),
+				"Saved StatefulSet", "statefulSet", utils.GetNamespacedName(statefulSet),
 			)
 		}
 

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -318,9 +318,8 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 
 		if !isReady {
 			statusErr := fmt.Errorf(
-				"StatefulSet Pod is not ready. Status: %v",
-				pod.Status.Conditions,
-			)
+				"status for Pod %s: resource not ready, conditions=%v",
+				utils.GetNamespacedNameString(pod), pod.Status.Conditions)
 
 			return statusErr
 		}
@@ -359,7 +358,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 	}
 
 	if !updated {
-		return fmt.Errorf("StatefulSet status is not updated")
+		return fmt.Errorf("status for StatefulSet is not updated")
 	}
 
 	r.Log.Info("StatefulSet is ready")

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -204,8 +204,7 @@ func (r *SingleClusterReconciler) createSTS(
 	}
 
 	r.Log.Info(
-		"Created new StatefulSet", "StatefulSet.Namespace", st.Namespace,
-		"StatefulSet.Name", st.Name,
+		"Created new StatefulSet", "statefulSet", klog.KObj(st),
 	)
 
 	if err := r.waitForSTSToBeReady(ctx, st, nil); err != nil {
@@ -257,7 +256,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 	)
 
 	r.Log.Info(
-		"Waiting for statefulset to be ready", "WaitTimePerPod",
+		"Waiting for statefulset to be ready", "waitTimePerPod",
 		podStatusRetryInterval*time.Duration(podStatusMaxRetry),
 	)
 
@@ -303,7 +302,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 
 			if err := utils.CheckPodFailed(pod); err != nil {
 				return fmt.Errorf(
-					"statefulset pod %s failed: %w", utils.NamespacedName(st.Namespace, podName), err,
+					"check StatefulSet pod %s: %w", utils.NamespacedName(st.Namespace, podName), err,
 				)
 			}
 
@@ -434,8 +433,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 			}
 
 			r.Log.Info(
-				"Created new ConfigMap", "ConfigMap.Namespace",
-				confMap.Namespace, "ConfigMap.Name", confMap.Name,
+				"Created new ConfigMap", "configMap", klog.KObj(confMap),
 			)
 
 			return nil
@@ -479,7 +477,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 func (r *SingleClusterReconciler) updateSTSConfigMap(
 	ctx context.Context, namespacedName types.NamespacedName, rack *asdbv1.Rack,
 ) error {
-	r.Log.Info("Updating ConfigMap", "ConfigMap", namespacedName)
+	r.Log.Info("Updating ConfigMap", "configMap", klog.KRef(namespacedName.Namespace, namespacedName.Name))
 
 	confMap := &corev1.ConfigMap{}
 	if err := r.Get(ctx, namespacedName, confMap); err != nil {
@@ -491,7 +489,7 @@ func (r *SingleClusterReconciler) updateSTSConfigMap(
 	if err != nil {
 		return fmt.Errorf(
 			"build dotConfig from map for rack %d in cluster %s: %w",
-			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
+			rack.ID, utils.GetNamespacedNameString(r.aeroCluster), err,
 		)
 	}
 
@@ -794,7 +792,10 @@ func (r *SingleClusterReconciler) updateSTSPVStorage(
 				st.Spec.VolumeClaimTemplates, pvc,
 			)
 
-			r.Log.V(1).Info("Added PVC for volume", "volume", volume)
+			r.Log.V(1).Info("Added PVC for volume",
+				"persistentVolumeClaim", klog.KObj(&pvc),
+				"volume", volume.Name,
+			)
 		}
 	}
 }

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -210,7 +210,7 @@ func (r *SingleClusterReconciler) createSTS(
 
 	if err := r.waitForSTSToBeReady(ctx, st, nil); err != nil {
 		return st, fmt.Errorf(
-			"could not wait until StatefulSet %s is ready: %w", utils.GetNamespacedNameString(st), err,
+			"wait for StatefulSet %s to be ready: %w", utils.GetNamespacedNameString(st), err,
 		)
 	}
 
@@ -297,7 +297,7 @@ func (r *SingleClusterReconciler) waitForSTSToBeReady(
 				pod,
 			); err != nil {
 				return fmt.Errorf(
-					"could not get StatefulSet pod %s: %w", utils.NamespacedName(st.Namespace, podName), err,
+					"get StatefulSet pod %s: %w", utils.NamespacedName(st.Namespace, podName), err,
 				)
 			}
 
@@ -402,7 +402,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 
 			configMapData, err = r.createConfigMapData(ctx, rack)
 			if err != nil {
-				return fmt.Errorf("failed to build dotConfig from map: %w", err)
+				return fmt.Errorf("build dotConfig from map: %w", err)
 			}
 
 			ls := utils.LabelsForAerospikeCluster(r.aeroCluster.Name)
@@ -429,7 +429,7 @@ func (r *SingleClusterReconciler) createSTSConfigMap(
 				ctx, confMap, common.CreateOption,
 			); err != nil {
 				return fmt.Errorf(
-					"could not create ConfigMap %s: %w", namespacedName, err,
+					"create ConfigMap %s: %w", namespacedName, err,
 				)
 			}
 
@@ -490,7 +490,7 @@ func (r *SingleClusterReconciler) updateSTSConfigMap(
 	configMapData, err := r.createConfigMapData(ctx, rack)
 	if err != nil {
 		return fmt.Errorf(
-			"unable to build dotConfig from map for rack %d in cluster %s: %w",
+			"build dotConfig from map for rack %d in cluster %s: %w",
 			rack.ID, utils.ClusterNamespacedName(r.aeroCluster), err,
 		)
 	}
@@ -662,7 +662,7 @@ func (r *SingleClusterReconciler) updateSTS(
 		return r.Update(ctx, found, common.UpdateOption)
 	}); err != nil {
 		return fmt.Errorf(
-			"could not update StatefulSet %s: %w",
+			"update StatefulSet %s: %w",
 			utils.GetNamespacedNameString(statefulSet),
 			err,
 		)
@@ -1212,7 +1212,7 @@ func (r *SingleClusterReconciler) updateAerospikeInitContainerImage(
 
 			if err := r.Update(ctx, statefulSet, common.UpdateOption); err != nil {
 				return fmt.Errorf(
-					"could not update StatefulSet %s: %w",
+					"update StatefulSet %s: %w",
 					utils.GetNamespacedNameString(statefulSet),
 					err,
 				)

--- a/internal/controller/cluster/strong_consistency.go
+++ b/internal/controller/cluster/strong_consistency.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"strconv"
 
 	gosets "github.com/deckarep/golang-set/v2"
@@ -12,7 +13,7 @@ import (
 )
 
 func (r *SingleClusterReconciler) getAndSetRoster(
-	policy *as.ClientPolicy, rosterNodeBlockList []string,
+	ctx context.Context, policy *as.ClientPolicy, rosterNodeBlockList []string,
 	ignorablePodNames sets.Set[string],
 ) error {
 	rackStateList := getConfiguredRackStateList(r.aeroCluster)
@@ -23,12 +24,12 @@ func (r *SingleClusterReconciler) getAndSetRoster(
 		blockedRackIDs.Add(strconv.Itoa(blockedRacks[idx].ID))
 	}
 
-	allHostConns, err := r.newAllHostConnWithOption(ignorablePodNames)
+	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return err
 	}
 
-	ignorableNamespaces, err := r.getIgnorableNamespaces(allHostConns)
+	ignorableNamespaces, err := r.getIgnorableNamespaces(ctx, allHostConns)
 	if err != nil {
 		return err
 	}
@@ -37,14 +38,15 @@ func (r *SingleClusterReconciler) getAndSetRoster(
 		ignorableNamespaces, blockedRackIDs)
 }
 
-func (r *SingleClusterReconciler) validateSCClusterState(policy *as.ClientPolicy, ignorablePodNames sets.Set[string],
+func (r *SingleClusterReconciler) validateSCClusterState(
+	ctx context.Context, policy *as.ClientPolicy, ignorablePodNames sets.Set[string],
 ) error {
-	allHostConns, err := r.newAllHostConnWithOption(ignorablePodNames)
+	allHostConns, err := r.newAllHostConnWithOption(ctx, ignorablePodNames)
 	if err != nil {
 		return err
 	}
 
-	ignorableNamespaces, err := r.getIgnorableNamespaces(allHostConns)
+	ignorableNamespaces, err := r.getIgnorableNamespaces(ctx, allHostConns)
 	if err != nil {
 		return err
 	}
@@ -77,9 +79,9 @@ func (r *SingleClusterReconciler) addedSCNamespaces(nodesNamespaces map[string][
 	return newAddedSCNamespaces.ToSlice()
 }
 
-func (r *SingleClusterReconciler) getIgnorableNamespaces(allHostConns []*deployment.HostConn) (
+func (r *SingleClusterReconciler) getIgnorableNamespaces(ctx context.Context, allHostConns []*deployment.HostConn) (
 	gosets.Set[string], error) {
-	nodesNamespaces, err := deployment.GetClusterNamespaces(r.Log, r.getClientPolicy(), allHostConns)
+	nodesNamespaces, err := deployment.GetClusterNamespaces(r.Log, r.getClientPolicy(ctx), allHostConns)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/common/result.go
+++ b/internal/controller/common/result.go
@@ -25,7 +25,7 @@ func ReconcileRequeueAfter(secs int) ReconcileResult {
 
 	return ReconcileResult{
 		Result: reconcile.Result{
-			RequeueAfter: t,
+			Requeue: true, RequeueAfter: t,
 		},
 	}
 }

--- a/internal/controller/common/result.go
+++ b/internal/controller/common/result.go
@@ -25,7 +25,7 @@ func ReconcileRequeueAfter(secs int) ReconcileResult {
 
 	return ReconcileResult{
 		Result: reconcile.Result{
-			Requeue: true, RequeueAfter: t,
+			RequeueAfter: t,
 		},
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,11 +42,27 @@ func NamespacedName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
+// NamespacedNames returns namespace/name identities for all names in namespace.
+func NamespacedNames(namespace string, names []string) []string {
+	namespacedNames := make([]string, 0, len(names))
+	for _, name := range names {
+		namespacedNames = append(namespacedNames, NamespacedName(namespace, name))
+	}
+
+	return namespacedNames
+}
+
 func GetNamespacedName(obj meta.Object) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}
+}
+
+// GetNamespacedNameString returns the namespace/name identity of obj as a string,
+// for use in free-form error and event text.
+func GetNamespacedNameString(obj meta.Object) string {
+	return NamespacedName(obj.GetNamespace(), obj.GetName())
 }
 
 func GetNamespacedNameForSTSOrConfigMap(

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -37,6 +37,19 @@ func NamespacedName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
+// ClusterNamespacedName return namespaced name
+func ClusterNamespacedName(aeroCluster *asdbv1.AerospikeCluster) string {
+	return NamespacedName(aeroCluster.Namespace, aeroCluster.Name)
+}
+
+// NewNamespacedName returns a types.NamespacedName for use in structured log fields.
+func NewNamespacedName(namespace, name string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+}
+
 // NamespacedNames returns namespace/name identities for all names in namespace.
 func NamespacedNames(namespace string, names []string) []string {
 	namespacedNames := make([]string, 0, len(names))
@@ -48,10 +61,7 @@ func NamespacedNames(namespace string, names []string) []string {
 }
 
 func GetNamespacedName(obj meta.Object) types.NamespacedName {
-	return types.NamespacedName{
-		Namespace: obj.GetNamespace(),
-		Name:      obj.GetName(),
-	}
+	return NewNamespacedName(obj.GetNamespace(), obj.GetName())
 }
 
 // GetNamespacedNameString returns the namespace/name identity of obj as a string,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -32,11 +32,6 @@ const (
 	ReasonRegistryUnavailable = "RegistryUnavailable"
 )
 
-// ClusterNamespacedName return namespaced name
-func ClusterNamespacedName(aeroCluster *asdbv1.AerospikeCluster) string {
-	return NamespacedName(aeroCluster.Namespace, aeroCluster.Name)
-}
-
 // NamespacedName return namespaced name
 func NamespacedName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)

--- a/test/cluster/test_client.go
+++ b/test/cluster/test_client.go
@@ -36,13 +36,13 @@ type FromSecretPasswordProvider struct {
 
 // Get returns the password for the username using userSpec.
 func (pp FromSecretPasswordProvider) Get(
-	_ string, userSpec *asdbv1.AerospikeUserSpec,
+	ctx context.Context, _ string, userSpec *asdbv1.AerospikeUserSpec,
 ) (string, error) {
 	secret := &v1.Secret{}
 	secretName := userSpec.SecretName
 	// Assuming secret is in same namespace
 	err := (*pp.k8sClient).Get(
-		context.TODO(),
+		ctx,
 		types.NamespacedName{Name: secretName, Namespace: pp.namespace}, secret,
 	)
 	if err != nil {
@@ -63,7 +63,7 @@ func (pp FromSecretPasswordProvider) Get(
 // This function is not used in the test code. This is just a dummy implementation.
 // Tests do not make client call till cluster is up and reconciled.
 // DefaultPassword only comes into play when the cluster is being created.
-func (pp FromSecretPasswordProvider) GetDefaultPassword(_ *asdbv1.AerospikeClusterSpec) string {
+func (pp FromSecretPasswordProvider) GetDefaultPassword(_ context.Context, _ *asdbv1.AerospikeClusterSpec) string {
 	return asdbv1.DefaultAdminPassword
 }
 
@@ -240,7 +240,7 @@ func getClientPolicy(
 	}
 
 	user, pass, err := aerospikecluster.AerospikeAdminCredentials(
-		&aeroCluster.Spec, statusToSpec,
+		context.TODO(), &aeroCluster.Spec, statusToSpec,
 		getPasswordProvider(aeroCluster, k8sClient),
 	)
 	if err != nil {


### PR DESCRIPTION
# Summary

Standardises logging, error handling, and Kubernetes event formatting across the `internal/controller/cluster` package, aligning AKO with patterns documented in the [Uniform logging, errors, and events approach document](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324). All changes are scoped to the cluster controller; no API or behaviour changes are included.

**Files changed:** `access_control.go`, `aero_info_calls.go`, `aerospikecluster_controller.go`, `client_policy.go`, `configmap.go`, `events.go` (new), `pod.go`, `poddistruptionbudget.go`, `pvc.go`, `rack.go`, `reconciler.go`, `service.go`, `statefulset.go`, `strong_consistency.go`

---

# Logging

### Structured object references via `klog.KObj` / `klog.KRef`

**Pattern:** Use `klog.KObj(obj)` / `klog.KRef(ns, name)` as log field values for Kubernetes objects, producing a nested `{"name","namespace"}` JSON shape queryable by log systems.

**Applied in:** All changed files. Representative examples:

```go
// Before
r.Log.V(1).Info("Pod warm restarted", "podName", podNamespacedName.Name)
r.Log.Info("PVC removed", "PVC", pvc.Name, "PVCCascadeDelete", cascadeDelete)

// After
r.Log.V(1).Info("Pod warm restarted", "pod", klog.KRef(podNamespacedName.Namespace, podNamespacedName.Name))
r.Log.Info("PVC removed", "persistentVolumeClaim", klog.KObj(&pvc), "pvcCascadeDelete", cascadeDelete)
```

**Approach doc:** [Section 1.3 — Structured log field names](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

### Reconcile entry logger: `lowerCamelCase` key + `klog.KRef`

**Pattern:** The reconcile-entry logger must use a `lowerCamelCase` Kind key and a `klog.KRef` value, not a raw `types.NamespacedName`.

**Applied in:** `aerospikecluster_controller.go`, `configmap.go`

```go
// Before
log := r.Log.WithValues("aerospikecluster", request.NamespacedName)

// After
log := r.Log.WithValues("aerospikeCluster", klog.KRef(request.Namespace, request.Name))
```

**Approach doc:** [Section 0.2 — Reconcile entry and exit logging](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324), [Section 1.3](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

### Log level demotion on requeue paths

**Pattern:** `log.Error` must not be used for transient / requeue conditions; use `log.V(1).Info` instead.

**Applied in:** `rack.go`, `aero_info_calls.go`

```go
// Before
r.Log.Error(err, "Statefulset setup failed...", "name", stsName)

// After
r.Log.V(1).Info("StatefulSet not ready, will requeue", "statefulSet", klog.KObj(found), "err", err)
```

**Approach doc:** [Section 1.2 — Log levels](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324), [Section 1.5 — log.Error usage](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

### `context.Context` propagated through helpers

**Pattern:** Pass `ctx` through function calls instead of `context.TODO()` so API calls respect cancellation.

**Applied in:** `reconciler.go`, `service.go`, `rack.go`, `pod.go`, `aero_info_calls.go`, `strong_consistency.go`

**Approach doc:** [Section 0.2](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

# Error Handling

### `%w` wrapping throughout

**Pattern:** Use `fmt.Errorf("…: %w", err)` instead of `%v` to preserve the error chain for `errors.Is` / `errors.As`.

**Applied in:** All changed files. Examples from `access_control.go`, `configmap.go`, `client_policy.go`, `pod.go`:

```go
// Before
return fmt.Errorf("failed to create role: %v", err)

// After
return fmt.Errorf("could not create role %s: %w", roleCreate.name, err)
```

**Approach doc:** [Section 2.1 — Wrapping with %w](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

### Object identity in errors

**Pattern:** Returned errors must include the failing scope (cluster `namespace/name`, rack id, pod id) using `utils.GetNamespacedNameString` / `utils.ClusterNamespacedName`.

**Applied in:** `reconciler.go`, `service.go`, `pod.go`, `configmap.go`

```go
// Before
return fmt.Errorf("failed to create headless service: %v", err)

// After
return fmt.Errorf("could not create headless Service for statefulset %s: %w",
    utils.ClusterNamespacedName(r.aeroCluster), err)
```

**Approach doc:** [Section 2.2 — Object identity in errors](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

### `stdout`/`stderr` context preserved in exec errors

**Pattern:** When `utils.Exec` fails, capture `stdout`/`stderr` and include them in the returned `fmt.Errorf` rather than logging a separate `V(1)` line.

**Applied in:** `pod.go`

```go
return fmt.Errorf(
    "pod %s: warm restart via /etc/aerospike/refresh-cmap-restart-asd.sh failed "+
        "after %s was missing: stdout=%q stderr=%q: %w",
    podName, initBinary, stdout, stderr, err)
```

**Approach doc:** [Section 2.5 — Single log.Error per failure](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324), [Section 1.8 — Large or sensitive values](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---
### Dropped repeatable prefixes in wrapped errors
Wrapped errors: Dropped repeated “failed to” (and similar) prefixes from fmt.Errorf chains so stacked errors stay short and scannable. Each layer now uses a plain action phrase + : %w (per Kubernetes logging guidance). User-facing log.Error lines still use “Failed to …” where appropriate.
[[Section 2.6]](https://aerospike.atlassian.net/wiki/spaces/KO/pages/edit-v2/5259788324#2.6-Error-wording%3A-avoid-repeatable-prefixes-in-wrapped-errors)

# Event Formatting

### Centralised event reason constants (`events.go`)

**Pattern:** All `Recorder.Eventf` call sites must use exported PascalCase constants for `Reason`; no raw string literals.

**Applied in:** New file `events.go` defines 40+ constants. All existing inline string reasons in `reconciler.go`, `rack.go`, `pod.go`, `aero_info_calls.go`, `access_control.go` are replaced.

```go
// Before
r.aeroCluster, corev1.EventTypeWarning, "DeleteFailed", "..."

// After
r.aeroCluster, corev1.EventTypeWarning, EventReasonDeleteFailed, "..."
```

**Approach doc:** [Section 3.2 — Event reasons (events.go)](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

### Distinct start/end event reasons

**Pattern:** Multi-step operations must use distinct reason pairs (verb / verb-ed) to allow `kubectl get events --field-selector` to distinguish start from finish.

**Applied in:** `rack.go`, `pod.go`

```go
EventReasonDynamicConfigUpdate   // started
EventReasonDynamicConfigUpdated  // finished

EventReasonRackScaleUp    // started
EventReasonRackScaledUp   // finished
```

**Approach doc:** [Section 3.2](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

### `involvedObject` always the reconciled CR; `GetNamespacedNameString` in messages

**Pattern:** Pass `r.aeroCluster` as the first arg to `Recorder.Eventf`. Use `utils.GetNamespacedNameString` for object ids in the message; no `%s/%s` hand-assembly.

**Applied in:** `reconciler.go`, `rack.go`, `pod.go`, `access_control.go`, `aero_info_calls.go`

```go
// Before
r.aeroCluster, corev1.EventTypeWarning, "DeleteFailed",
    "Unable to handle AerospikeCluster delete operations %s/%s",
    r.aeroCluster.Namespace, r.aeroCluster.Name

// After
r.aeroCluster, corev1.EventTypeWarning, EventReasonDeleteFailed,
    "Failed to delete AerospikeCluster %s",
    utils.GetNamespacedNameString(r.aeroCluster)
```

**Approach doc:** [Section 3.1 — Involved object](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324), [Section 3.3 — Event messages](https://aerospike.atlassian.net/wiki/pages/resumedraft.action?draftId=5259788324)

---

# Patterns Considered but Not Implemented

- **Sentinel errors (Section 2.4):** No suitable candidate identified in this PR. The requeue paths in `rack.go` and `aero_info_calls.go` were converted to `log.V(1).Info` but were not given named sentinel values — deferred to a follow-up that spans all four controllers.
- **`logcheck` linter (Section 7.3):** Not wired in this PR. Requires a `golangci-lint` custom linter configuration change tracked separately.