### PR TITLE
bugfix: skipping unnecessary volume mounts from aerospike init container. [KO-618]

### DIFF
--- a/config/manifests/bases/aerospike-kubernetes-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/aerospike-kubernetes-operator.clusterserviceversion.yaml
@@ -128,8 +128,8 @@ spec:
         displayName: Headless Service
         path: headlessService
       - description: |-
-          IgnoreSidecarFailure controls whether reconciliation is blocked when a sidecar
-          container is failing but the Aerospike server container is still running.
+          IgnoreSidecarFailure controls whether cluster operations are blocked when a
+          sidecar container is failing but the Aerospike server container is still running.
         displayName: Ignore Sidecar Failure
         path: ignoreSidecarFailure
       - description: Aerospike server image

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -1579,19 +1579,18 @@ func (r *SingleClusterReconciler) isRackStorageUpdatedInAeroCluster(
 	}
 
 	// Check for removed volumeAttachments
-	allConfiguredInitContainers := []string{
-		asdbv1.
-			AerospikeInitContainerName,
-	}
 	allConfiguredContainers := []string{asdbv1.AerospikeServerContainerName}
 
 	for idx := range r.aeroCluster.Spec.PodSpec.Sidecars {
 		allConfiguredContainers = append(allConfiguredContainers, r.aeroCluster.Spec.PodSpec.Sidecars[idx].Name)
 	}
 
-	// Include InitContainers (excluding placeholder)
+	// Collect user-defined init containers. The aerospike-init container is intentionally
+	// excluded because isVolumeAttachmentRemoved skips it unconditionally — its volume
+	// mounts are not individually tracked in storage spec.
+	var allConfiguredInitContainers []string
+
 	for idx := range r.aeroCluster.Spec.PodSpec.InitContainers {
-		// Skip placeholder (aerospike-init) as it's not a real container in the spec
 		if r.aeroCluster.Spec.PodSpec.InitContainers[idx].Name != asdbv1.AerospikeInitContainerName {
 			allConfiguredInitContainers = append(
 				allConfiguredInitContainers, r.aeroCluster.Spec.PodSpec.InitContainers[idx].Name,
@@ -1791,12 +1790,11 @@ func (r *SingleClusterReconciler) isVolumeAttachmentRemoved(
 	// TODO: Deal with injected volumes later.
 	for idx := range podContainers {
 		container := &podContainers[idx]
-		if isInitContainers && container.Name == asdbv1.AerospikeInitContainerName {
-			// InitContainer has all the volumes mounted, there is no specific entry in storage for initContainer
-			continue
-		}
 
-		// Skip injected containers.
+		// Skip containers not owned by the operator (injected sidecars, etc.).
+		// Note: for init containers, aerospike-init is intentionally absent from
+		// configuredContainers — its volume mounts are operator-managed and not
+		// individually tracked in the storage spec.
 		if !utils.ContainsString(configuredContainers, container.Name) {
 			continue
 		}

--- a/internal/controller/cluster/rack.go
+++ b/internal/controller/cluster/rack.go
@@ -1620,8 +1620,8 @@ func (r *SingleClusterReconciler) isRackStorageUpdatedInAeroCluster(
 	}
 
 	// Collect user-defined init containers. The aerospike-init container is intentionally
-	// excluded because isVolumeAttachmentRemoved skips it unconditionally — its volume
-	// mounts are not individually tracked in storage spec.
+	// excluded here so that isVolumeAttachmentRemoved never inspects its volume mounts —
+	// those mounts are operator-managed and are not individually tracked in the storage spec.
 	var allConfiguredInitContainers []string
 
 	for idx := range r.aeroCluster.Spec.PodSpec.InitContainers {

--- a/internal/controller/cluster/rack_test.go
+++ b/internal/controller/cluster/rack_test.go
@@ -347,3 +347,163 @@ func TestCreateEmptyRack_DeletesSTSWhenReadinessFails(t *testing.T) {
 	err := r.Get(context.TODO(), types.NamespacedName{Name: "test-cluster-1", Namespace: "test-ns"}, &appsv1.StatefulSet{})
 	require.Error(t, err, "the StatefulSet created by createSTS should have been deleted by the cleanup path")
 }
+
+// TestIsVolumeAttachmentRemoved validates the volume-attachment-removed detection used by
+// isRackStorageUpdatedInAeroCluster. Key invariants after the allConfiguredInitContainers
+// refactor:
+//
+//  1. The aerospike-init container is never in configuredContainers, so its volume mounts
+//     are always skipped — no rolling restart is triggered by init-container mount changes.
+//  2. User-defined init containers ARE in configuredContainers; removing a volume from their
+//     mounts does trigger a rolling restart.
+//  3. Injected init containers (not in configuredContainers) are always skipped.
+func TestIsVolumeAttachmentRemoved(t *testing.T) {
+	newReconciler := func(ac *asdbv1.AerospikeCluster) *SingleClusterReconciler {
+		return newTestReconciler(t, ac, &interceptor.Funcs{})
+	}
+
+	newAC := func() *asdbv1.AerospikeCluster {
+		return newTestAerospikeCluster(namespace, clusterName)
+	}
+
+	pvVolumeSpec := func(name string) asdbv1.VolumeSpec {
+		return asdbv1.VolumeSpec{
+			Name: name,
+			Source: asdbv1.VolumeSource{
+				PersistentVolume: &asdbv1.PersistentVolumeSpec{
+					VolumeMode: corev1.PersistentVolumeFilesystem,
+				},
+			},
+			Aerospike: &asdbv1.AerospikeServerVolumeAttachment{Path: "/opt/aerospike/" + name},
+		}
+	}
+
+	cmVolumeSpec := func(name string) asdbv1.VolumeSpec {
+		return asdbv1.VolumeSpec{
+			Name:   name,
+			Source: asdbv1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}},
+		}
+	}
+
+	t.Run("aerospike-init container mounts are never flagged as removed", func(t *testing.T) {
+		// A pod whose aerospike-init container has a volume mount for "data-vol".
+		// Even though "data-vol" is absent from allConfiguredInitContainers, the
+		// aerospike-init container itself is not in configuredContainers so it is
+		// skipped entirely.
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: asdbv1.AerospikeInitContainerName,
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "data-vol", MountPath: "/workdir/filesystem-volumes/data-vol"},
+						},
+					},
+				},
+			},
+		}
+
+		r := newReconciler(newAC())
+
+		// configuredContainers does NOT contain aerospike-init (post-refactor).
+		removed := r.isVolumeAttachmentRemoved(
+			[]asdbv1.VolumeSpec{pvVolumeSpec("data-vol")},
+			nil,
+			[]string{},
+			pod.Spec.InitContainers,
+			true,
+		)
+
+		require.False(t, removed,
+			"aerospike-init mounts must never trigger a rolling restart — the container is not in configuredContainers")
+	})
+
+	t.Run("user-defined init container volume present in storage — no restart", func(t *testing.T) {
+		const customInit = "my-custom-init"
+
+		vol := cmVolumeSpec("cfg-vol")
+		vol.InitContainers = []asdbv1.VolumeAttachment{
+			{ContainerName: customInit, Path: "/cfg"},
+		}
+
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:         customInit,
+						VolumeMounts: []corev1.VolumeMount{{Name: "cfg-vol", MountPath: "/cfg"}},
+					},
+				},
+			},
+		}
+
+		r := newReconciler(newAC())
+
+		removed := r.isVolumeAttachmentRemoved(
+			[]asdbv1.VolumeSpec{vol},
+			nil,
+			[]string{customInit},
+			pod.Spec.InitContainers,
+			true,
+		)
+
+		require.False(t, removed, "volume still present in storage must not trigger a rolling restart")
+	})
+
+	t.Run("user-defined init container volume removed from storage — rolling restart triggered", func(t *testing.T) {
+		const customInit = "my-custom-init"
+
+		// Pod still has cfg-vol mounted, but storage no longer lists it.
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:         customInit,
+						VolumeMounts: []corev1.VolumeMount{{Name: "cfg-vol", MountPath: "/cfg"}},
+					},
+				},
+			},
+		}
+
+		r := newReconciler(newAC())
+
+		// rackStatusVolumes contains cfg-vol so the operator knows it was previously managed.
+		removed := r.isVolumeAttachmentRemoved(
+			[]asdbv1.VolumeSpec{},
+			[]asdbv1.VolumeSpec{cmVolumeSpec("cfg-vol")},
+			[]string{customInit},
+			pod.Spec.InitContainers,
+			true,
+		)
+
+		require.True(t, removed,
+			"volume removed from storage while still mounted in a user-defined init container must trigger a rolling restart")
+	})
+
+	t.Run("injected init container is always skipped — no restart", func(t *testing.T) {
+		// An injected container (e.g. Istio) mounts a volume not in storage.
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:         "istio-init",
+						VolumeMounts: []corev1.VolumeMount{{Name: "injected-vol", MountPath: "/etc/istio"}},
+					},
+				},
+			},
+		}
+
+		r := newReconciler(newAC())
+
+		// configuredContainers does not include "istio-init".
+		removed := r.isVolumeAttachmentRemoved(
+			[]asdbv1.VolumeSpec{},
+			nil,
+			[]string{},
+			pod.Spec.InitContainers,
+			true,
+		)
+
+		require.False(t, removed, "injected init container mounts must never trigger a rolling restart")
+	})
+}

--- a/internal/controller/cluster/statefulset.go
+++ b/internal/controller/cluster/statefulset.go
@@ -1613,7 +1613,7 @@ func getFinalVolumeAttachmentsForVolume(volume *asdbv1.VolumeSpec, workDirPath s
 	// Create dummy attachment for initContainer
 	initVolumePath := "/" + volume.Name // Using volume name for initContainer
 
-	// All volumes should be mounted in init container to allow initialization
+	// User-specified init container attachments are always honoured.
 	initContainerAttachments = append(
 		initContainerAttachments, volume.InitContainers...,
 	)
@@ -1654,9 +1654,18 @@ func getFinalVolumeAttachmentsForVolume(volume *asdbv1.VolumeSpec, workDirPath s
 		}
 	}
 
-	initContainerAttachments = append(
-		initContainerAttachments, aerosikeInitContainerAttachment,
-	)
+	// Auto-mount in the init container only for volumes it actually needs to access:
+	// - PersistentVolumes: the init container must wipe/initialize them before ASD starts.
+	// - Volumes with an Aerospike attachment: the init container sets up the workdir (smd,
+	//   usr/udf/lua) under them.
+	// Non-PV volumes that are not used by Aerospike (e.g. ConfigMap/Secret sidecars) have
+	// no role in the init container and are skipped; they remain accessible via the explicit
+	// volume.InitContainers field if a user ever needs them there.
+	if volume.Source.PersistentVolume != nil || volume.Aerospike != nil {
+		initContainerAttachments = append(
+			initContainerAttachments, aerosikeInitContainerAttachment,
+		)
+	}
 
 	return initContainerAttachments, containerAttachments
 }

--- a/internal/controller/cluster/statefulset_test.go
+++ b/internal/controller/cluster/statefulset_test.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 )
 
 func replicaCount(n int32) *int32 { return &n }
@@ -112,5 +115,179 @@ func TestWaitForSTSPodsServerReady(t *testing.T) {
 		if err := r.waitForSTSPodsServerReady(context.Background(), multiSTS, ignorable); err != nil {
 			t.Errorf("expected nil when running pod + ignorable pod, got: %v", err)
 		}
+	})
+}
+
+// TestGetFinalVolumeAttachmentsForVolume validates the selective init-container
+// auto-mount logic introduced to avoid mounting irrelevant volumes (ConfigMap,
+// Secret, EmptyDir without an Aerospike path) in the aerospike-init container.
+//
+// Rules under test:
+//   - PV volumes (block or filesystem) are always auto-mounted in the init container.
+//   - Non-PV volumes with an Aerospike attachment are auto-mounted (the init container
+//     needs them to set up the workdir).
+//   - Non-PV volumes without an Aerospike attachment are NOT auto-mounted; the init
+//     container has no code that touches them.
+//   - Explicit volume.InitContainers entries are always honoured regardless of the
+//     above rules.
+func TestGetFinalVolumeAttachmentsForVolume(t *testing.T) {
+	const workDir = "/opt/aerospike"
+
+	// hasInitContainerAutoMount returns true when the returned initContainerAttachments
+	// contains the automatic aerospike-init attachment (identified by ContainerName).
+	hasInitContainerAutoMount := func(attachments []asdbv1.VolumeAttachment) bool {
+		for _, a := range attachments {
+			if a.ContainerName == asdbv1.AerospikeInitContainerName {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	t.Run("PV block volume is auto-mounted in init container", func(t *testing.T) {
+		vol := &asdbv1.VolumeSpec{
+			Name: "block-vol",
+			Source: asdbv1.VolumeSource{
+				PersistentVolume: &asdbv1.PersistentVolumeSpec{
+					VolumeMode: corev1.PersistentVolumeBlock,
+				},
+			},
+		}
+
+		initAttachments, _ := getFinalVolumeAttachmentsForVolume(vol, workDir)
+
+		assert.True(t, hasInitContainerAutoMount(initAttachments),
+			"PV block volume must be auto-mounted in the init container for wiping")
+	})
+
+	t.Run("PV filesystem volume is auto-mounted in init container", func(t *testing.T) {
+		vol := &asdbv1.VolumeSpec{
+			Name: "fs-vol",
+			Source: asdbv1.VolumeSource{
+				PersistentVolume: &asdbv1.PersistentVolumeSpec{
+					VolumeMode: corev1.PersistentVolumeFilesystem,
+				},
+			},
+		}
+
+		initAttachments, _ := getFinalVolumeAttachmentsForVolume(vol, workDir)
+
+		assert.True(t, hasInitContainerAutoMount(initAttachments),
+			"PV filesystem volume must be auto-mounted in the init container for initialization")
+	})
+
+	t.Run("non-PV volume with Aerospike attachment is auto-mounted in init container", func(t *testing.T) {
+		vol := &asdbv1.VolumeSpec{
+			Name: "hostpath-workdir",
+			Source: asdbv1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: "/mnt/data"},
+			},
+			Aerospike: &asdbv1.AerospikeServerVolumeAttachment{
+				Path: "/opt/aerospike/data",
+			},
+		}
+
+		initAttachments, _ := getFinalVolumeAttachmentsForVolume(vol, workDir)
+
+		assert.True(t, hasInitContainerAutoMount(initAttachments),
+			"non-PV volume used by Aerospike must be auto-mounted so the init container can set up the workdir")
+	})
+
+	t.Run("ConfigMap volume without Aerospike attachment is NOT auto-mounted in init container", func(t *testing.T) {
+		vol := &asdbv1.VolumeSpec{
+			Name: "sidecar-config",
+			Source: asdbv1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"},
+				},
+			},
+		}
+
+		initAttachments, _ := getFinalVolumeAttachmentsForVolume(vol, workDir)
+
+		assert.False(t, hasInitContainerAutoMount(initAttachments),
+			"ConfigMap volume not used by Aerospike must not be auto-mounted in the init container")
+	})
+
+	t.Run("Secret volume without Aerospike attachment is NOT auto-mounted in init container", func(t *testing.T) {
+		vol := &asdbv1.VolumeSpec{
+			Name: "sidecar-secret",
+			Source: asdbv1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: "my-secret"},
+			},
+		}
+
+		initAttachments, _ := getFinalVolumeAttachmentsForVolume(vol, workDir)
+
+		assert.False(t, hasInitContainerAutoMount(initAttachments),
+			"Secret volume not used by Aerospike must not be auto-mounted in the init container")
+	})
+
+	t.Run("EmptyDir volume without Aerospike attachment is NOT auto-mounted in init container", func(t *testing.T) {
+		vol := &asdbv1.VolumeSpec{
+			Name:   "scratch",
+			Source: asdbv1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		}
+
+		initAttachments, _ := getFinalVolumeAttachmentsForVolume(vol, workDir)
+
+		assert.False(t, hasInitContainerAutoMount(initAttachments),
+			"EmptyDir volume not used by Aerospike must not be auto-mounted in the init container")
+	})
+
+	t.Run("explicit volume.InitContainers entries are always honoured", func(t *testing.T) {
+		const customInitContainer = "my-custom-init"
+
+		vol := &asdbv1.VolumeSpec{
+			Name:   "sidecar-config",
+			Source: asdbv1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}},
+			InitContainers: []asdbv1.VolumeAttachment{
+				{ContainerName: customInitContainer, Path: "/custom/path"},
+			},
+		}
+
+		initAttachments, _ := getFinalVolumeAttachmentsForVolume(vol, workDir)
+
+		// The aerospike-init auto-mount must be absent, but the explicit user entry must be present.
+		assert.False(t, hasInitContainerAutoMount(initAttachments),
+			"aerospike-init auto-mount must not appear for a non-PV, non-Aerospike volume")
+
+		found := false
+
+		for _, a := range initAttachments {
+			if a.ContainerName == customInitContainer {
+				found = true
+				break
+			}
+		}
+
+		assert.True(t, found, "explicit volume.InitContainers entry must always be included")
+	})
+
+	t.Run("auto-mount path uses volume name as path segment", func(t *testing.T) {
+		const volName = "my-pv"
+
+		vol := &asdbv1.VolumeSpec{
+			Name: volName,
+			Source: asdbv1.VolumeSource{
+				PersistentVolume: &asdbv1.PersistentVolumeSpec{
+					VolumeMode: corev1.PersistentVolumeFilesystem,
+				},
+			},
+		}
+
+		initAttachments, _ := getFinalVolumeAttachmentsForVolume(vol, workDir)
+
+		for _, a := range initAttachments {
+			if a.ContainerName == asdbv1.AerospikeInitContainerName {
+				assert.Equal(t, "/"+volName, a.Path,
+					"auto-mount path must be /<volumeName>")
+
+				return
+			}
+		}
+
+		t.Fatal("aerospike-init auto-mount attachment not found")
 	})
 }

--- a/test/cluster/cluster_helper.go
+++ b/test/cluster/cluster_helper.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	goctx "context"
+	"crypto/rand"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -1787,6 +1788,59 @@ func WriteDataToCluster(
 			return err
 		}
 	}
+
+	return nil
+}
+
+// LoadBulkDataInCluster writes numKeys records of ~10 KB each into the given
+// Aerospike namespace. Use this in tests that need real data present so that
+// a scale-down (or restart) triggers actual partition migrations.
+func LoadBulkDataInCluster(
+	aeroCluster *asdbv1.AerospikeCluster,
+	k8sClient client.Client,
+	namespace string,
+	numKeys int,
+) error {
+	asClient, err := getAerospikeClient(aeroCluster, k8sClient)
+	if err != nil {
+		return err
+	}
+
+	defer asClient.Close()
+
+	pkgLog.Info("Loading bulk data", "nodes", asClient.GetNodeNames(), "namespace", namespace, "numKeys", numKeys)
+
+	const binSize = 10_000 // ~10 KB per record
+
+	token := make([]byte, binSize)
+	if _, err = rand.Read(token); err != nil {
+		return fmt.Errorf("generate random payload: %w", err)
+	}
+
+	wp := as.NewWritePolicy(0, 0)
+	binMap := as.BinMap{"testbin": token}
+
+	for i := 0; i < numKeys; i++ {
+		key, keyErr := as.NewKey(namespace, "testset", "testkey"+strconv.Itoa(i))
+		if keyErr != nil {
+			return fmt.Errorf("create key %d: %w", i, keyErr)
+		}
+
+		// Retry briefly in case a service endpoint is still warming up.
+		for j := 0; j < 10; j++ {
+			if err = asClient.Put(wp, key, binMap); err == nil {
+				break
+			}
+
+			time.Sleep(time.Second)
+		}
+
+		if err != nil {
+			return fmt.Errorf("put key %d after retries: %w", i, err)
+		}
+	}
+
+	pkgLog.Info("Bulk data load complete", "namespace", namespace, "numKeys", numKeys)
 
 	return nil
 }

--- a/test/cluster/cluster_test.go
+++ b/test/cluster/cluster_test.go
@@ -599,6 +599,12 @@ func ScaleDownWithMigrateFillDelay(ctx goctx.Context) {
 					aeroCluster.Spec.AerospikeConfig.Value[asdbv1.ConfKeyService].(map[string]interface{})["migrate-fill-delay"] =
 						migrateFillDelay
 					Expect(DeployCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
+
+					// Load data so that scale-down triggers real migrations.
+					// Without data the migrate-fill-delay behaviour is a no-op.
+					aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(LoadBulkDataInCluster(aeroCluster, k8sClient, "test", 1000)).ToNot(HaveOccurred())
 				},
 			)
 
@@ -639,8 +645,9 @@ func ScaleDownWithMigrateFillDelay(ctx goctx.Context) {
 					// verify that migrate-fill-delay is set to 0 while scaling down
 					secondPodName := aeroCluster.Name + "-" + strconv.Itoa(aeroCluster.Spec.RackConfig.Racks[0].ID) + "-1"
 
+					retryInt := time.Second * 10
 					err = validateMigrateFillDelay(ctx, k8sClient, logger, clusterNamespacedName, 0,
-						nil, secondPodName)
+						&retryInt, secondPodName)
 					Expect(err).ToNot(HaveOccurred())
 
 					err = waitForAerospikeCluster(

--- a/test/cluster/large_reconcile_test.go
+++ b/test/cluster/large_reconcile_test.go
@@ -2,9 +2,7 @@ package cluster
 
 import (
 	goctx "context"
-	"crypto/rand"
 	"fmt"
-	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	as "github.com/aerospike/aerospike-client-go/v8"
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/test"
 )
@@ -199,65 +196,7 @@ var _ = Describe(
 func loadDataInCluster(
 	k8sClient client.Client, aeroCluster *asdbv1.AerospikeCluster,
 ) error {
-	asClient, err := getAerospikeClient(aeroCluster, k8sClient)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		fmt.Println("Closing Aerospike client")
-		asClient.Close()
-	}()
-
-	keyPrefix := "testkey"
-
-	size := 100
-	bufferSize := 10000
-	token := make([]byte, bufferSize)
-
-	_, readErr := rand.Read(token)
-	if readErr != nil {
-		return readErr
-	}
-
-	pkgLog.Info(
-		"Loading record", "nodes", asClient.GetNodeNames(),
-	)
-
-	// The k8s services take time to come up so the timeouts are on the
-	// higher side.
-	wp := as.NewWritePolicy(0, 0)
-
-	// loads size * bufferSize data
-	for i := 0; i < size; i++ {
-		key, err := as.NewKey("test", "testset", keyPrefix+strconv.Itoa(i))
-		if err != nil {
-			return err
-		}
-
-		binMap := map[string]interface{}{
-			"testbin": token,
-		}
-
-		for j := 0; j < 1000; j++ {
-			err = asClient.Put(wp, key, binMap)
-			if err == nil {
-				break
-			}
-
-			time.Sleep(time.Second * 1)
-		}
-
-		if err != nil {
-			return err
-		}
-
-		fmt.Print(strconv.Itoa(i) + ", ")
-	}
-
-	fmt.Println("added records")
-
-	return nil
+	return LoadBulkDataInCluster(aeroCluster, k8sClient, "test", 100)
 }
 
 func waitForClusterScaleDown(

--- a/test/cluster/statefulset_storage_test.go
+++ b/test/cluster/statefulset_storage_test.go
@@ -229,6 +229,19 @@ var _ = Describe(
 							BeTrue(), "Unable to find volume",
 						)
 
+						// Non-PV volumes with an Aerospike attachment must be auto-mounted in
+						// the aerospike-init container (it needs them to set up the workdir).
+						updatedSTS, err := getSTSFromRackID(aeroCluster, 0, "")
+						Expect(err).ToNot(HaveOccurred())
+
+						aerospikeInitContainer = test.GetContainerByName(
+							updatedSTS.Spec.Template.Spec.InitContainers, asdbv1.AerospikeInitContainerName,
+						)
+						Expect(aerospikeInitContainer).NotTo(BeNil(), "aerospike-init container not found in STS")
+						Expect(aerospikeInitContainer.VolumeMounts).To(ContainElement(
+							HaveField("Name", "newvolume"),
+						), "non-PV volume with Aerospike attachment must be auto-mounted in the aerospike-init container")
+
 						// Delete
 						newAeroCluster := createNonSCDummyAerospikeCluster(
 							clusterNamespacedName, 2,
@@ -383,6 +396,63 @@ var _ = Describe(
 						Expect(isPresent).To(
 							BeTrue(), "Unable to find volume",
 						)
+					},
+				)
+
+				It(
+					"Should not mount non-PV sidecar-only volumes in the aerospike-init container", func() {
+						// Non-PV volumes that are only attached to sidecars (no aerospike path)
+						// must NOT appear in the aerospike-init container's VolumeMounts.
+						// The init container has no code that touches these volumes.
+						aeroCluster, err := getCluster(k8sClient, ctx, clusterNamespacedName)
+						Expect(err).ToNot(HaveOccurred())
+
+						sidecar := v1.Container{
+							Name:    "sidecar-consumer",
+							Image:   "busybox:1.28",
+							Command: []string{"sh", "-c", "sleep 3600"},
+						}
+						aeroCluster.Spec.PodSpec.Sidecars = append(
+							aeroCluster.Spec.PodSpec.Sidecars, sidecar,
+						)
+
+						// EmptyDir volume mounted only in the sidecar — no Aerospike attachment.
+						sidecarOnlyVol := asdbv1.VolumeSpec{
+							Name:   "sidecar-config",
+							Source: asdbv1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+							Sidecars: []asdbv1.VolumeAttachment{
+								{ContainerName: "sidecar-consumer", Path: "/config"},
+							},
+						}
+						aeroCluster.Spec.Storage.Volumes = append(
+							aeroCluster.Spec.Storage.Volumes, sidecarOnlyVol,
+						)
+
+						err = updateCluster(k8sClient, ctx, aeroCluster)
+						Expect(err).ToNot(HaveOccurred())
+
+						sts, err := getSTSFromRackID(aeroCluster, 0, "")
+						Expect(err).ToNot(HaveOccurred())
+
+						aerospikeInitContainer := test.GetContainerByName(
+							sts.Spec.Template.Spec.InitContainers, asdbv1.AerospikeInitContainerName,
+						)
+						Expect(aerospikeInitContainer).NotTo(BeNil(), "aerospike-init container not found in STS")
+
+						for _, vm := range aerospikeInitContainer.VolumeMounts {
+							Expect(vm.Name).NotTo(Equal("sidecar-config"),
+								"non-PV sidecar-only volume must not be auto-mounted in the aerospike-init container")
+						}
+
+						// The sidecar container must still have it mounted.
+						sidecarContainer := test.GetContainerByName(
+							sts.Spec.Template.Spec.Containers, "sidecar-consumer",
+						)
+						Expect(sidecarContainer).NotTo(BeNil(), "sidecar-consumer container not found in STS")
+
+						Expect(sidecarContainer.VolumeMounts).To(ContainElement(
+							HaveField("Name", "sidecar-config"),
+						), "sidecar-only volume must be mounted in the sidecar container")
 					},
 				)
 			},

--- a/test/cluster/statefulset_storage_test.go
+++ b/test/cluster/statefulset_storage_test.go
@@ -428,6 +428,8 @@ var _ = Describe(
 						// HostPath volume mounted only in the sidecar — no Aerospike attachment.
 						// This specifically covers the KO-618 bug where HostPath volumes were
 						// unconditionally mounted in the aerospike-init container.
+						// ReadOnly is required for HostPath volumes by the webhook.
+						readOnly := true
 						sidecarOnlyHostPathVol := asdbv1.VolumeSpec{
 							Name: "sidecar-hostpath",
 							Source: asdbv1.VolumeSource{
@@ -436,7 +438,15 @@ var _ = Describe(
 								},
 							},
 							Sidecars: []asdbv1.VolumeAttachment{
-								{ContainerName: "sidecar-consumer", Path: "/hostdata"},
+								{
+									ContainerName: "sidecar-consumer",
+									Path:          "/hostdata",
+									AttachmentOptions: asdbv1.AttachmentOptions{
+										MountOptions: asdbv1.MountOptions{
+											ReadOnly: &readOnly,
+										},
+									},
+								},
 							},
 						}
 

--- a/test/cluster/statefulset_storage_test.go
+++ b/test/cluster/statefulset_storage_test.go
@@ -424,8 +424,24 @@ var _ = Describe(
 								{ContainerName: "sidecar-consumer", Path: "/config"},
 							},
 						}
+
+						// HostPath volume mounted only in the sidecar — no Aerospike attachment.
+						// This specifically covers the KO-618 bug where HostPath volumes were
+						// unconditionally mounted in the aerospike-init container.
+						sidecarOnlyHostPathVol := asdbv1.VolumeSpec{
+							Name: "sidecar-hostpath",
+							Source: asdbv1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/tmp/sidecar-data",
+								},
+							},
+							Sidecars: []asdbv1.VolumeAttachment{
+								{ContainerName: "sidecar-consumer", Path: "/hostdata"},
+							},
+						}
+
 						aeroCluster.Spec.Storage.Volumes = append(
-							aeroCluster.Spec.Storage.Volumes, sidecarOnlyVol,
+							aeroCluster.Spec.Storage.Volumes, sidecarOnlyVol, sidecarOnlyHostPathVol,
 						)
 
 						err = updateCluster(k8sClient, ctx, aeroCluster)
@@ -441,10 +457,12 @@ var _ = Describe(
 
 						for _, vm := range aerospikeInitContainer.VolumeMounts {
 							Expect(vm.Name).NotTo(Equal("sidecar-config"),
-								"non-PV sidecar-only volume must not be auto-mounted in the aerospike-init container")
+								"non-PV EmptyDir sidecar-only volume must not be auto-mounted in the aerospike-init container")
+							Expect(vm.Name).NotTo(Equal("sidecar-hostpath"),
+								"non-PV HostPath sidecar-only volume must not be auto-mounted in the aerospike-init container")
 						}
 
-						// The sidecar container must still have it mounted.
+						// The sidecar container must still have both volumes mounted.
 						sidecarContainer := test.GetContainerByName(
 							sts.Spec.Template.Spec.Containers, "sidecar-consumer",
 						)
@@ -452,7 +470,11 @@ var _ = Describe(
 
 						Expect(sidecarContainer.VolumeMounts).To(ContainElement(
 							HaveField("Name", "sidecar-config"),
-						), "sidecar-only volume must be mounted in the sidecar container")
+						), "EmptyDir sidecar-only volume must be mounted in the sidecar container")
+
+						Expect(sidecarContainer.VolumeMounts).To(ContainElement(
+							HaveField("Name", "sidecar-hostpath"),
+						), "HostPath sidecar-only volume must be mounted in the sidecar container")
 					},
 				)
 			},


### PR DESCRIPTION
Summary
Problem: The aerospike-init container was unconditionally mounting every storage volume defined in the AerospikeCluster CR — including non-PV volumes (ConfigMap, Secret, EmptyDir, HostPath) that are only attached to sidecars and have no aerospike path. The init container has no code that touches these volumes (initVolumes, wipeVolumes, cleanDirtyVolumes all call getPersistentVolumes() first, filtering to PV-only). These mounts were dead weight.

Fix: getFinalVolumeAttachmentsForVolume in statefulset.go now auto-mounts a volume in the init container only when the init container actually needs it:

PersistentVolumes — must be mounted for wipe/initialization before ASD starts.
Non-PV volumes with an aerospike attachment — must be mounted so the init container can set up the workdir (smd, usr/udf/lua).
Non-PV volumes without an aerospike attachment (e.g. ConfigMap/Secret used only by sidecars) — skipped. 

Backward Compatibility & Upgrade Impact:

1. No rolling restart triggered on operator upgrade. The STS uses OnDeleteStatefulSetStrategyType, so Kubernetes never auto-restarts pods on template changes. The operator's own restart detection (isRackStorageUpdatedInAeroCluster) explicitly skips the aerospike-init container, and podSpecHash covers only user-facing CR spec fields — neither fires from this change.
2. Pods pick up the slimmer init container template only on their next natural recreation (image upgrade, config change, etc.).