### PR TITLE
fix: allow advertise-ipv6 when cluster nodes report IPv6 addresses

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - delete

--- a/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrole.yaml
+++ b/helm-charts/aerospike-kubernetes-operator/templates/aerospike-operator-manager-clusterrole.yaml
@@ -27,6 +27,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - delete

--- a/internal/webhook/v1/aerospikecluster_validating_webhook.go
+++ b/internal/webhook/v1/aerospikecluster_validating_webhook.go
@@ -47,6 +47,30 @@ import (
 
 // +kubebuilder:object:generate=false
 type AerospikeClusterCustomValidator struct {
+	ipv6Prober *nodeIPv6Prober
+}
+
+// ipv6Capable reports whether the cluster has IPv6-capable nodes, which gates the
+// advertise-ipv6 Aerospike setting. A non-nil probe error is the reason capability
+// could not be determined; the cluster is then reported as not IPv6-capable.
+//
+// The value is only consulted when advertise-ipv6 is requested, so an unprobeable
+// cluster keeps rejecting that one setting instead of failing every admission.
+func (acv *AerospikeClusterCustomValidator) ipv6Capable(
+	ctx context.Context, aslog logr.Logger,
+) (bool, error) {
+	if acv.ipv6Prober == nil {
+		return false, nil
+	}
+
+	capable, err := acv.ipv6Prober.IPv6Capable(ctx)
+	if err != nil {
+		aslog.Error(err, "Failed to determine node IPv6 capability, treating cluster as not IPv6-capable")
+
+		return false, err
+	}
+
+	return capable, nil
 }
 
 //nolint:lll // for readability
@@ -55,13 +79,16 @@ type AerospikeClusterCustomValidator struct {
 var _ admission.Validator[*asdbv1.AerospikeCluster] = &AerospikeClusterCustomValidator{}
 
 // ValidateCreate implements admission.Validator so a webhook will be registered for the type
-func (acv *AerospikeClusterCustomValidator) ValidateCreate(_ context.Context, aerospikeCluster *asdbv1.AerospikeCluster,
+func (acv *AerospikeClusterCustomValidator) ValidateCreate(ctx context.Context,
+	aerospikeCluster *asdbv1.AerospikeCluster,
 ) (admission.Warnings, error) {
 	aslog := logf.Log.WithName(asdbv1.ClusterNamespacedName(aerospikeCluster))
 
 	aslog.Info("Validate create")
 
-	warns, vErr := validate(aslog, aerospikeCluster)
+	ipv6Capable, ipv6ProbeErr := acv.ipv6Capable(ctx, aslog)
+
+	warns, vErr := validate(aslog, aerospikeCluster, ipv6Capable, ipv6ProbeErr)
 	if vErr != nil {
 		return warns, vErr
 	}
@@ -222,7 +249,7 @@ func (acv *AerospikeClusterCustomValidator) ValidateDelete(_ context.Context, ae
 }
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type
-func (acv *AerospikeClusterCustomValidator) ValidateUpdate(_ context.Context,
+func (acv *AerospikeClusterCustomValidator) ValidateUpdate(ctx context.Context,
 	oldObject,
 	aerospikeCluster *asdbv1.AerospikeCluster,
 ) (admission.Warnings, error) {
@@ -232,7 +259,9 @@ func (acv *AerospikeClusterCustomValidator) ValidateUpdate(_ context.Context,
 
 	var warnings admission.Warnings
 
-	warns, vErr := validate(aslog, aerospikeCluster)
+	ipv6Capable, ipv6ProbeErr := acv.ipv6Capable(ctx, aslog)
+
+	warns, vErr := validate(aslog, aerospikeCluster, ipv6Capable, ipv6ProbeErr)
 	warnings = append(warnings, warns...)
 
 	if vErr != nil {
@@ -326,7 +355,9 @@ func (acv *AerospikeClusterCustomValidator) ValidateUpdate(_ context.Context,
 	return warnings, nil
 }
 
-func validate(aslog logr.Logger, cluster *asdbv1.AerospikeCluster) (admission.Warnings, error) {
+func validate(
+	aslog logr.Logger, cluster *asdbv1.AerospikeCluster, ipv6Capable bool, ipv6ProbeErr error,
+) (admission.Warnings, error) {
 	aslog.V(1).Info("Validate AerospikeCluster spec", "obj.Spec", cluster.Spec)
 
 	var warnings admission.Warnings
@@ -378,7 +409,7 @@ func validate(aslog logr.Logger, cluster *asdbv1.AerospikeCluster) (admission.Wa
 	}
 
 	// Validate rackConfig
-	warns, err := validateRackConfig(aslog, cluster, version)
+	warns, err := validateRackConfig(aslog, cluster, version, ipv6Capable, ipv6ProbeErr)
 
 	warnings = append(warnings, warns...)
 	if err != nil {
@@ -938,7 +969,7 @@ func validateResourceAndLimits(
 }
 
 func validateRackConfig(aslog logr.Logger, cluster *asdbv1.AerospikeCluster,
-	version string) (admission.Warnings, error) {
+	version string, ipv6Capable bool, ipv6ProbeErr error) (admission.Warnings, error) {
 	var warnings admission.Warnings
 
 	// If EnableRackIDOverride is enabled, only single rack is allowed
@@ -1032,7 +1063,7 @@ func validateRackConfig(aslog logr.Logger, cluster *asdbv1.AerospikeCluster,
 
 		configWarns, err = validateAerospikeConfig(aslog, version,
 			&rack.AerospikeConfig, &rack.Storage, int(cluster.Spec.Size),
-			cluster.Spec.OperatorClientCertSpec,
+			cluster.Spec.OperatorClientCertSpec, ipv6Capable, ipv6ProbeErr,
 		)
 		warnings = append(warnings, configWarns...)
 
@@ -1259,11 +1290,11 @@ func cgroupMemTrackingWarning(version string, conf map[string]interface{}) admis
 func validateAerospikeConfig(
 	aslog logr.Logger, version string, configSpec *asdbv1.AerospikeConfigSpec,
 	storage *asdbv1.AerospikeStorageSpec, clSize int,
-	clientCert *asdbv1.AerospikeOperatorClientCertSpec,
+	clientCert *asdbv1.AerospikeOperatorClientCertSpec, ipv6Capable bool, ipv6ProbeErr error,
 ) (admission.Warnings, error) {
 	// It validates the aerospikeConfig schema and generic aerospikeConfig fields
 	if err := validation.ValidateAerospikeConfig(
-		aslog, version, configSpec.Value, clSize,
+		aslog, version, configSpec.Value, clSize, ipv6Capable, ipv6ProbeErr,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/webhook/v1/aerospikecluster_webhook.go
+++ b/internal/webhook/v1/aerospikecluster_webhook.go
@@ -17,15 +17,45 @@ limitations under the License.
 package v1
 
 import (
+	"time"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 )
 
+// WebhookOption configures the AerospikeCluster webhook.
+type WebhookOption func(*webhookOptions)
+
+type webhookOptions struct {
+	nodeIPv6CacheTTL time.Duration
+}
+
+// WithNodeIPv6CacheTTL overrides how long the node IPv6 capability probe result is reused.
+// Tests use a short TTL so a seeded node is observed promptly; production uses the default.
+func WithNodeIPv6CacheTTL(ttl time.Duration) WebhookOption {
+	return func(o *webhookOptions) {
+		o.nodeIPv6CacheTTL = ttl
+	}
+}
+
 // SetupAerospikeClusterWebhookWithManager registers the webhook for AerospikeCluster in the manager.
-func SetupAerospikeClusterWebhookWithManager(mgr ctrl.Manager) error {
+func SetupAerospikeClusterWebhookWithManager(mgr ctrl.Manager, opts ...WebhookOption) error {
+	var options webhookOptions
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	// The prober reads through the API reader rather than the manager cache: nodes are
+	// read rarely and behind a cache of their own, so a cluster-wide node informer would
+	// cost memory and a watch permission for nothing.
+	validator := &AerospikeClusterCustomValidator{
+		ipv6Prober: newNodeIPv6Prober(mgr.GetAPIReader(), options.nodeIPv6CacheTTL),
+	}
+
 	return ctrl.NewWebhookManagedBy(mgr, &asdbv1.AerospikeCluster{}).
 		WithDefaulter(&AerospikeClusterCustomDefaulter{}).
-		WithValidator(&AerospikeClusterCustomValidator{}).
+		WithValidator(validator).
 		Complete()
 }

--- a/internal/webhook/v1/ipv6.go
+++ b/internal/webhook/v1/ipv6.go
@@ -1,0 +1,110 @@
+package v1
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list
+
+const (
+	// defaultNodeIPv6CacheTTL bounds how stale a cached IPv6 capability answer can be.
+	// Node addressing is a property of the cluster network, so it changes only when the
+	// cluster is rebuilt or a differently addressed node pool joins. A few minutes keeps
+	// admission off the API server while still picking such a change up without a restart.
+	defaultNodeIPv6CacheTTL = 5 * time.Minute
+
+	// nodeListPageSize keeps a cache refresh from materialising every node of a large
+	// cluster at once. The scan stops at the first IPv6-capable node, so single-stack
+	// IPv6 clusters answer from the first page.
+	nodeListPageSize = 100
+)
+
+// nodeIPv6Prober reports whether the Kubernetes cluster has at least one IPv6-capable
+// node, caching the answer because it is consulted on every AerospikeCluster admission.
+type nodeIPv6Prober struct {
+	expiry time.Time
+	reader client.Reader
+	ttl    time.Duration
+	mu     sync.Mutex
+	cached bool
+}
+
+func newNodeIPv6Prober(reader client.Reader, ttl time.Duration) *nodeIPv6Prober {
+	if ttl <= 0 {
+		ttl = defaultNodeIPv6CacheTTL
+	}
+
+	return &nodeIPv6Prober{
+		reader: reader,
+		ttl:    ttl,
+	}
+}
+
+// IPv6Capable reports whether any node carries an IPv6 InternalIP address.
+// The lock is held across the refresh so that concurrent admissions collapse into a
+// single node listing rather than each issuing its own.
+func (p *nodeIPv6Prober) IPv6Capable(ctx context.Context) (bool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if time.Now().Before(p.expiry) {
+		return p.cached, nil
+	}
+
+	capable, err := clusterHasIPv6Node(ctx, p.reader)
+	if err != nil {
+		return false, err
+	}
+
+	p.cached = capable
+	p.expiry = time.Now().Add(p.ttl)
+
+	return capable, nil
+}
+
+// clusterHasIPv6Node reports whether any node reports an IPv6 InternalIP. This mirrors
+// the address selection the init container performs at runtime, so admission agrees with
+// the addresses the pods actually end up advertising.
+func clusterHasIPv6Node(ctx context.Context, reader client.Reader) (bool, error) {
+	listOpts := []client.ListOption{client.Limit(nodeListPageSize)}
+
+	for {
+		nodes := &v1.NodeList{}
+		if err := reader.List(ctx, nodes, listOpts...); err != nil {
+			return false, err
+		}
+
+		for idx := range nodes.Items {
+			if nodeHasIPv6InternalIP(&nodes.Items[idx]) {
+				return true, nil
+			}
+		}
+
+		if nodes.Continue == "" {
+			return false, nil
+		}
+
+		listOpts = []client.ListOption{client.Limit(nodeListPageSize), client.Continue(nodes.Continue)}
+	}
+}
+
+func nodeHasIPv6InternalIP(node *v1.Node) bool {
+	for idx := range node.Status.Addresses {
+		address := &node.Status.Addresses[idx]
+		if address.Type != v1.NodeInternalIP {
+			continue
+		}
+
+		if ip := net.ParseIP(address.Address); ip != nil && ip.To4() == nil {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -16,10 +17,20 @@ import (
 var networkConnectionTypes = []string{asdbv1.ConfKeyNetworkService, asdbv1.ConfKeyNetworkHeartbeat,
 	asdbv1.ConfKeyNetworkFabric, asdbv1.ConfKeyNetworkAdmin}
 
+// confKeyAdvertiseIPv6 is the aerospikeConfig.service parameter that makes Aerospike
+// advertise its IPv6 address to mesh peers instead of its IPv4 address.
+const confKeyAdvertiseIPv6 = "advertise-ipv6"
+
 // ValidateAerospikeConfig validates the aerospikeConfig.
 // It validates the schema, service, network, logging and namespace configurations.
+// ipv6Capable reports whether the Kubernetes cluster has at least one IPv6-capable node.
+// It gates advertise-ipv6, which can only work where the pods have IPv6 addresses to advertise.
+// ipv6ProbeErr, when non-nil, is the reason node IPv6 capability could not be determined;
+// the advertise-ipv6 rejection then reports that failure instead of claiming no node is
+// IPv6-capable.
 func ValidateAerospikeConfig(
-	aslog logr.Logger, version string, config map[string]interface{}, clSize int,
+	aslog logr.Logger, version string, config map[string]interface{}, clSize int, ipv6Capable bool,
+	ipv6ProbeErr error,
 ) error {
 	if config == nil {
 		return fmt.Errorf("aerospikeConfig cannot be empty")
@@ -37,8 +48,8 @@ func ValidateAerospikeConfig(
 		)
 	}
 
-	if val, exists := serviceConf["advertise-ipv6"]; exists && val.(bool) {
-		return fmt.Errorf("advertise-ipv6 is not supported")
+	if err := validateAdvertiseIPv6(serviceConf, ipv6Capable, ipv6ProbeErr); err != nil {
+		return err
 	}
 
 	// TODO: Shouldn't be set by user, confirm this
@@ -651,6 +662,41 @@ func ValidateAerospikeConfigSchema(
 	return nil
 }
 
+// validateAdvertiseIPv6 rejects advertise-ipv6 on a cluster that cannot carry IPv6 traffic.
+// Aerospike needs it to form an IPv6 mesh, so it is only rejected where the pods would have
+// no IPv6 address to advertise to their peers. When ipv6ProbeErr is non-nil the capability
+// is unknown rather than absent, and the rejection reports the probe failure instead.
+func validateAdvertiseIPv6(serviceConf map[string]interface{}, ipv6Capable bool, ipv6ProbeErr error) error {
+	val, exists := serviceConf[confKeyAdvertiseIPv6]
+	if !exists {
+		return nil
+	}
+
+	advertiseIPv6, isBool := val.(bool)
+	if !isBool {
+		return fmt.Errorf(
+			"aerospikeConfig.service.%s must be a boolean, got %T (%v)", confKeyAdvertiseIPv6, val, val,
+		)
+	}
+
+	if advertiseIPv6 && !ipv6Capable {
+		if ipv6ProbeErr != nil {
+			return fmt.Errorf(
+				"aerospikeConfig.service.%s requires an IPv6-capable Kubernetes cluster, "+
+					"but node IPv6 capability could not be determined: %w",
+				confKeyAdvertiseIPv6, ipv6ProbeErr,
+			)
+		}
+
+		return errors.New(
+			"aerospikeConfig.service." + confKeyAdvertiseIPv6 + " requires an IPv6-capable Kubernetes cluster, " +
+				"but no Kubernetes node reports an IPv6 InternalIP address",
+		)
+	}
+
+	return nil
+}
+
 func isValueUpdated(m1, m2 map[string]interface{}, key string) bool {
 	val1, ok1 := m1[key]
 	val2, ok2 := m2[key]
@@ -667,11 +713,12 @@ func isValueUpdated(m1, m2 map[string]interface{}, key string) bool {
 // It also validates the update of tls, network and namespace configurations.
 func ValidateAerospikeConfigUpdate(
 	aslog logr.Logger, version string,
-	oldConfig, newConfig map[string]interface{}, clSize int,
+	oldConfig, newConfig map[string]interface{}, clSize int, ipv6Capable bool,
+	ipv6ProbeErr error,
 ) error {
 	aslog.Info("Validate AerospikeConfig update")
 
-	if err := ValidateAerospikeConfig(aslog, version, newConfig, clSize); err != nil {
+	if err := ValidateAerospikeConfig(aslog, version, newConfig, clSize, ipv6Capable, ipv6ProbeErr); err != nil {
 		return err
 	}
 

--- a/pkg/validation/validate_test.go
+++ b/pkg/validation/validate_test.go
@@ -1,0 +1,125 @@
+package validation
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestValidateAdvertiseIPv6(t *testing.T) {
+	testCases := []struct {
+		// advertiseIPv6 is the raw aerospikeConfig.service value; nil means the key is absent.
+		advertiseIPv6 interface{}
+		// ipv6ProbeErr is the reason node IPv6 capability could not be determined, if any.
+		ipv6ProbeErr error
+		name         string
+		errSubstring string
+		ipv6Capable  bool
+	}{
+		{
+			name:          "rejected when enabled and the cluster has no IPv6-capable node",
+			advertiseIPv6: true,
+			ipv6Capable:   false,
+			errSubstring:  "no Kubernetes node reports an IPv6 InternalIP address",
+		},
+		{
+			name:          "rejected with the probe failure when enabled and capability could not be determined",
+			advertiseIPv6: true,
+			ipv6Capable:   false,
+			ipv6ProbeErr:  errors.New("listing nodes: connection refused"),
+			errSubstring:  "node IPv6 capability could not be determined: listing nodes: connection refused",
+		},
+		{
+			name:          "allowed when disabled even though the probe failed",
+			advertiseIPv6: false,
+			ipv6Capable:   false,
+			ipv6ProbeErr:  errors.New("listing nodes: connection refused"),
+		},
+		{
+			name:          "allowed when absent even though the probe failed",
+			advertiseIPv6: nil,
+			ipv6Capable:   false,
+			ipv6ProbeErr:  errors.New("listing nodes: connection refused"),
+		},
+		{
+			name:          "allowed when enabled and the cluster has an IPv6-capable node",
+			advertiseIPv6: true,
+			ipv6Capable:   true,
+		},
+		{
+			name:          "allowed when disabled on a cluster with no IPv6-capable node",
+			advertiseIPv6: false,
+			ipv6Capable:   false,
+		},
+		{
+			name:          "allowed when disabled on an IPv6-capable cluster",
+			advertiseIPv6: false,
+			ipv6Capable:   true,
+		},
+		{
+			name:          "allowed when absent on a cluster with no IPv6-capable node",
+			advertiseIPv6: nil,
+			ipv6Capable:   false,
+		},
+		{
+			name:          "allowed when absent on an IPv6-capable cluster",
+			advertiseIPv6: nil,
+			ipv6Capable:   true,
+		},
+		{
+			name:          "rejected as invalid config when a string",
+			advertiseIPv6: "true",
+			ipv6Capable:   true,
+			errSubstring:  "advertise-ipv6 must be a boolean, got string (true)",
+		},
+		{
+			name:          "rejected as invalid config when a number",
+			advertiseIPv6: 1,
+			ipv6Capable:   false,
+			errSubstring:  "advertise-ipv6 must be a boolean, got int (1)",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			serviceConf := map[string]interface{}{"cluster-name": "test-cluster"}
+			if testCase.advertiseIPv6 != nil {
+				serviceConf[confKeyAdvertiseIPv6] = testCase.advertiseIPv6
+			}
+
+			err := validateAdvertiseIPv6(serviceConf, testCase.ipv6Capable, testCase.ipv6ProbeErr)
+
+			if testCase.errSubstring == "" {
+				if err != nil {
+					t.Fatalf("expected the config to be accepted, got error: %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected an error containing %q, got nil", testCase.errSubstring)
+			}
+
+			if !strings.Contains(err.Error(), testCase.errSubstring) {
+				t.Fatalf("expected an error containing %q, got: %v", testCase.errSubstring, err)
+			}
+		})
+	}
+}
+
+// TestValidateAerospikeConfigRejectsNilConfig covers the early return that the
+// advertise-ipv6 guard sits behind, and pins the ipv6Capable and ipv6ProbeErr
+// parameters into the exported signature.
+func TestValidateAerospikeConfigRejectsNilConfig(t *testing.T) {
+	err := ValidateAerospikeConfig(logf.Log, "8.1.2.0", nil, 1, true, nil)
+	if err == nil {
+		t.Fatal("expected a nil aerospikeConfig to be rejected")
+	}
+
+	if !strings.Contains(err.Error(), "aerospikeConfig cannot be empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/test/envtests/cluster/cluster_webhook_test.go
+++ b/test/envtests/cluster/cluster_webhook_test.go
@@ -26,6 +26,11 @@ import (
 var _ = Describe("AerospikeCluster validation", func() {
 	const (
 		clusterName = "invalid-cluster"
+
+		// ipv6ProbeNodeName is the node these specs seed to steer the webhook's node
+		// IPv6 capability check, and ipv6NodeInternalIP is a ULA address it advertises.
+		ipv6ProbeNodeName  = "envtests-ipv6-probe-node"
+		ipv6NodeInternalIP = "fd00::a"
 	)
 
 	ctx := context.TODO()
@@ -639,7 +644,12 @@ var _ = Describe("AerospikeCluster validation", func() {
 			})
 
 			Context("negative", func() {
-				It("rejects setting advertise-ipv6", func() {
+				It("rejects setting advertise-ipv6 when no node is IPv6-capable", func() {
+					// An IPv4-only node makes this a genuine capability check rather than
+					// a cluster that simply has no nodes.
+					createNodeWithInternalIP(ctx, ipv6ProbeNodeName, "10.101.0.10")
+					DeferCleanup(func() { deleteNode(ctx, ipv6ProbeNodeName) })
+
 					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 1)
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyService].(map[string]interface{})["advertise-ipv6"] = true
 
@@ -650,7 +660,31 @@ var _ = Describe("AerospikeCluster validation", func() {
 					// Webhook response validation
 					envtests.NewStatusErrorMatcher().
 						WithMessageSubstrings(testutil.WebhookErrorPrefix,
-							"advertise-ipv6 is not supported").
+							"advertise-ipv6 requires an IPv6-capable Kubernetes cluster",
+							"no Kubernetes node reports an IPv6 InternalIP address").
+						Validate(err)
+				})
+
+				// Schema validation runs before the advertise-ipv6 guard, so a non-boolean
+				// is reported as a schema error rather than reaching the guard's own type
+				// check. This spec pins that ordering; the guard's type check is covered by
+				// the unit tests in pkg/validation.
+				It("rejects a non-boolean advertise-ipv6 as a schema error", func() {
+					createNodeWithInternalIP(ctx, ipv6ProbeNodeName, ipv6NodeInternalIP)
+					DeferCleanup(func() { deleteNode(ctx, ipv6ProbeNodeName) })
+
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 1)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyService].(map[string]interface{})["advertise-ipv6"] = "true"
+
+					// Deploy cluster
+					err := envtests.K8sClient.Create(ctx, aeroCluster)
+					Expect(err).To(HaveOccurred())
+
+					// Webhook response validation
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(testutil.WebhookErrorPrefix,
+							"config schema error",
+							"(root).service.advertise-ipv6 Invalid type. Expected: boolean, given: string").
 						Validate(err)
 				})
 
@@ -733,6 +767,19 @@ var _ = Describe("AerospikeCluster validation", func() {
 				})
 			})
 			Context("positive", func() {
+				It("accepts setting advertise-ipv6 when a node is IPv6-capable", func() {
+					createNodeWithInternalIP(ctx, ipv6ProbeNodeName, ipv6NodeInternalIP)
+					DeferCleanup(func() { deleteNode(ctx, ipv6ProbeNodeName) })
+
+					// Size 2 satisfies the default replication-factor 2 of the dummy
+					// cluster, which the rejection specs never have to clear.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyService].(map[string]interface{})["advertise-ipv6"] = true
+
+					// Deploy cluster
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).ToNot(HaveOccurred())
+				})
+
 				It("does not warn when cgroup-mem-tracking is true "+
 					"(version >= "+testutil.CgroupMemTrackingServerVersion+")", func() {
 					aeroCluster := testCluster.CreateAerospikeClusterPost640(

--- a/test/envtests/cluster/cluster_webhook_utils.go
+++ b/test/envtests/cluster/cluster_webhook_utils.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -11,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/test"
@@ -172,6 +174,47 @@ func deleteCluster(ctx context.Context, nsName types.NamespacedName) {
 	}
 	// Delete the cluster after each test
 	Expect(testCluster.DeleteCluster(envtests.K8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+}
+
+// createNodeWithInternalIP creates a node whose only InternalIP is the given address.
+// The validating webhook reads node addresses to decide whether the cluster can carry
+// IPv6 traffic, so this is how a spec chooses which side of that check it exercises.
+func createNodeWithInternalIP(ctx context.Context, name, internalIP string) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	Expect(envtests.K8sClient.Create(ctx, node)).ToNot(HaveOccurred())
+
+	// Addresses live on the status subresource, so they need a second write.
+	node.Status.Addresses = []corev1.NodeAddress{
+		{
+			Type:    corev1.NodeInternalIP,
+			Address: internalIP,
+		},
+	}
+	Expect(envtests.K8sClient.Status().Update(ctx, node)).ToNot(HaveOccurred())
+
+	expireNodeIPv6Cache()
+}
+
+func deleteNode(ctx context.Context, name string) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	Expect(client.IgnoreNotFound(envtests.K8sClient.Delete(ctx, node))).ToNot(HaveOccurred())
+
+	expireNodeIPv6Cache()
+}
+
+// expireNodeIPv6Cache waits out the webhook's node IPv6 capability cache so the next
+// admission re-reads node addresses. Specs run serially, so nothing repopulates the
+// cache in the meantime.
+func expireNodeIPv6Cache() {
+	time.Sleep(3 * envtests.NodeIPv6CacheTTL)
 }
 
 func patchFirstPVStorageClassSpec(storage *asdbv1.AerospikeStorageSpec) {

--- a/test/envtests/envtest_support.go
+++ b/test/envtests/envtest_support.go
@@ -58,6 +58,10 @@ import (
 // K8sClient is the Kubernetes client for envtests. Exported for use by subpackages (e.g. envtests/cluster).
 // var K8sClient client.Client
 
+// NodeIPv6CacheTTL is the node IPv6 capability cache window used by the webhook under test.
+// Specs that seed or remove IPv6 nodes should poll for at least this long.
+const NodeIPv6CacheTTL = 100 * time.Millisecond
+
 // Package-level vars used by envtests and set by SetupTestEnv.
 var (
 	testEnv         *envtest.Environment
@@ -144,7 +148,11 @@ func SetupTestEnv() {
 	Expect(err).NotTo(HaveOccurred())
 
 	EvictionWebhook = evictionwebhook.SetupEvictionWebhookWithManager(mgr)
-	err = webhookv1.SetupAerospikeClusterWebhookWithManager(mgr)
+	// A short node IPv6 capability TTL lets specs seed or remove IPv6 nodes and observe
+	// the effect on admission without waiting out the production cache window.
+	err = webhookv1.SetupAerospikeClusterWebhookWithManager(
+		mgr, webhookv1.WithNodeIPv6CacheTTL(NodeIPv6CacheTTL),
+	)
 	Expect(err).NotTo(HaveOccurred())
 	err = webhookv1beta1.SetupAerospikeBackupServiceWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
#336 added validation that rejects `service.advertise-ipv6` outright. This PR narrows that check rather than reverting it: on a single-stack IPv6 cluster, `advertise-ipv6: true` is the only way Aerospike mesh heartbeats can form a multi-node cluster, so the webhook now rejects the setting only where it genuinely cannot work — when no Kubernetes node reports an IPv6 `InternalIP`.

**No behaviour change on IPv4-only clusters** — `advertise-ipv6` is still rejected there, with a message that now says why.

- The webhook probes nodes for an IPv6 `InternalIP`, caches the answer for five minutes, and pages with an early exit so admission never lists a large cluster in full. Reads go through `mgr.GetAPIReader()` rather than the manager cache — the pattern `internal/webhook/eviction/eviction_webhook.go` established in #413 — so no cluster-wide Node informer or watch permission is added.
- If the probe fails, the webhook fails closed: only `advertise-ipv6: true` is rejected (with the probe error in the message), never unrelated admissions.
- Reading nodes needs `get`/`list` on core `nodes`, added via a `+kubebuilder:rbac` marker. `config/rbac/role.yaml` and the chart clusterrole are updated together, as in #413/#340; no `Chart.yaml` bump.
- The unchecked `val.(bool)` assertion is replaced with the two-value form: the JSON schema rejects non-booleans first in webhook flow, but exported `ValidateAerospikeConfig` must not panic on bad input.

## Testing

- Unit tests (`pkg/validation`) cover the guard: enabled/disabled/absent × capable/incapable, both rejection messages (no IPv6 nodes vs. probe failure), and non-boolean values.
- Envtests (`test/envtests/cluster`) drive the real webhook against seeded nodes: rejection with only an IPv4 node present, acceptance with an IPv6 node, and schema-error precedence for non-boolean values. Suites pass under `ENVTEST_K8S_VERSION=1.23` and `1.35`.
- IPv4 control — admission message before/after on a v4-only cluster:

      # upstream: advertise-ipv6 is not supported
      # patched:  aerospikeConfig.service.advertise-ipv6 requires an IPv6-capable Kubernetes
      #           cluster, but no Kubernetes node reports an IPv6 InternalIP address

- IPv6 validation: healthy 3-node RF=2 formation on a single-stack IPv6 EKS cluster (Aerospike server 8.1.1.0 Enterprise, real feature key), surviving single-pod deletion, operator-driven rolling restarts, scale 3→4→3 with quiesce, and eviction-API handling. Full lifecycle logs available on request.

Fixes #585
