### PR TITLE
chore: clean ako chart values.yaml on release [KO-587]

### DIFF
--- a/scripts/release-helm-charts.sh
+++ b/scripts/release-helm-charts.sh
@@ -116,22 +116,23 @@ fi
 echo "    Extracted to ${EXTRACT_DIR}/helm-charts/"
 
 # ---------------------------------------------------------------------------
-# Step 2 — Strip @schema annotations from the operator chart's values.yaml
+# Step 2 — Clean up the operator chart's values.yaml for customers
 #
 # The values.schema.json for aerospike-kubernetes-operator is authored via
-# inline `# @schema ...` comments (see values.docs.jsonschema.yaml tooling).
-# Those annotations are dev-facing only, so strip them before packaging to
-# give customers a clean values.yaml.
+# inline `# @schema ...` comments, and doc comments use the helm-docs
+# `# -- ...` convention. Both are dev-facing only, so strip/simplify them
+# before packaging to give customers a clean values.yaml.
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "==> [2/5] Stripping @schema annotations from operator chart values.yaml..."
+echo "==> [2/5] Cleaning up operator chart values.yaml..."
 
 OPERATOR_VALUES="${EXTRACT_DIR}/helm-charts/aerospike-kubernetes-operator/values.yaml"
 if [[ -f "${OPERATOR_VALUES}" ]]; then
     sed -i.bak -E \
         -e '/^[[:space:]]*# @schema/d' \
         -e 's/[[:space:]]+# @schema.*$//' \
+        -e 's/^([[:space:]]*)# -- /\1# /' \
         "${OPERATOR_VALUES}"
     rm -f "${OPERATOR_VALUES}.bak"
     echo "    Cleaned ${OPERATOR_VALUES}"

--- a/scripts/release-helm-charts.sh
+++ b/scripts/release-helm-charts.sh
@@ -9,11 +9,13 @@
 #
 # What it does:
 #   1. Extracts helm-charts/ from the main repo at the given tag (non-destructive)
-#   2. Packages each chart into a temp dir
-#   3. Runs `helm repo index <tempdir> --merge <committed-index>` so that only
+#   2. Strips @schema annotations from the aerospike-kubernetes-operator chart's
+#      values.yaml so customers get a clean file
+#   3. Packages each chart into a temp dir
+#   4. Runs `helm repo index <tempdir> --merge <committed-index>` so that only
 #      new entries get fresh timestamps; all pre-existing entries are taken
 #      verbatim from the committed index.yaml
-#   4. Moves the new .tgz files and updated index.yaml into this directory
+#   5. Moves the new .tgz files and updated index.yaml into this directory
 
 set -euo pipefail
 
@@ -101,7 +103,7 @@ mkdir -p "${EXTRACT_DIR}" "${NEW_PKGS_DIR}"
 # Step 1 — Extract helm-charts/ from the tagged commit (non-destructive)
 # ---------------------------------------------------------------------------
 
-echo "==> [1/4] Extracting helm-charts/ from tag ${TAG}..."
+echo "==> [1/5] Extracting helm-charts/ from tag ${TAG}..."
 
 git -C "${MAIN_REPO_DIR}" archive "${TAG}" -- helm-charts/ \
     | tar -x -C "${EXTRACT_DIR}"
@@ -114,11 +116,35 @@ fi
 echo "    Extracted to ${EXTRACT_DIR}/helm-charts/"
 
 # ---------------------------------------------------------------------------
-# Step 2 — Package each chart into the temp dir
+# Step 2 — Strip @schema annotations from the operator chart's values.yaml
+#
+# The values.schema.json for aerospike-kubernetes-operator is authored via
+# inline `# @schema ...` comments (see values.docs.jsonschema.yaml tooling).
+# Those annotations are dev-facing only, so strip them before packaging to
+# give customers a clean values.yaml.
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "==> [2/4] Packaging charts..."
+echo "==> [2/5] Stripping @schema annotations from operator chart values.yaml..."
+
+OPERATOR_VALUES="${EXTRACT_DIR}/helm-charts/aerospike-kubernetes-operator/values.yaml"
+if [[ -f "${OPERATOR_VALUES}" ]]; then
+    sed -i.bak -E \
+        -e '/^[[:space:]]*# @schema/d' \
+        -e 's/[[:space:]]+# @schema.*$//' \
+        "${OPERATOR_VALUES}"
+    rm -f "${OPERATOR_VALUES}.bak"
+    echo "    Cleaned ${OPERATOR_VALUES}"
+else
+    echo "    [skip] values.yaml not found for aerospike-kubernetes-operator"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — Package each chart into the temp dir
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "==> [3/5] Packaging charts..."
 
 packaged=()
 for chart in "${CHART_NAMES[@]}"; do
@@ -149,7 +175,7 @@ fi
 echo "    Packaged ${#packaged[@]} chart(s)"
 
 # ---------------------------------------------------------------------------
-# Step 3 — Generate index.yaml for new packages, merging with committed index
+# Step 4 — Generate index.yaml for new packages, merging with committed index
 #
 # Running helm repo index on a directory that contains ONLY the new .tgz files
 # means helm generates fresh entries only for those. --merge then pulls in all
@@ -157,7 +183,7 @@ echo "    Packaged ${#packaged[@]} chart(s)"
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "==> [3/4] Running helm repo index..."
+echo "==> [4/5] Running helm repo index..."
 
 MERGE_FLAG=()
 if git show HEAD:index.yaml > "${WORK_DIR}/index.yaml.committed" 2>/dev/null; then
@@ -171,11 +197,11 @@ helm repo index "${NEW_PKGS_DIR}" --url "${HELM_REPO_URL}" "${MERGE_FLAG[@]}"
 echo "    index.yaml generated"
 
 # ---------------------------------------------------------------------------
-# Step 4 — Move new packages and updated index.yaml into the packages dir
+# Step 5 — Move new packages and updated index.yaml into the packages dir
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "==> [4/4] Moving packages and index.yaml into ${PACKAGES_DIR}..."
+echo "==> [5/5] Moving packages and index.yaml into ${PACKAGES_DIR}..."
 
 for pkg in "${packaged[@]}"; do
     mv "${NEW_PKGS_DIR}/${pkg}" "${PACKAGES_DIR}/"


### PR DESCRIPTION
Strip the dev-facing `@schema` and `# --` comments used to generate `values.schema.json` from the `values.yaml` of AKO helm chart so that customers can get a clean values file.


<details>
  <summary>values.yaml file post running the script</summary>
  
  ```yaml
# Default values for Aerospike Kubernetes Operator.

# Number of operator replicas to deploy
replicas: 2

# Operator image
operatorImage:
  # Operator image repository
  repository: aerospike/aerospike-kubernetes-operator
  # Operator image tag
  tag: 4.5.0
  # Operator image pull policy
  pullPolicy: IfNotPresent

# In case the above image is pulled from a registry that requires
# authentication, a secret containing credentials can be added
# imagePullSecrets:
#   - secret_with_credentials_to_custom_registry
imagePullSecrets: []

# RBAC resource creation for the operator
rbac:
  # Create RBAC resources and a service account for the operator
  create: true
  # Name of an existing service account to use when rbac.create is false
  serviceAccountName: ""

# Port for the operator's health probe bind address
healthPort: 8081

# Port for the operator's metrics bind address
metricsPort: 8443

# Certificate configuration for the webhook and metrics endpoints
certs:
  # Webhook server certificate configuration
  webhook:
    create: true
    # Name of the secret holding the webhook server certificate
    webhookServerCertSecretName: "webhook-server-cert"

  # Metrics server certificate configuration
  metrics:
    create: false
    # Name of the secret holding the metrics server certificate
    metricsServerCertSecretName: "metrics-server-cert"

# Operator manager logging (controller-runtime / Zap)
# development must stay set; level/encoder are optional (uncomment or use --set).
logging:
  development: true
  # (Optional) Zap log level (--zap-log-level): debug, info, error, panic, or a positive integer for custom verbosity. Empty leaves the flag off
  level: ""
  # (Optional) Zap log encoder (--zap-encoder). Empty leaves the flag off
  encoder: ""

# Operator manager /metrics endpoint configuration
# Always passed in the Deployment args for clarity; defaults to TLS on (`true`).
metrics:
  secure: true

# Comma-separated (no spaces) list of namespaces to watch for Aerospike custom resources
watchNamespaces: "default,aerospike"

# Comma-separated (no spaces) list of namespaces to ignore. Only used for eviction webhook
ignoreNamespaces: "kube-system,kube-node-lease"

# Enable the eviction webhook to safely block Aerospike pod evictions during node maintenance
# Also enables Prometheus metrics: aerospike_ako_eviction_webhook_requests_total (labels: eviction_namespace, decision)
safePodEviction:
  enable: false
  timeoutSeconds: "20"

# Grace period to delete/recover failed pods (in seconds)
failedPodGracePeriodSeconds: "60"

# Registry used to pull aerospike-init image
aerospikeKubernetesInitRegistry: "docker.io"

# Namespace in registry used to pull aerospike-init image
aerospikeKubernetesInitRegistryNamespace: "aerospike"

# Name and tag of aerospike-init image
aerospikeKubernetesInitNameTag: "aerospike-kubernetes-init:2.5.3"

# Resources - limits / requests
resources:
  limits:
    cpu: 400m
    memory: 512Mi
  requests:
    cpu: 10m
    memory: 64Mi

# Affinity rules
affinity: {}

# Extra environment variables that will be passed into the operator pods
extraEnv: {}

# Node selector
nodeSelector: {}

# Tolerations
tolerations: []

# Deployment annotations
annotations: {}

# Deployment labels are inherited by the pods automatically
labels: {}

# Pod annotations
podAnnotations: {}

# Pod labels
podLabels: {}

# Service configuration
metricsService:
  port: 8443
  type: ClusterIP
  # (Optional) Extra labels for the service
  labels: {}
  # (Optional) Extra annotations for the service
  annotations: {}

# Service configuration
webhookService:
  port: 443
  targetPort: 9443
  # Kubernetes Service type
  type: ClusterIP
  # (Optional) Extra labels for the service
  labels: {}
  # (Optional) Extra annotations for the service
  annotations: {}

# Pod security context
podSecurityContext: {}

# Container security context
securityContext:
  allowPrivilegeEscalation: false

# Liveness probe configuration
livenessProbe:
  initialDelaySeconds: 15
  periodSeconds: 20
  timeoutSeconds: 1
  successThreshold: 1
  failureThreshold: 3

# Readiness probe configuration
readinessProbe:
  initialDelaySeconds: 5
  periodSeconds: 10
  timeoutSeconds: 1
  successThreshold: 1
  failureThreshold: 3

# Override the chart name used in generated resource names
nameOverride: ""

# Override the fully qualified name used for generated resource names
fullnameOverride: ""

# Deprecated, use webhookService.targetPort instead. Setting this fails chart rendering with a message pointing to the replacement
webhookServicePort:
```
</details>
