### PR TITLE
chore: allow ReadWriteOncePod access mode for persistentvolumes [KO-588]

### DIFF
--- a/api/v1/aerospikecluster_types.go
+++ b/api/v1/aerospikecluster_types.go
@@ -815,7 +815,7 @@ type PersistentVolumeSpec struct { //nolint:govet // for readability
 
 	// AccessModes contains the desired access modes the volume should have.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
-	// +kubebuilder:validation:items:Enum=ReadOnlyMany;ReadWriteMany;ReadWriteOnce
+	// +kubebuilder:validation:items:Enum=ReadOnlyMany;ReadWriteMany;ReadWriteOnce;ReadWriteOncePod
 	// +optional
 	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty" protobuf:"bytes,1,rep,name=accessModes,casttype=PersistentVolumeAccessMode"` //nolint:lll // for readability
 

--- a/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
+++ b/config/crd/bases/asdb.aerospike.com_aerospikeclusters.yaml
@@ -6877,6 +6877,7 @@ spec:
                                               - ReadOnlyMany
                                               - ReadWriteMany
                                               - ReadWriteOnce
+                                              - ReadWriteOncePod
                                               type: string
                                             type: array
                                           metadata:
@@ -8526,6 +8527,7 @@ spec:
                                               - ReadOnlyMany
                                               - ReadWriteMany
                                               - ReadWriteOnce
+                                              - ReadWriteOncePod
                                               type: string
                                             type: array
                                           metadata:
@@ -9238,6 +9240,7 @@ spec:
                                     - ReadOnlyMany
                                     - ReadWriteMany
                                     - ReadWriteOnce
+                                    - ReadWriteOncePod
                                     type: string
                                   type: array
                                 metadata:
@@ -16429,6 +16432,7 @@ spec:
                                               - ReadOnlyMany
                                               - ReadWriteMany
                                               - ReadWriteOnce
+                                              - ReadWriteOncePod
                                               type: string
                                             type: array
                                           metadata:
@@ -18078,6 +18082,7 @@ spec:
                                               - ReadOnlyMany
                                               - ReadWriteMany
                                               - ReadWriteOnce
+                                              - ReadWriteOncePod
                                               type: string
                                             type: array
                                           metadata:
@@ -18855,6 +18860,7 @@ spec:
                                     - ReadOnlyMany
                                     - ReadWriteMany
                                     - ReadWriteOnce
+                                    - ReadWriteOncePod
                                     type: string
                                   type: array
                                 metadata:

--- a/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/crds/customresourcedefinition_aerospikeclusters.asdb.aerospike.com.yaml
@@ -6877,6 +6877,7 @@ spec:
                                               - ReadOnlyMany
                                               - ReadWriteMany
                                               - ReadWriteOnce
+                                              - ReadWriteOncePod
                                               type: string
                                             type: array
                                           metadata:
@@ -8526,6 +8527,7 @@ spec:
                                               - ReadOnlyMany
                                               - ReadWriteMany
                                               - ReadWriteOnce
+                                              - ReadWriteOncePod
                                               type: string
                                             type: array
                                           metadata:
@@ -9238,6 +9240,7 @@ spec:
                                     - ReadOnlyMany
                                     - ReadWriteMany
                                     - ReadWriteOnce
+                                    - ReadWriteOncePod
                                     type: string
                                   type: array
                                 metadata:
@@ -16429,6 +16432,7 @@ spec:
                                               - ReadOnlyMany
                                               - ReadWriteMany
                                               - ReadWriteOnce
+                                              - ReadWriteOncePod
                                               type: string
                                             type: array
                                           metadata:
@@ -18078,6 +18082,7 @@ spec:
                                               - ReadOnlyMany
                                               - ReadWriteMany
                                               - ReadWriteOnce
+                                              - ReadWriteOncePod
                                               type: string
                                             type: array
                                           metadata:
@@ -18855,6 +18860,7 @@ spec:
                                     - ReadOnlyMany
                                     - ReadWriteMany
                                     - ReadWriteOnce
+                                    - ReadWriteOncePod
                                     type: string
                                   type: array
                                 metadata:

--- a/test/cluster/storage_test.go
+++ b/test/cluster/storage_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
-	"regexp"
-	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -151,7 +149,14 @@ var _ = Describe(
 							"Should allow ReadWriteOncePod accessMode for PV source",
 							func() {
 								// ReadWriteOncePod was introduced as an alpha feature in Kubernetes 1.22.
-								skipIfK8sVersionBelow(1, 22, "ReadWriteOncePod accessMode support")
+								// Beta in v1.27 and GA in v1.29.
+								versionBelowThanExpected, currVersion, err := isK8sVersionBelow(k8sClientSet, 1, 27)
+								Expect(err).ShouldNot(HaveOccurred())
+
+								if versionBelowThanExpected {
+									Skip(fmt.Sprintf("requires Kubernetes >= 1.27 (server is %s): ReadWriteOncePod accessMode support",
+										currVersion))
+								}
 
 								aeroCluster := createDummyAerospikeCluster(
 									clusterNamespacedName, 2,
@@ -1046,29 +1051,5 @@ func validateWorkDirSubPathMounts(pod *v1.Pod, volumeName, workDirPath string) {
 
 		Expect(found).To(BeTrue(), "volume %s not mounted with subPath %s at path %s",
 			volumeName, subPath, expectedPath)
-	}
-}
-
-var k8sVersionRegex = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
-
-// skipIfK8sVersionBelow skips the current spec when the API server's version is
-// older than the provided major.minor. Used to gate features that are unavailable
-// on older Kubernetes clusters.
-func skipIfK8sVersionBelow(major, minor int, reason string) {
-	info, err := k8sClientSet.Discovery().ServerVersion()
-	Expect(err).ToNot(HaveOccurred())
-
-	matches := k8sVersionRegex.FindStringSubmatch(info.GitVersion)
-	Expect(matches).To(HaveLen(3), "unable to parse Kubernetes version %q", info.GitVersion)
-
-	serverMajor, err := strconv.Atoi(matches[1])
-	Expect(err).ToNot(HaveOccurred())
-
-	serverMinor, err := strconv.Atoi(matches[2])
-	Expect(err).ToNot(HaveOccurred())
-
-	if serverMajor < major || (serverMajor == major && serverMinor < minor) {
-		Skip(fmt.Sprintf("requires Kubernetes >= %d.%d (server is %s): %s",
-			major, minor, info.GitVersion, reason))
 	}
 }

--- a/test/cluster/storage_test.go
+++ b/test/cluster/storage_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"regexp"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -142,6 +144,39 @@ var _ = Describe(
 									[]v1.PersistentVolumeAccessMode{accessMode}
 
 								Expect(DeployCluster(k8sClient, ctx, aeroCluster)).Should(HaveOccurred())
+							},
+						)
+
+						FIt(
+							"Should allow ReadWriteOncePod accessMode for PV source",
+							func() {
+								// ReadWriteOncePod was introduced as an alpha feature in Kubernetes 1.22.
+								skipIfK8sVersionBelow(1, 22, "ReadWriteOncePod accessMode support")
+
+								aeroCluster := createDummyAerospikeCluster(
+									clusterNamespacedName, 2,
+								)
+
+								for i, volume := range aeroCluster.Spec.Storage.Volumes {
+									if volume.Source.PersistentVolume != nil {
+										aeroCluster.Spec.Storage.Volumes[i].Source.PersistentVolume.AccessModes =
+											[]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}
+									}
+								}
+
+								Expect(DeployCluster(k8sClient, ctx, aeroCluster)).ShouldNot(HaveOccurred())
+
+								pvcs, err := getAeroClusterPVCList(
+									aeroCluster, k8sClient,
+								)
+								Expect(err).ShouldNot(HaveOccurred())
+								Expect(pvcs).ShouldNot(BeEmpty())
+
+								for idx := range pvcs {
+									Expect(pvcs[idx].Spec.AccessModes).To(
+										ContainElement(v1.ReadWriteOncePod),
+									)
+								}
 							},
 						)
 
@@ -1011,5 +1046,29 @@ func validateWorkDirSubPathMounts(pod *v1.Pod, volumeName, workDirPath string) {
 
 		Expect(found).To(BeTrue(), "volume %s not mounted with subPath %s at path %s",
 			volumeName, subPath, expectedPath)
+	}
+}
+
+var k8sVersionRegex = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
+
+// skipIfK8sVersionBelow skips the current spec when the API server's version is
+// older than the provided major.minor. Used to gate features that are unavailable
+// on older Kubernetes clusters.
+func skipIfK8sVersionBelow(major, minor int, reason string) {
+	info, err := k8sClientSet.Discovery().ServerVersion()
+	Expect(err).ToNot(HaveOccurred())
+
+	matches := k8sVersionRegex.FindStringSubmatch(info.GitVersion)
+	Expect(matches).To(HaveLen(3), "unable to parse Kubernetes version %q", info.GitVersion)
+
+	serverMajor, err := strconv.Atoi(matches[1])
+	Expect(err).ToNot(HaveOccurred())
+
+	serverMinor, err := strconv.Atoi(matches[2])
+	Expect(err).ToNot(HaveOccurred())
+
+	if serverMajor < major || (serverMajor == major && serverMinor < minor) {
+		Skip(fmt.Sprintf("requires Kubernetes >= %d.%d (server is %s): %s",
+			major, minor, info.GitVersion, reason))
 	}
 }

--- a/test/cluster/storage_test.go
+++ b/test/cluster/storage_test.go
@@ -147,7 +147,7 @@ var _ = Describe(
 							},
 						)
 
-						FIt(
+						It(
 							"Should allow ReadWriteOncePod accessMode for PV source",
 							func() {
 								// ReadWriteOncePod was introduced as an alpha feature in Kubernetes 1.22.

--- a/test/cluster/utils.go
+++ b/test/cluster/utils.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -945,4 +947,34 @@ kubectl annotate pod ${POD_NAME} aerospike.com/override-rack-id=${RAND} --overwr
 			},
 		},
 	}
+}
+
+var k8sVersionRegex = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
+
+// isK8sVersionBelow returns if the API server's version is
+// older than the provided major.minor. Used to gate features that are unavailable
+// on older Kubernetes clusters.
+func isK8sVersionBelow(k8sClientSet *kubernetes.Clientset, major, minor int) (isBelow bool, version string, err error) {
+	serverVersion, err := k8sClientSet.Discovery().ServerVersion()
+	if err != nil {
+		return false, "", err
+	}
+
+	matches := k8sVersionRegex.FindStringSubmatch(serverVersion.GitVersion)
+
+	serverMajor, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return false, "", err
+	}
+
+	serverMinor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return false, "", err
+	}
+
+	if serverMajor < major || (serverMajor == major && serverMinor < minor) {
+		return true, serverVersion.GitVersion, nil
+	}
+
+	return false, serverVersion.GitVersion, nil
 }

--- a/test/envtests/cluster/storage_webhook_test.go
+++ b/test/envtests/cluster/storage_webhook_test.go
@@ -114,6 +114,32 @@ var _ = Describe("Storage webhook validation", func() {
 		})
 
 		Context("spec.storage volumes (PersistentVolumeSpec)", func() {
+			Context("positive", func() {
+				// accessModes carries a +kubebuilder:validation:items:Enum marker, so every value in
+				// the allowed set must be accepted by the CRD schema.
+				DescribeTable("allows valid accessMode enum values (items:Enum)",
+					func(accessMode corev1.PersistentVolumeAccessMode) {
+						// Size 2 satisfies the strong-consistency namespace replication-factor (2).
+						aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 2)
+						setFirstPVAccessModes(&aeroCluster.Spec.Storage, accessMode)
+
+						Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+					},
+					Entry("ReadOnlyMany", corev1.ReadOnlyMany),
+					Entry("ReadWriteMany", corev1.ReadWriteMany),
+					Entry("ReadWriteOnce", corev1.ReadWriteOnce),
+					Entry("ReadWriteOncePod", corev1.ReadWriteOncePod),
+				)
+
+				It("allows multiple valid accessModes together, including ReadWriteOncePod (items:Enum)", func() {
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 2)
+					setFirstPVAccessModes(&aeroCluster.Spec.Storage,
+						corev1.ReadWriteOnce, corev1.ReadWriteOncePod)
+
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+				})
+			})
+
 			Context("negative", func() {
 				It("rejects invalid volumeMode (Enum)", func() {
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 1)
@@ -134,18 +160,26 @@ var _ = Describe("Storage webhook validation", func() {
 						Validate(err)
 				})
 
-				It("rejects accessMode not in allowed enum (items:Enum)", func() {
+				DescribeTable("rejects accessMode not in allowed enum (items:Enum)",
+					func(accessMode corev1.PersistentVolumeAccessMode) {
+						aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 1)
+						setFirstPVAccessModes(&aeroCluster.Spec.Storage, accessMode)
+
+						err := envtests.K8sClient.Create(ctx, aeroCluster)
+						Expect(err).To(HaveOccurred())
+						envtests.NewStatusErrorMatcher().
+							WithMessageSubstrings(testutil.CRDSchemaErrorPrefix, "accessModes").
+							Validate(err)
+					},
+					Entry("arbitrary invalid value", corev1.PersistentVolumeAccessMode("invalid")),
+					// Guards against a typo/casing regression in the newly added enum value.
+					Entry("wrong casing of ReadWriteOncePod", corev1.PersistentVolumeAccessMode("ReadWriteOncepod")),
+				)
+
+				It("rejects a valid and an invalid accessMode together (items:Enum)", func() {
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(nsName, 1)
-
-					for i := range aeroCluster.Spec.Storage.Volumes {
-						if aeroCluster.Spec.Storage.Volumes[i].Source.PersistentVolume != nil {
-							aeroCluster.Spec.Storage.Volumes[i].Source.PersistentVolume.AccessModes = []corev1.PersistentVolumeAccessMode{
-								corev1.PersistentVolumeAccessMode("invalid"),
-							}
-
-							break
-						}
-					}
+					setFirstPVAccessModes(&aeroCluster.Spec.Storage,
+						corev1.ReadWriteOncePod, corev1.PersistentVolumeAccessMode("invalid"))
 
 					err := envtests.K8sClient.Create(ctx, aeroCluster)
 					Expect(err).To(HaveOccurred())
@@ -470,6 +504,20 @@ var _ = Describe("Storage webhook validation", func() {
 		})
 	})
 })
+
+// setFirstPVAccessModes sets AccessModes on the first volume backed by a
+// PersistentVolume source. It is used to exercise the accessModes items:Enum marker.
+func setFirstPVAccessModes(
+	storage *asdbv1.AerospikeStorageSpec,
+	modes ...corev1.PersistentVolumeAccessMode,
+) {
+	for i := range storage.Volumes {
+		if storage.Volumes[i].Source.PersistentVolume != nil {
+			storage.Volumes[i].Source.PersistentVolume.AccessModes = modes
+			return
+		}
+	}
+}
 
 func setVolumePolicyMethod(
 	storage *asdbv1.AerospikeStorageSpec,


### PR DESCRIPTION
Fixes https://aerospike.atlassian.net/browse/KO-588.

Adds the `ReadWriteOncePod` access mode in the PersistentVolume enum spec.

Integration test logs:

```
  Timeline >>
  > Enter [BeforeEach] When adding cluster @ 07/20/26 16:58:18.056
  < Exit [BeforeEach] When adding cluster @ 07/20/26 16:58:18.056 (0s)
  > Enter [It] Should allow ReadWriteOncePod accessMode for PV source @ 07/20/26 16:58:18.056
  2026-07-20T16:58:18+05:30     INFO    aerospikecluster        Cluster size is not correct     {"name": "storage-1"}
  2026-07-20T16:58:48+05:30     INFO    aerospikecluster        Cluster size is not correct     {"name": "storage-1"}
  2026-07-20T16:59:18+05:30     INFO    aerospikecluster        Cluster state is validated successfully {"name": "storage-1"}
  2026-07-20T16:59:18+05:30     INFO    aerospikecluster        AerospikeCluster available

  < Exit [It] Should allow ReadWriteOncePod accessMode for PV source @ 07/20/26 16:59:18.346 (1m0.29s)
  > Enter [AfterEach] When adding cluster @ 07/20/26 16:59:18.346
  < Exit [AfterEach] When adding cluster @ 07/20/26 16:59:20.934 (2.588s)
  << Timeline
------------------------------
SSSSSSSSSSSSSSSSS
------------------------------
[SynchronizedAfterSuite] PASSED [0.556 seconds]
[SynchronizedAfterSuite]
/Users/strivedi/Code/aerospike-kubernetes-operator/test/cluster/suite_test.go:134

  Timeline >>
  > Enter [SynchronizedAfterSuite] TOP-LEVEL @ 07/20/26 16:59:20.938
  < Exit [SynchronizedAfterSuite] TOP-LEVEL @ 07/20/26 16:59:20.938 (0s)
  > Enter [SynchronizedAfterSuite] TOP-LEVEL @ 07/20/26 16:59:20.938
  STEP: Cleaning up all clusters and pvcs @ 07/20/26 16:59:20.938
  STEP: tearing down the test environment @ 07/20/26 16:59:21.493
  < Exit [SynchronizedAfterSuite] TOP-LEVEL @ 07/20/26 16:59:21.494 (556ms)
  << Timeline
------------------------------
[ReportAfterSuite] PASSED [0.012 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo

  Timeline >>
  > Enter [ReportAfterSuite] TOP-LEVEL @ 07/20/26 16:59:21.497
  < Exit [ReportAfterSuite] TOP-LEVEL @ 07/20/26 16:59:21.507 (10ms)
  << Timeline
------------------------------

Ran 1 of 348 Specs in 66.076 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 347 Skipped

coverage: 7.6% of statements
composite coverage: 7.6% of statements

Ginkgo ran 1 suite in 1m8.345953708s
Test Suite Passed
```