### PR TITLE
fix(test): wait for handovers to settle before failing pods [KO-627]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ testbin/*
 test/config
 test/junit.xml
 
+# Ginkgo junit reports (test/test-results/junit-*.xml)
+test/test-results/
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/test/cluster/cluster_helper.go
+++ b/test/cluster/cluster_helper.go
@@ -780,6 +780,11 @@ func DeleteCluster(
 			k8sClient, ctx, clusterNamespacedName,
 		)
 		if err != nil {
+			if isRetriableAPIError(err) {
+				time.Sleep(time.Second)
+				continue
+			}
+
 			return err
 		}
 		// Pods still may exist in terminating state for some time even if CR is deleted. Keeping them breaks some
@@ -788,6 +793,11 @@ func DeleteCluster(
 			k8sClient, ctx, aeroCluster,
 		)
 		if err != nil {
+			if isRetriableAPIError(err) {
+				time.Sleep(time.Second)
+				continue
+			}
+
 			return err
 		}
 
@@ -802,6 +812,11 @@ func DeleteCluster(
 	for {
 		newPVCList, err := getAeroClusterPVCList(aeroCluster, k8sClient)
 		if err != nil {
+			if isRetriableAPIError(err) {
+				time.Sleep(time.Second)
+				continue
+			}
+
 			return fmt.Errorf("error getting PVCs: %v", err)
 		}
 

--- a/test/cluster/cluster_test.go
+++ b/test/cluster/cluster_test.go
@@ -1243,7 +1243,7 @@ func clusterWithMaxIgnorablePod(ctx goctx.Context) {
 				aeroCluster.Spec.RackConfig.MaxIgnorablePods = &maxIgnorable
 				aeroCluster.Spec.Size--
 
-				Expect(k8sClient.Update(ctx, aeroCluster)).ToNot(HaveOccurred())
+				Expect(updateClusterWithNoWait(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
 
 				assertScaleDownBlocked(ctx, clusterNamespacedName, specSizeBeforeScaleDown, statusSizeBeforeScaleDown,
 					podCountBeforeScaleDown, 2*time.Minute, 1, victim)

--- a/test/cluster/cluster_test.go
+++ b/test/cluster/cluster_test.go
@@ -1020,6 +1020,29 @@ func clusterWithMaxIgnorablePod(ctx goctx.Context) {
 					)
 					Expect(err).ToNot(HaveOccurred())
 
+					By("Waiting for post-scale-up handovers to settle before failing pods")
+
+					// scaleUpClusterTest returns as soon as the CR reports Completed,
+					// which the operator stamps in the same reconcile that expands the
+					// roster - partition handovers are still in flight for a few seconds
+					// after that. Failing two pods inside that window leaves affected
+					// partitions with no trusted copy and, with replication-factor 2, no
+					// permission to promote a subset, so the roster step fails and
+					// recoverIgnorablePods is never reached.
+					migrationsInProgress := func() int {
+						cluster, gErr := getCluster(k8sClient, ctx, clusterNamespacedName)
+						Expect(gErr).ToNot(HaveOccurred())
+
+						clusterPods, lErr := getPodList(cluster, k8sClient)
+						Expect(lErr).ToNot(HaveOccurred())
+
+						return getMigrationsInProgress(ctx, k8sClient, clusterNamespacedName, clusterPods)
+					}
+
+					Eventually(migrationsInProgress, 2*time.Minute, 5*time.Second).Should(BeZero())
+					// Guard against a transient zero at a rebalance regime transition.
+					Consistently(migrationsInProgress, 6*time.Second, 2*time.Second).Should(BeZero())
+
 					By("Marking two pods as failed")
 
 					pod1Name := clusterNamespacedName.Name + "-1-0"

--- a/test/cluster/utils.go
+++ b/test/cluster/utils.go
@@ -779,6 +779,14 @@ func CleanupPVC(k8sClient client.Client, ns, clName string) error {
 	return nil
 }
 
+// isRetriableAPIError reports whether err is a transient apiserver error (e.g. a momentary
+// etcd/apiserver hiccup) that a caller polling for cluster/pod/PVC state should retry rather
+// than treat as a hard failure.
+func isRetriableAPIError(err error) bool {
+	return errors.IsInternalError(err) || errors.IsServerTimeout(err) ||
+		errors.IsTimeout(err) || errors.IsTooManyRequests(err)
+}
+
 func getSTSList(
 	aeroCluster *asdbv1.AerospikeCluster, k8sClient client.Client,
 ) (*appsv1.StatefulSetList, error) {


### PR DESCRIPTION
## What
Fixes 2 test failure.

1. Fixes https://aerospike.atlassian.net/browse/KO-627. Wait for post-scale-up partition handovers to settle before failing pods in the `maxIgnorablePods` batch-recovery e2e spec.

2. Fixes another test failure in master branch for the test `blocks scale-down when a pending pod consumes maxIgnorablePods=1 and another pod is failed`. [Test failure](http://192.168.200.205:8080/job/Aerospike%20Kubernetes%20Operator/job/master/119/testReport/junit/(root)/Cluster_Suite/_It__AerospikeCluster_DeployClusterWithMaxIgnorablePod_Pending_pod_consumes_maxIgnorablePods_1_so_scale_down_blocks_with_a_separate_failed_pod_blocks_scale_down_when_a_pending_pod_consumes_maxIgnorablePods_1_and_another_pod_is_failed/) was due to failing to update the object.
```
    Operation cannot be fulfilled on aerospikeclusters.asdb.aerospike.com "ignore-pod-cluster-7": the object has been modified; please apply your changes to the latest version and try again
```
Replaced `k8sClient.Update` with `updateClusterWithNoWait()`.

## Test failure cause (1st one)
`scaleUpClusterTest` returns on phase `Completed`, which the operator stamps in the *same* reconcile that expands the SC roster — handovers are still in flight. The spec then failed two rack-1 pods ~1s later, mid-handover, when an affected partition holds only one trusted (non-subset) copy. Killing that node leaves only subsets, and at rf 2 losing 2 of 6 roster nodes also blocks subset promotion (`n_missing + n_not_trusted < replication_factor` → `2 < 2`). Result: ~900–1200 unavailable partitions, `getAndSetRoster` fails, `recoverIgnorablePods` is never reached, and the spec times out after 180s.

## Verification
- Passes at rf 2, two runs.

```
AerospikeCluster DeployClusterWithMaxIgnorablePod UpdateClusterWithMaxIgnorablePodAndFailedPod Should recover multiple ignorable pods via batch deletion in a single reconcile pass
/Users/strivedi/Code/aerospike-kubernetes-operator/test/cluster/cluster_test.go:1008

  Timeline >>
  > Enter [BeforeEach] UpdateClusterWithMaxIgnorablePodAndFailedPod @ 09/03/26 22:22:39.947
  STEP: Deploying cluster @ 09/03/26 22:22:40.031
  2026-09-03T22:22:40+05:30	INFO	aerospikecluster	Cluster size is not correct	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:23:10+05:30	INFO	aerospikecluster	Cluster size is not correct	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:23:40+05:30	INFO	aerospikecluster	Cluster state is validated successfully	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:23:40+05:30	INFO	aerospikecluster	AerospikeCluster available

  < Exit [BeforeEach] UpdateClusterWithMaxIgnorablePodAndFailedPod @ 09/03/26 22:23:40.227 (1m0.282s)
  > Enter [It] Should recover multiple ignorable pods via batch deletion in a single reconcile pass @ 09/03/26 22:23:40.227
  STEP: Scaling up cluster with 2 @ 09/03/26 22:23:40.228
  2026-09-03T22:23:40+05:30	INFO	aerospikecluster	Cluster size is not correct	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:24:10+05:30	INFO	aerospikecluster	Cluster size is not correct	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:24:40+05:30	INFO	aerospikecluster	Cluster state is validated successfully	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:24:40+05:30	INFO	aerospikecluster	AerospikeCluster available

  STEP: Waiting for post-scale-up handovers to settle before failing pods @ 09/03/26 22:24:40.535
  STEP: Marking two pods as failed @ 09/03/26 22:24:48.414
  STEP: Waiting for both pods to have a failed server container @ 09/03/26 22:24:48.754
  STEP: Setting MaxIgnorablePods=2 to trigger reconcile — both pods should be deleted and recovered together @ 09/03/26 22:24:53.898
  STEP: Verifying both pods recover — server container becomes ready after STS recreates them @ 09/03/26 22:24:54.125
  STEP: Verifying cluster reaches Completed @ 09/03/26 22:25:34.59
  2026-09-03T22:25:34+05:30	INFO	aerospikecluster	Cluster state is validated successfully	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:25:34+05:30	INFO	aerospikecluster	AerospikeCluster available

  STEP: Verifying SC roster includes all nodes — both recovered pods are back in the cluster @ 09/03/26 22:25:34.643
  < Exit [It] Should recover multiple ignorable pods via batch deletion in a single reconcile pass @ 09/03/26 22:26:07.266 (2m27.041s)
  > Enter [AfterEach] DeployClusterWithMaxIgnorablePod @ 09/03/26 22:26:07.266
  < Exit [AfterEach] DeployClusterWithMaxIgnorablePod @ 09/03/26 22:26:11.007 (3.741s)
  << Timeline
------------------------------
SSSSSSSSSSSSSSSSS
------------------------------
[SynchronizedAfterSuite] PASSED [0.597 seconds]
[SynchronizedAfterSuite]
/Users/strivedi/Code/aerospike-kubernetes-operator/test/cluster/suite_test.go:134

  Timeline >>
  > Enter [SynchronizedAfterSuite] TOP-LEVEL @ 09/03/26 22:26:11.01
  < Exit [SynchronizedAfterSuite] TOP-LEVEL @ 09/03/26 22:26:11.01 (0s)
  > Enter [SynchronizedAfterSuite] TOP-LEVEL @ 09/03/26 22:26:11.011
  STEP: Cleaning up all clusters and pvcs @ 09/03/26 22:26:11.011
  STEP: tearing down the test environment @ 09/03/26 22:26:11.606
  < Exit [SynchronizedAfterSuite] TOP-LEVEL @ 09/03/26 22:26:11.607 (597ms)
  << Timeline
------------------------------
[ReportAfterSuite] PASSED [0.014 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo

  Timeline >>
  > Enter [ReportAfterSuite] TOP-LEVEL @ 09/03/26 22:26:11.611
  < Exit [ReportAfterSuite] TOP-LEVEL @ 09/03/26 22:26:11.622 (12ms)
  << Timeline
------------------------------

Ran 1 of 364 Specs in 214.647 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 363 Skipped

coverage: 16.0% of statements
composite coverage: 16.0% of statements

Ginkgo ran 1 suite in 3m37.149544916s
Test Suite Passed
```


Test 2 verification

```
• [429.516 seconds]
AerospikeCluster DeployClusterWithMaxIgnorablePod Pending pod consumes maxIgnorablePods=1 so scale-down blocks with a separate failed pod blocks scale-down when a pending pod consumes maxIgnorablePods=1 and another pod is failed
/Users/strivedi/Code/aerospike-kubernetes-operator/test/cluster/cluster_test.go:1154

  Timeline >>
  > Enter [It] blocks scale-down when a pending pod consumes maxIgnorablePods=1 and another pod is failed @ 09/03/26 22:54:43.83
  2026-09-03T22:54:44+05:30	INFO	aerospikecluster	Cluster size is not correct	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:55:14+05:30	INFO	aerospikecluster	Cluster size is not correct	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:55:44+05:30	INFO	aerospikecluster	Cluster state is validated successfully	{"name": "ignore-pod-cluster-1"}
  2026-09-03T22:55:44+05:30	INFO	aerospikecluster	AerospikeCluster available

  STEP: Asserting scale-down did not complete (status and pod count unchanged) @ 09/03/26 22:55:50.503
  2026-09-03T22:59:50+05:30	INFO	aerospikecluster	Cluster status is not matching the spec	{"name": "ignore-pod-cluster-1"}
  2026-09-03T23:00:20+05:30	INFO	aerospikecluster	Cluster status is not matching the spec	{"name": "ignore-pod-cluster-1"}
  2026-09-03T23:00:50+05:30	INFO	aerospikecluster	Cluster status is not matching the spec	{"name": "ignore-pod-cluster-1"}
  2026-09-03T23:01:20+05:30	INFO	aerospikecluster	Cluster status is not matching the spec	{"name": "ignore-pod-cluster-1"}
  < Exit [It] blocks scale-down when a pending pod consumes maxIgnorablePods=1 and another pod is failed @ 09/03/26 23:01:50.679 (7m6.855s)
  > Enter [AfterEach] DeployClusterWithMaxIgnorablePod @ 09/03/26 23:01:50.679
  < Exit [AfterEach] DeployClusterWithMaxIgnorablePod @ 09/03/26 23:01:53.34 (2.661s)
  << Timeline
------------------------------
SSSSSSSSSSSSSSSSS
------------------------------
[SynchronizedAfterSuite] PASSED [0.587 seconds]
[SynchronizedAfterSuite]
/Users/strivedi/Code/aerospike-kubernetes-operator/test/cluster/suite_test.go:134

  Timeline >>
  > Enter [SynchronizedAfterSuite] TOP-LEVEL @ 09/03/26 23:01:53.343
  < Exit [SynchronizedAfterSuite] TOP-LEVEL @ 09/03/26 23:01:53.343 (0s)
  > Enter [SynchronizedAfterSuite] TOP-LEVEL @ 09/03/26 23:01:53.344
  STEP: Cleaning up all clusters and pvcs @ 09/03/26 23:01:53.344
  STEP: tearing down the test environment @ 09/03/26 23:01:53.93
  < Exit [SynchronizedAfterSuite] TOP-LEVEL @ 09/03/26 23:01:53.931 (587ms)
  << Timeline
------------------------------
[ReportAfterSuite] PASSED [0.020 seconds]
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo

  Timeline >>
  > Enter [ReportAfterSuite] TOP-LEVEL @ 09/03/26 23:01:53.935
  < Exit [ReportAfterSuite] TOP-LEVEL @ 09/03/26 23:01:53.951 (16ms)
  << Timeline
------------------------------

Ran 1 of 364 Specs in 432.746 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 363 Skipped
```