### PR TITLE
feat: block unsafe vertical scaling in the validating webhook [KO-619]

### DIFF
--- a/internal/webhook/v1/aerospikecluster_validating_webhook.go
+++ b/internal/webhook/v1/aerospikecluster_validating_webhook.go
@@ -310,6 +310,10 @@ func (acv *AerospikeClusterCustomValidator) ValidateUpdate(_ context.Context,
 		return warnings, err
 	}
 
+	if err := validateVerticalScaling(oldObject, aerospikeCluster); err != nil {
+		return warnings, err
+	}
+
 	// Validate actual pod names to catch silent DNS label overflows at runtime.
 	// This uses real rack IDs, real revisions, and the real max ordinal (Size-1),
 	// so it only rejects what would actually fail — not a conservative estimate.
@@ -871,6 +875,130 @@ func validateConcurrentRackRevisions(oldObj, newObj *asdbv1.AerospikeCluster) er
 	}
 
 	return nil
+}
+
+// validateVerticalScaling rejects a rack revision change that would leave too few
+// nodes standing while a rack's pods are replaced.
+//
+// Inputs are spec-only. Size 1 and replication-factor 1 are rejected in AP and SC.
+// The RF floor and roster-majority checks are SC only (pkg/validation already
+// allows AP size < RF). The worst batch is the first rack: DistributeItems always
+// gives it the most pods.
+func validateVerticalScaling(oldObj, newObj *asdbv1.AerospikeCluster) error {
+	// New racks and non-revision updates are not vertical scaling.
+	if !hasRackRevisionChange(oldObj.Spec.RackConfig.Racks, newObj.Spec.RackConfig.Racks) {
+		return nil
+	}
+
+	// AP and SC: replacing the only node takes the cluster down.
+	if newObj.Spec.Size == 1 {
+		return fmt.Errorf(
+			"vertical scaling (rack revision change) is not allowed: spec.size is 1, so the only node would go down",
+		)
+	}
+
+	nsConfs := getNsConfForNamespaces(newObj.Spec.RackConfig)
+	nsNames := sets.List(sets.KeySet(nsConfs))
+
+	// AP and SC. validateBatchSize already rejects RF 1 when a batch is set; this
+	// covers the unset-batch case (one pod per pass).
+	for _, nsName := range nsNames {
+		if nsConfs[nsName].replicationFactor == 1 {
+			return fmt.Errorf(
+				"vertical scaling (rack revision change) is not allowed: namespace %q has "+
+					"replication-factor 1, so no replica remains while pods are replaced",
+				nsName,
+			)
+		}
+	}
+
+	// SC only: survivors must stay at or above RF, and more than half the roster.
+	leaving := podsLeavingFirstRack(newObj)
+	survivors := newObj.Spec.Size - leaving
+	hasSC := false
+
+	for _, nsName := range nsNames {
+		if !nsConfs[nsName].scEnabled {
+			continue
+		}
+
+		hasSC = true
+
+		if int(survivors) < nsConfs[nsName].replicationFactor {
+			return fmt.Errorf(
+				"vertical scaling (rack revision change) is not allowed: %d of %d nodes "+
+					"would go down, leaving %d for strong-consistency namespace %q "+
+					"(needs replication-factor %d)",
+				leaving, newObj.Spec.Size, survivors, nsName,
+				nsConfs[nsName].replicationFactor,
+			)
+		}
+	}
+
+	if hasSC && survivors <= newObj.Spec.Size/2 {
+		return fmt.Errorf(
+			"vertical scaling (rack revision change) is not allowed: %d of %d nodes "+
+				"would go down, leaving %d, which is not a majority of the "+
+				"strong-consistency roster",
+			leaving, newObj.Spec.Size, survivors,
+		)
+	}
+
+	return nil
+}
+
+// hasRackRevisionChange is true when an existing rack's revision changed. A newly
+// added rack is not vertical scaling. A revert counts.
+func hasRackRevisionChange(oldRacks, newRacks []asdbv1.Rack) bool {
+	oldRevisions := make(map[int]string, len(oldRacks))
+
+	for idx := range oldRacks {
+		oldRevisions[oldRacks[idx].ID] = oldRacks[idx].Revision
+	}
+
+	for idx := range newRacks {
+		oldRevision, existed := oldRevisions[newRacks[idx].ID]
+		if existed && oldRevision != newRacks[idx].Revision {
+			return true
+		}
+	}
+
+	return false
+}
+
+// podsLeavingFirstRack is the largest delete batch in the cluster: DistributeItems
+// always puts the most pods on spec index 0.
+func podsLeavingFirstRack(cluster *asdbv1.AerospikeCluster) int32 {
+	batch := cluster.Spec.RackConfig.RollingUpdateBatchSize
+	racks := cluster.Spec.RackConfig.Racks
+
+	if len(racks) == 0 {
+		return clampedBatch(batch, cluster.Spec.Size)
+	}
+
+	topology := asdbv1.DistributeItems(cluster.Spec.Size, utils.Len32(racks))
+
+	return clampedBatch(batch, topology[0])
+}
+
+// clampedBatch resolves rollingUpdateBatchSize against a rack size. Round-up matches
+// the reconciler replica step; unset becomes 1; result is capped at the rack size.
+func clampedBatch(batch *intstr.IntOrString, base int32) int32 {
+	if base < 1 {
+		return 0
+	}
+
+	value, _ := intstr.GetScaledValueFromIntOrPercent(batch, int(base), true)
+
+	if value >= int(base) {
+		return base
+	}
+
+	if value < 1 {
+		return 1
+	}
+
+	return int32(value) //nolint:gosec // above zero and below base, itself an int32 pod count
 }
 
 // TODO: FIX

--- a/internal/webhook/v1/aerospikecluster_validating_webhook.go
+++ b/internal/webhook/v1/aerospikecluster_validating_webhook.go
@@ -880,11 +880,13 @@ func validateConcurrentRackRevisions(oldObj, newObj *asdbv1.AerospikeCluster) er
 // validateVerticalScaling rejects a rack revision change that would leave too few
 // nodes standing while a rack's pods are replaced.
 //
-// Inputs are spec-only. Size 1 and replication-factor 1 are rejected in AP and SC.
-// The RF floor and roster-majority checks are SC only (pkg/validation already
-// allows AP size < RF). The worst batch is the first rack: DistributeItems always
-// gives it the most pods.
+// Inputs are spec-only. Size 1 and replication-factor <= 1 are rejected in AP and
+// SC. The survivors floor and roster-majority checks are SC only (pkg/validation
+// already allows AP size < RF). The worst batch is the first rack: DistributeItems
+// always gives it the most pods.
 func validateVerticalScaling(oldObj, newObj *asdbv1.AerospikeCluster) error {
+	const notAllowed = "vertical scaling (rack revision change) is not allowed"
+
 	// New racks and non-revision updates are not vertical scaling.
 	if !hasRackRevisionChange(oldObj.Spec.RackConfig.Racks, newObj.Spec.RackConfig.Racks) {
 		return nil
@@ -892,55 +894,44 @@ func validateVerticalScaling(oldObj, newObj *asdbv1.AerospikeCluster) error {
 
 	// AP and SC: replacing the only node takes the cluster down.
 	if newObj.Spec.Size == 1 {
-		return fmt.Errorf(
-			"vertical scaling (rack revision change) is not allowed: spec.size is 1, so the only node would go down",
-		)
+		return fmt.Errorf("%s: spec.size is 1, so the only node would go down", notAllowed)
 	}
 
-	nsConfs := getNsConfForNamespaces(newObj.Spec.RackConfig)
-	nsNames := sets.List(sets.KeySet(nsConfs))
+	summary := summarizeNsReplication(getNsConfForNamespaces(newObj.Spec.RackConfig))
 
 	// AP and SC. validateBatchSize already rejects RF 1 when a batch is set; this
 	// covers the unset-batch case (one pod per pass).
-	for _, nsName := range nsNames {
-		if nsConfs[nsName].replicationFactor == 1 {
-			return fmt.Errorf(
-				"vertical scaling (rack revision change) is not allowed: namespace %q has "+
-					"replication-factor 1, so no replica remains while pods are replaced",
-				nsName,
-			)
-		}
+	if summary.unreplicatedNs != "" {
+		return fmt.Errorf(
+			"%s: namespace %q has replication-factor %d, so no replica remains while pods are replaced",
+			notAllowed, summary.unreplicatedNs, summary.unreplicatedRF,
+		)
 	}
 
-	// SC only: survivors must stay at or above RF, and more than half the roster.
+	// An AP-only cluster has no survivors floor and no roster.
+	if !summary.hasSC() {
+		return nil
+	}
+
 	leaving := podsLeavingFirstRack(newObj)
 	survivors := newObj.Spec.Size - leaving
-	hasSC := false
 
-	for _, nsName := range nsNames {
-		if !nsConfs[nsName].scEnabled {
-			continue
-		}
-
-		hasSC = true
-
-		if int(survivors) < nsConfs[nsName].replicationFactor {
-			return fmt.Errorf(
-				"vertical scaling (rack revision change) is not allowed: %d of %d nodes "+
-					"would go down, leaving %d for strong-consistency namespace %q "+
-					"(needs replication-factor %d)",
-				leaving, newObj.Spec.Size, survivors, nsName,
-				nsConfs[nsName].replicationFactor,
-			)
-		}
+	// Survivors must clear the highest replication-factor of any SC namespace.
+	if int(survivors) < summary.strictestSCRF {
+		return fmt.Errorf(
+			"%s: %d of %d nodes would go down, leaving %d for strong-consistency "+
+				"namespace %q (needs replication-factor %d)",
+			notAllowed, leaving, newObj.Spec.Size, survivors,
+			summary.strictestSCNs, summary.strictestSCRF,
+		)
 	}
 
-	if hasSC && survivors <= newObj.Spec.Size/2 {
+	// Survivors must also be a majority of the roster.
+	if survivors <= newObj.Spec.Size/2 {
 		return fmt.Errorf(
-			"vertical scaling (rack revision change) is not allowed: %d of %d nodes "+
-				"would go down, leaving %d, which is not a majority of the "+
-				"strong-consistency roster",
-			leaving, newObj.Spec.Size, survivors,
+			"%s: %d of %d nodes would go down, leaving %d, which is not a majority of "+
+				"the strong-consistency roster",
+			notAllowed, leaving, newObj.Spec.Size, survivors,
 		)
 	}
 
@@ -966,28 +957,27 @@ func hasRackRevisionChange(oldRacks, newRacks []asdbv1.Rack) bool {
 	return false
 }
 
-// podsLeavingFirstRack is the largest delete batch in the cluster: DistributeItems
-// always puts the most pods on spec index 0.
+// podsLeavingFirstRack is the largest delete batch in the cluster. DistributeItems
+// gives spec index 0 the most pods, exactly ceil(size/racks), so the first rack's
+// size is all that is needed and the full topology is not worth building.
+//
+// The rack count is floored at 1 so the division is always safe. Reaching here
+// requires hasRackRevisionChange to have found a changed rack, which is only possible
+// when spec.rackConfig.racks is non-empty, and the mutating webhook's
+// setDefaultRackConf injects the default rack before that anyway. The floor therefore
+// only matters to direct callers such as unit tests, where it degenerates to treating
+// the whole cluster as one rack.
 func podsLeavingFirstRack(cluster *asdbv1.AerospikeCluster) int32 {
-	batch := cluster.Spec.RackConfig.RollingUpdateBatchSize
-	racks := cluster.Spec.RackConfig.Racks
+	racks := max(utils.Len32(cluster.Spec.RackConfig.Racks), 1)
+	firstRackSize := (cluster.Spec.Size + racks - 1) / racks
 
-	if len(racks) == 0 {
-		return clampedBatch(batch, cluster.Spec.Size)
-	}
-
-	topology := asdbv1.DistributeItems(cluster.Spec.Size, utils.Len32(racks))
-
-	return clampedBatch(batch, topology[0])
+	return clampedBatch(cluster.Spec.RackConfig.RollingUpdateBatchSize, firstRackSize)
 }
 
 // clampedBatch resolves rollingUpdateBatchSize against a rack size. Round-up matches
 // the reconciler replica step; unset becomes 1; result is capped at the rack size.
+// Callers must pass base >= 1.
 func clampedBatch(batch *intstr.IntOrString, base int32) int32 {
-	if base < 1 {
-		return 0
-	}
-
 	value, _ := intstr.GetScaledValueFromIntOrPercent(batch, int(base), true)
 
 	if value >= int(base) {
@@ -1297,6 +1287,81 @@ func getNsConfForNamespaces(rackConfig asdbv1.RackConfig) map[string]nsConf {
 	}
 
 	return nsConfs
+}
+
+// nsRFSummary reduces the per-namespace configs to the two thresholds
+// validateVerticalScaling needs. It holds two separate reductions because the two
+// rules have different scopes:
+//
+//   - replication-factor <= 1 is fatal in AP and in SC: no replica exists anywhere,
+//     so replacing any pod loses data. Reduced over every namespace.
+//   - the survivors floor is strong-consistency only, because pkg/validation
+//     deliberately allows an AP cluster smaller than its replication-factor. Folding
+//     AP in would let an AP namespace at RF 2 lower the floor for an SC namespace at
+//     RF 5.
+//
+// The floor reduces with max, not min: survivors must clear every SC namespace's
+// replication-factor, so the binding namespace is the one with the highest. Reducing
+// with min would admit an update that strands the strictest namespace — SC namespaces
+// at RF 3 and RF 5 with 4 survivors satisfy 3 but not 5. This is the opposite of
+// validateMaxUnavailable, which reduces with min because maxUnavailable is an upper
+// bound rather than a lower one.
+// Fields are grouped by type rather than by rule, because govet's fieldalignment
+// wants the strings ahead of the ints.
+type nsRFSummary struct {
+	// Namespace with RF <= 1, AP or SC; "" when every namespace has a replica.
+	// Drives the no-replica rejection, and names the namespace in it.
+	unreplicatedNs string
+
+	// SC namespace holding strictestSCRF; "" when no namespace is strongly
+	// consistent, which is also how hasSC reports an AP-only cluster.
+	strictestSCNs string
+
+	// unreplicatedNs's replication-factor, reported in the rejection so an
+	// unparsable 0 reads differently from a deliberate 1.
+	unreplicatedRF int
+
+	// Highest replication-factor across SC namespaces, and the floor survivors must
+	// clear; 0 when no namespace is strongly consistent. Highest rather than lowest
+	// because survivors have to satisfy every SC namespace at once.
+	strictestSCRF int
+}
+
+// hasSC is true when at least one namespace is strongly consistent.
+func (s *nsRFSummary) hasSC() bool {
+	return s.strictestSCNs != ""
+}
+
+// summarizeNsReplication reduces the namespace configs in a single pass. Ties break on
+// namespace name so a rejection message does not depend on Go's randomized map order.
+func summarizeNsReplication(nsConfs map[string]nsConf) nsRFSummary {
+	var summary nsRFSummary
+
+	for nsName, conf := range nsConfs {
+		// `<= 1` rather than `== 1` matches validateBatchSize and also catches the 0 that
+		// getNsConfForNamespaces leaves behind when replication-factor fails to parse. An
+		// unset replication-factor is already defaulted to 2 by
+		// validation.GetNamespaceReplicationFactor, and validate() rejects an unparsable
+		// one before ValidateUpdate reaches here, so this is belt and braces.
+		if conf.replicationFactor <= 1 &&
+			(summary.unreplicatedNs == "" || nsName < summary.unreplicatedNs) {
+			summary.unreplicatedNs = nsName
+			summary.unreplicatedRF = conf.replicationFactor
+		}
+
+		if !conf.scEnabled {
+			continue
+		}
+
+		if conf.replicationFactor > summary.strictestSCRF ||
+			(conf.replicationFactor == summary.strictestSCRF &&
+				(summary.strictestSCNs == "" || nsName < summary.strictestSCNs)) {
+			summary.strictestSCNs = nsName
+			summary.strictestSCRF = conf.replicationFactor
+		}
+	}
+
+	return summary
 }
 
 // getAllNamespaceNamesAndRFMap collects all unique namespace identifiers ("name@rackID") and

--- a/internal/webhook/v1/aerospikecluster_validating_webhook.go
+++ b/internal/webhook/v1/aerospikecluster_validating_webhook.go
@@ -897,42 +897,43 @@ func validateVerticalScaling(oldObj, newObj *asdbv1.AerospikeCluster) error {
 		return fmt.Errorf("%s: spec.size is 1, so the only node would go down", notAllowed)
 	}
 
-	summary := summarizeNsReplication(getNsConfForNamespaces(newObj.Spec.RackConfig))
-
-	// AP and SC. validateBatchSize already rejects RF 1 when a batch is set; this
-	// covers the unset-batch case (one pod per pass).
-	if summary.unreplicatedNs != "" {
-		return fmt.Errorf(
-			"%s: namespace %q has replication-factor %d, so no replica remains while pods are replaced",
-			notAllowed, summary.unreplicatedNs, summary.unreplicatedRF,
-		)
-	}
-
-	// An AP-only cluster has no survivors floor and no roster.
-	if !summary.hasSC() {
-		return nil
-	}
-
 	leaving := podsLeavingFirstRack(newObj)
 	survivors := newObj.Spec.Size - leaving
 
-	// Survivors must clear the highest replication-factor of any SC namespace.
-	if int(survivors) < summary.strictestSCRF {
-		return fmt.Errorf(
-			"%s: %d of %d nodes would go down, leaving %d for strong-consistency "+
-				"namespace %q (needs replication-factor %d)",
-			notAllowed, leaving, newObj.Spec.Size, survivors,
-			summary.strictestSCNs, summary.strictestSCRF,
-		)
-	}
+	// Rejecting on the first namespace that breaks a rule means survivors have to
+	// satisfy every namespace.
+	for nsName, conf := range getNsConfForNamespaces(newObj.Spec.RackConfig) {
+		// AP and SC. validateBatchSize already rejects RF 1 when a batch is set; this
+		// covers the unset-batch case (one pod per pass).
+		if conf.replicationFactor <= 1 {
+			return fmt.Errorf(
+				"%s: namespace %q has replication-factor %d, so no replica remains while pods are replaced",
+				notAllowed, nsName, conf.replicationFactor,
+			)
+		}
 
-	// Survivors must also be a majority of the roster.
-	if survivors <= newObj.Spec.Size/2 {
-		return fmt.Errorf(
-			"%s: %d of %d nodes would go down, leaving %d, which is not a majority of "+
-				"the strong-consistency roster",
-			notAllowed, leaving, newObj.Spec.Size, survivors,
-		)
+		// The remaining floors are strong-consistency only: pkg/validation already
+		// allows an AP cluster smaller than its replication-factor, and AP has no
+		// roster.
+		if !conf.scEnabled {
+			continue
+		}
+
+		if int(survivors) < conf.replicationFactor {
+			return fmt.Errorf(
+				"%s: %d of %d nodes would go down, leaving %d for strong-consistency "+
+					"namespace %q (needs replication-factor %d)",
+				notAllowed, leaving, newObj.Spec.Size, survivors, nsName, conf.replicationFactor,
+			)
+		}
+
+		if survivors <= newObj.Spec.Size/2 {
+			return fmt.Errorf(
+				"%s: %d of %d nodes would go down, leaving %d, which is not a majority of "+
+					"the strong-consistency roster",
+				notAllowed, leaving, newObj.Spec.Size, survivors,
+			)
+		}
 	}
 
 	return nil
@@ -969,7 +970,18 @@ func hasRackRevisionChange(oldRacks, newRacks []asdbv1.Rack) bool {
 // the whole cluster as one rack.
 func podsLeavingFirstRack(cluster *asdbv1.AerospikeCluster) int32 {
 	racks := max(utils.Len32(cluster.Spec.RackConfig.Racks), 1)
-	firstRackSize := (cluster.Spec.Size + racks - 1) / racks
+
+	// Mirrors DistributeItems: every rack gets size/racks pods, then the remainder is
+	// handed out one pod at a time starting at index 0. So the first rack takes one
+	// extra whenever the split is uneven, which is both why it is the largest rack and
+	// why ceil(size/racks) is its exact pod count.
+	//
+	//	size 6 over 3 racks -> [2, 2, 2], first rack 2 (no remainder)
+	//	size 7 over 3 racks -> [3, 2, 2], first rack 3 (remainder 1 goes to index 0)
+	firstRackSize := cluster.Spec.Size / racks
+	if cluster.Spec.Size%racks != 0 {
+		firstRackSize++
+	}
 
 	return clampedBatch(cluster.Spec.RackConfig.RollingUpdateBatchSize, firstRackSize)
 }
@@ -1287,81 +1299,6 @@ func getNsConfForNamespaces(rackConfig asdbv1.RackConfig) map[string]nsConf {
 	}
 
 	return nsConfs
-}
-
-// nsRFSummary reduces the per-namespace configs to the two thresholds
-// validateVerticalScaling needs. It holds two separate reductions because the two
-// rules have different scopes:
-//
-//   - replication-factor <= 1 is fatal in AP and in SC: no replica exists anywhere,
-//     so replacing any pod loses data. Reduced over every namespace.
-//   - the survivors floor is strong-consistency only, because pkg/validation
-//     deliberately allows an AP cluster smaller than its replication-factor. Folding
-//     AP in would let an AP namespace at RF 2 lower the floor for an SC namespace at
-//     RF 5.
-//
-// The floor reduces with max, not min: survivors must clear every SC namespace's
-// replication-factor, so the binding namespace is the one with the highest. Reducing
-// with min would admit an update that strands the strictest namespace — SC namespaces
-// at RF 3 and RF 5 with 4 survivors satisfy 3 but not 5. This is the opposite of
-// validateMaxUnavailable, which reduces with min because maxUnavailable is an upper
-// bound rather than a lower one.
-// Fields are grouped by type rather than by rule, because govet's fieldalignment
-// wants the strings ahead of the ints.
-type nsRFSummary struct {
-	// Namespace with RF <= 1, AP or SC; "" when every namespace has a replica.
-	// Drives the no-replica rejection, and names the namespace in it.
-	unreplicatedNs string
-
-	// SC namespace holding strictestSCRF; "" when no namespace is strongly
-	// consistent, which is also how hasSC reports an AP-only cluster.
-	strictestSCNs string
-
-	// unreplicatedNs's replication-factor, reported in the rejection so an
-	// unparsable 0 reads differently from a deliberate 1.
-	unreplicatedRF int
-
-	// Highest replication-factor across SC namespaces, and the floor survivors must
-	// clear; 0 when no namespace is strongly consistent. Highest rather than lowest
-	// because survivors have to satisfy every SC namespace at once.
-	strictestSCRF int
-}
-
-// hasSC is true when at least one namespace is strongly consistent.
-func (s *nsRFSummary) hasSC() bool {
-	return s.strictestSCNs != ""
-}
-
-// summarizeNsReplication reduces the namespace configs in a single pass. Ties break on
-// namespace name so a rejection message does not depend on Go's randomized map order.
-func summarizeNsReplication(nsConfs map[string]nsConf) nsRFSummary {
-	var summary nsRFSummary
-
-	for nsName, conf := range nsConfs {
-		// `<= 1` rather than `== 1` matches validateBatchSize and also catches the 0 that
-		// getNsConfForNamespaces leaves behind when replication-factor fails to parse. An
-		// unset replication-factor is already defaulted to 2 by
-		// validation.GetNamespaceReplicationFactor, and validate() rejects an unparsable
-		// one before ValidateUpdate reaches here, so this is belt and braces.
-		if conf.replicationFactor <= 1 &&
-			(summary.unreplicatedNs == "" || nsName < summary.unreplicatedNs) {
-			summary.unreplicatedNs = nsName
-			summary.unreplicatedRF = conf.replicationFactor
-		}
-
-		if !conf.scEnabled {
-			continue
-		}
-
-		if conf.replicationFactor > summary.strictestSCRF ||
-			(conf.replicationFactor == summary.strictestSCRF &&
-				(summary.strictestSCNs == "" || nsName < summary.strictestSCNs)) {
-			summary.strictestSCNs = nsName
-			summary.strictestSCRF = conf.replicationFactor
-		}
-	}
-
-	return summary
 }
 
 // getAllNamespaceNamesAndRFMap collects all unique namespace identifiers ("name@rackID") and

--- a/internal/webhook/v1/aerospikecluster_vertical_scaling_test.go
+++ b/internal/webhook/v1/aerospikecluster_vertical_scaling_test.go
@@ -1,0 +1,495 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
+	"github.com/aerospike/aerospike-kubernetes-operator/v4/pkg/utils"
+)
+
+func nsConfig(name string, replicationFactor int, strongConsistency bool) map[string]interface{} {
+	ns := map[string]interface{}{
+		asdbv1.ConfKeyName:              name,
+		asdbv1.ConfKeyReplicationFactor: replicationFactor,
+	}
+
+	if strongConsistency {
+		ns[asdbv1.ConfKeyStrongConsistency] = true
+	}
+
+	return ns
+}
+
+// verticalScaleCluster builds racks numbered from 1 in spec-list order.
+func verticalScaleCluster(
+	size int32, revisions []string, batch *intstr.IntOrString, namespaces []interface{},
+) *asdbv1.AerospikeCluster {
+	racks := make([]asdbv1.Rack, 0, len(revisions))
+
+	for idx := range revisions {
+		racks = append(racks, asdbv1.Rack{
+			ID:       idx + 1,
+			Revision: revisions[idx],
+			AerospikeConfig: asdbv1.AerospikeConfigSpec{
+				Value: map[string]interface{}{
+					asdbv1.ConfKeyNamespace: namespaces,
+				},
+			},
+		})
+	}
+
+	return &asdbv1.AerospikeCluster{
+		Spec: asdbv1.AerospikeClusterSpec{
+			Size: size,
+			RackConfig: asdbv1.RackConfig{
+				Racks:                  racks,
+				RollingUpdateBatchSize: batch,
+			},
+		},
+	}
+}
+
+func TestValidateVerticalScaling(t *testing.T) {
+	tests := []struct {
+		name         string
+		batch        *intstr.IntOrString
+		oldRevisions []string
+		newRevisions []string
+		wantReject   []string
+		oldSize      int32
+		newSize      int32
+		rf           int
+		sc           bool
+	}{
+		// Gate skipped (no revision change).
+		{
+			name:         "allows an update that changes no rack revision",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v1", "v1", "v1"},
+			rf:           5,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+		},
+		{
+			name:         "allows a pure resize with no rack revision change",
+			oldSize:      12,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v1", "v1", "v1"},
+			rf:           5,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+		},
+		{
+			name:         "allows adding a new rack that carries a revision",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1"},
+			newRevisions: []string{"v1", "v2"},
+			rf:           5,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+		},
+
+		// Size 1, AP and SC.
+		{
+			name:         "rejects a bump on a single-node SC cluster",
+			oldSize:      1,
+			newSize:      1,
+			oldRevisions: []string{"v1"},
+			newRevisions: []string{"v2"},
+			rf:           2,
+			sc:           true,
+			batch:        ptr.To(intstr.FromInt32(1)),
+			wantReject:   []string{"spec.size is 1"},
+		},
+		{
+			name:         "rejects a bump on a single-node AP cluster",
+			oldSize:      1,
+			newSize:      1,
+			oldRevisions: []string{"v1"},
+			newRevisions: []string{"v2"},
+			rf:           2,
+			batch:        ptr.To(intstr.FromInt32(1)),
+			wantReject:   []string{"spec.size is 1"},
+		},
+		{
+			name:         "rejects a bump bundled with a scale-down to one node",
+			oldSize:      6,
+			newSize:      1,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           2,
+			sc:           true,
+			batch:        ptr.To(intstr.FromInt32(1)),
+			wantReject:   []string{"spec.size is 1"},
+		},
+
+		// RF 1, AP and SC.
+		{
+			name:         "rejects a bump when an SC namespace is at replication-factor 1",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           1,
+			sc:           true,
+			batch:        ptr.To(intstr.FromInt32(1)),
+			wantReject:   []string{"replication-factor 1"},
+		},
+		{
+			name:         "rejects a bump when an AP namespace is at replication-factor 1",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           1,
+			batch:        ptr.To(intstr.FromInt32(1)),
+			wantReject:   []string{"replication-factor 1"},
+		},
+
+		// SC floor.
+		{
+			name:         "rejects a three-rack bump at full batch when survivors fall below RF",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           5,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+			wantReject:   []string{"2 of 6 nodes", "leaving 4", "replication-factor 5"},
+		},
+		{
+			name:         "allows a three-rack bump at full batch when survivors meet RF",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           3,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+		},
+		{
+			name:         "sizes the batch against the largest rack when pods divide unevenly",
+			oldSize:      7,
+			newSize:      7,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           5,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+			wantReject:   []string{"3 of 7 nodes", "leaving 4"},
+		},
+		{
+			name:         "allows an uneven three-rack bump when survivors meet RF",
+			oldSize:      7,
+			newSize:      7,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           4,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+		},
+		{
+			name:         "allows a single-rack bump when the batch is one pod",
+			oldSize:      5,
+			newSize:      5,
+			oldRevisions: []string{"v1"},
+			newRevisions: []string{"v2"},
+			rf:           2,
+			sc:           true,
+			batch:        ptr.To(intstr.FromInt32(1)),
+		},
+		{
+			name:         "rejects a single-rack bump at full batch",
+			oldSize:      5,
+			newSize:      5,
+			oldRevisions: []string{"v1"},
+			newRevisions: []string{"v2"},
+			rf:           2,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+			wantReject:   []string{"5 of 5 nodes", "leaving 0"},
+		},
+
+		// Batch resolution.
+		{
+			name:         "rounds a percentage batch up against the first rack",
+			oldSize:      4,
+			newSize:      4,
+			oldRevisions: []string{"v1", "v1"},
+			newRevisions: []string{"v2", "v1"},
+			rf:           4,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("50%")),
+			wantReject:   []string{"1 of 4 nodes", "leaving 3", "replication-factor 4"},
+		},
+		{
+			name:         "allows a rounded percentage batch when survivors meet RF",
+			oldSize:      4,
+			newSize:      4,
+			oldRevisions: []string{"v1", "v1"},
+			newRevisions: []string{"v2", "v1"},
+			rf:           3,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("50%")),
+		},
+		{
+			name:         "treats an unset batch as one pod",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           5,
+			sc:           true,
+		},
+		{
+			name:         "rejects an unset batch only when one pod is already too many",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           6,
+			sc:           true,
+			wantReject:   []string{"1 of 6 nodes", "leaving 5", "replication-factor 6"},
+		},
+		{
+			name:         "caps an integer batch at the first rack's pod count",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           4,
+			sc:           true,
+			batch:        ptr.To(intstr.FromInt32(10)),
+		},
+
+		// SC majority: survivors must be more than half the roster.
+		{
+			name:         "rejects a two-rack bump at full batch when survivors are half the roster",
+			oldSize:      4,
+			newSize:      4,
+			oldRevisions: []string{"v1", "v1"},
+			newRevisions: []string{"v2", "v1"},
+			rf:           2,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+			wantReject:   []string{"2 of 4 nodes", "leaving 2", "majority"},
+		},
+		{
+			name:         "rejects a three-rack bump at full batch when survivors are half the roster",
+			oldSize:      4,
+			newSize:      4,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           2,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+			wantReject:   []string{"2 of 4 nodes", "leaving 2", "majority"},
+		},
+		{
+			name:         "allows an AP bump when survivors are half the roster",
+			oldSize:      4,
+			newSize:      4,
+			oldRevisions: []string{"v1", "v1"},
+			newRevisions: []string{"v2", "v1"},
+			rf:           2,
+			batch:        ptr.To(intstr.FromString("100%")),
+		},
+
+		// AP: no RF floor.
+		{
+			name:         "allows an AP bump even when survivors fall below RF",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           5,
+			batch:        ptr.To(intstr.FromString("100%")),
+		},
+
+		// Bundled resize uses new spec.size.
+		{
+			name:         "sizes a bundled scale-down with the new cluster size",
+			oldSize:      12,
+			newSize:      6,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           5,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+			wantReject:   []string{"2 of 6 nodes", "leaving 4"},
+		},
+		{
+			name:         "sizes a bundled scale-up with the new cluster size",
+			oldSize:      3,
+			newSize:      9,
+			oldRevisions: []string{"v1", "v1", "v1"},
+			newRevisions: []string{"v2", "v1", "v1"},
+			rf:           5,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+		},
+
+		// Revert is a revision change.
+		{
+			name:         "treats a revert like a bump",
+			oldSize:      6,
+			newSize:      6,
+			oldRevisions: []string{"v2", "v1", "v1"},
+			newRevisions: []string{"v1", "v1", "v1"},
+			rf:           5,
+			sc:           true,
+			batch:        ptr.To(intstr.FromString("100%")),
+			wantReject:   []string{"2 of 6 nodes"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			namespaces := []interface{}{nsConfig("test", test.rf, test.sc)}
+			oldObj := verticalScaleCluster(test.oldSize, test.oldRevisions, test.batch, namespaces)
+			newObj := verticalScaleCluster(test.newSize, test.newRevisions, test.batch, namespaces)
+
+			err := validateVerticalScaling(oldObj, newObj)
+
+			if len(test.wantReject) == 0 {
+				if err != nil {
+					t.Fatalf("expected the update to be allowed, got error: %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected a rejection containing %v, got nil", test.wantReject)
+			}
+
+			for _, fragment := range test.wantReject {
+				if !strings.Contains(err.Error(), fragment) {
+					t.Errorf("expected error to contain %q, got: %v", fragment, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateVerticalScalingIgnoresBatchOnlyChange(t *testing.T) {
+	// Batch-only updates are not vertical scaling.
+	revisions := []string{"v1", "v1", "v1"}
+	namespaces := []interface{}{nsConfig("test", 5, true)}
+	oldObj := verticalScaleCluster(6, revisions, ptr.To(intstr.FromInt32(1)), namespaces)
+	newObj := verticalScaleCluster(6, revisions, ptr.To(intstr.FromString("100%")), namespaces)
+
+	if err := validateVerticalScaling(oldObj, newObj); err != nil {
+		t.Fatalf("expected a batch-only change to be allowed, got error: %v", err)
+	}
+}
+
+func TestValidateVerticalScalingChecksEverySCNamespace(t *testing.T) {
+	// Mixed AP+SC: only the SC namespace's RF is a floor.
+	namespaces := []interface{}{
+		nsConfig("ap-ns", 6, false),
+		nsConfig("sc-ns", 5, true),
+	}
+
+	oldObj := verticalScaleCluster(
+		6, []string{"v1", "v1", "v1"}, ptr.To(intstr.FromString("100%")), namespaces,
+	)
+	newObj := verticalScaleCluster(
+		6, []string{"v2", "v1", "v1"}, ptr.To(intstr.FromString("100%")), namespaces,
+	)
+
+	err := validateVerticalScaling(oldObj, newObj)
+	if err == nil {
+		t.Fatal("expected the SC namespace to be rejected, got nil")
+	}
+
+	if !strings.Contains(err.Error(), `"sc-ns"`) {
+		t.Errorf("expected the SC namespace to be named, got: %v", err)
+	}
+
+	if strings.Contains(err.Error(), "ap-ns") {
+		t.Errorf("expected the AP namespace not to drive the rejection, got: %v", err)
+	}
+}
+
+func TestDistributeItemsPutsMaximumOnFirstRack(t *testing.T) {
+	// First spec rack always has the most pods (worst batch).
+	for size := int32(1); size <= 12; size++ {
+		for racks := int32(1); racks <= 3; racks++ {
+			topology := asdbv1.DistributeItems(size, racks)
+
+			for idx := range topology {
+				if topology[idx] > topology[0] {
+					t.Fatalf(
+						"size %d over %d racks: rack at position %d holds %d pods, more than the first rack's %d",
+						size, racks, idx, topology[idx], topology[0],
+					)
+				}
+			}
+		}
+	}
+}
+
+func TestPodsLeavingFirstRack(t *testing.T) {
+	tests := []struct {
+		batch *intstr.IntOrString
+		name  string
+		racks int
+		size  int32
+		want  int32
+	}{
+		{name: "unset batch is one pod", size: 6, racks: 3, want: 1},
+		{name: "full batch takes the whole first rack", size: 6, racks: 3, batch: ptr.To(intstr.FromString("100%")), want: 2},
+		{name: "full batch on an uneven split", size: 7, racks: 3, batch: ptr.To(intstr.FromString("100%")), want: 3},
+		{name: "percentage rounds up", size: 4, racks: 2, batch: ptr.To(intstr.FromString("50%")), want: 1},
+		{name: "percentage rounds up to more than one", size: 9, racks: 3, batch: ptr.To(intstr.FromString("50%")), want: 2},
+		{name: "integer batch is capped at the first rack", size: 6, racks: 3, batch: ptr.To(intstr.FromInt32(10)), want: 2},
+		{name: "integer batch below the rack size is kept", size: 9, racks: 3, batch: ptr.To(intstr.FromInt32(2)), want: 2},
+		{name: "single rack holds the whole cluster", size: 5, racks: 1, batch: ptr.To(intstr.FromString("100%")), want: 5},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			revisions := make([]string, test.racks)
+			for idx := range revisions {
+				revisions[idx] = "v1"
+			}
+
+			cluster := verticalScaleCluster(
+				test.size, revisions, test.batch, []interface{}{nsConfig("test", 2, true)},
+			)
+
+			if got := podsLeavingFirstRack(cluster); got != test.want {
+				topology := asdbv1.DistributeItems(
+					cluster.Spec.Size, utils.Len32(cluster.Spec.RackConfig.Racks),
+				)
+				t.Errorf("got %d pods leaving, want %d (topology %v)", got, test.want, topology)
+			}
+		})
+	}
+}

--- a/internal/webhook/v1/aerospikecluster_vertical_scaling_test.go
+++ b/internal/webhook/v1/aerospikecluster_vertical_scaling_test.go
@@ -409,7 +409,7 @@ func TestValidateVerticalScalingIgnoresBatchOnlyChange(t *testing.T) {
 	}
 }
 
-func TestValidateVerticalScalingChecksEverySCNamespace(t *testing.T) {
+func TestValidateVerticalScalingUsesStrictestSCNamespace(t *testing.T) {
 	// Mixed AP+SC: only the SC namespace's RF is a floor.
 	namespaces := []interface{}{
 		nsConfig("ap-ns", 6, false),
@@ -432,13 +432,97 @@ func TestValidateVerticalScalingChecksEverySCNamespace(t *testing.T) {
 		t.Errorf("expected the SC namespace to be named, got: %v", err)
 	}
 
+	if !strings.Contains(err.Error(), "replication-factor 5") {
+		t.Errorf("expected the SC namespace's RF to be the floor, got: %v", err)
+	}
+
 	if strings.Contains(err.Error(), "ap-ns") {
 		t.Errorf("expected the AP namespace not to drive the rejection, got: %v", err)
 	}
 }
 
+// TestValidateVerticalScalingIgnoresAPReplicationFactorBelowSC pins that an AP
+// namespace never lowers the floor. A reduction over every namespace would use the
+// AP namespace's RF 2 here and wrongly allow the update.
+func TestValidateVerticalScalingIgnoresAPReplicationFactorBelowSC(t *testing.T) {
+	namespaces := []interface{}{
+		nsConfig("ap-ns", 2, false),
+		nsConfig("sc-ns", 5, true),
+	}
+
+	// Size 6 over 3 racks with a full batch: 2 leave, 4 survive, below the SC RF 5.
+	oldObj := verticalScaleCluster(
+		6, []string{"v1", "v1", "v1"}, ptr.To(intstr.FromString("100%")), namespaces,
+	)
+	newObj := verticalScaleCluster(
+		6, []string{"v2", "v1", "v1"}, ptr.To(intstr.FromString("100%")), namespaces,
+	)
+
+	err := validateVerticalScaling(oldObj, newObj)
+	if err == nil {
+		t.Fatal("expected the SC namespace's RF 5 to reject, got nil")
+	}
+
+	for _, fragment := range []string{`"sc-ns"`, "replication-factor 5", "leaving 4"} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Errorf("expected the rejection to contain %q, got: %v", fragment, err)
+		}
+	}
+
+	if strings.Contains(err.Error(), "ap-ns") {
+		t.Errorf("expected the AP namespace not to drive the rejection, got: %v", err)
+	}
+}
+
+// TestValidateVerticalScalingUsesHighestSCReplicationFactor pins the direction of the
+// reduction across SC namespaces. Survivors must clear every SC namespace, so the
+// binding one is the highest RF; reducing with min would allow the rejecting case.
+func TestValidateVerticalScalingUsesHighestSCReplicationFactor(t *testing.T) {
+	namespaces := []interface{}{
+		nsConfig("sc-low", 3, true),
+		nsConfig("sc-high", 5, true),
+	}
+
+	t.Run("rejects when only the lower RF is met", func(t *testing.T) {
+		// Size 6 over 3 racks, full batch: 2 leave, 4 survive. Clears RF 3, not RF 5.
+		oldObj := verticalScaleCluster(
+			6, []string{"v1", "v1", "v1"}, ptr.To(intstr.FromString("100%")), namespaces,
+		)
+		newObj := verticalScaleCluster(
+			6, []string{"v2", "v1", "v1"}, ptr.To(intstr.FromString("100%")), namespaces,
+		)
+
+		err := validateVerticalScaling(oldObj, newObj)
+		if err == nil {
+			t.Fatal("expected the highest SC RF to reject, got nil")
+		}
+
+		for _, fragment := range []string{`"sc-high"`, "replication-factor 5", "leaving 4"} {
+			if !strings.Contains(err.Error(), fragment) {
+				t.Errorf("expected the rejection to contain %q, got: %v", fragment, err)
+			}
+		}
+	})
+
+	t.Run("allows when the highest RF is met", func(t *testing.T) {
+		// Size 8 over 3 racks, full batch: first rack holds 3, so 3 leave and 5
+		// survive, which meets RF 5 and is a majority of 8.
+		oldObj := verticalScaleCluster(
+			8, []string{"v1", "v1", "v1"}, ptr.To(intstr.FromString("100%")), namespaces,
+		)
+		newObj := verticalScaleCluster(
+			8, []string{"v2", "v1", "v1"}, ptr.To(intstr.FromString("100%")), namespaces,
+		)
+
+		if err := validateVerticalScaling(oldObj, newObj); err != nil {
+			t.Fatalf("expected 5 survivors to meet RF 5, got error: %v", err)
+		}
+	})
+}
+
 func TestDistributeItemsPutsMaximumOnFirstRack(t *testing.T) {
-	// First spec rack always has the most pods (worst batch).
+	// First spec rack always has the most pods (worst batch), and holds exactly
+	// ceil(size/racks) — the closed form podsLeavingFirstRack relies on.
 	for size := int32(1); size <= 12; size++ {
 		for racks := int32(1); racks <= 3; racks++ {
 			topology := asdbv1.DistributeItems(size, racks)
@@ -450,6 +534,13 @@ func TestDistributeItemsPutsMaximumOnFirstRack(t *testing.T) {
 						size, racks, idx, topology[idx], topology[0],
 					)
 				}
+			}
+
+			if want := (size + racks - 1) / racks; topology[0] != want {
+				t.Fatalf(
+					"size %d over %d racks: first rack holds %d pods, want ceil = %d",
+					size, racks, topology[0], want,
+				)
 			}
 		}
 	}
@@ -491,5 +582,42 @@ func TestPodsLeavingFirstRack(t *testing.T) {
 				t.Errorf("got %d pods leaving, want %d (topology %v)", got, test.want, topology)
 			}
 		})
+	}
+}
+
+// TestPodsLeavingFirstRackMatchesDistributeItems proves the closed form is equivalent
+// to indexing the topology DistributeItems builds, across the whole supported range.
+func TestPodsLeavingFirstRackMatchesDistributeItems(t *testing.T) {
+	batches := []*intstr.IntOrString{
+		nil,
+		ptr.To(intstr.FromInt32(1)),
+		ptr.To(intstr.FromInt32(10)),
+		ptr.To(intstr.FromString("50%")),
+		ptr.To(intstr.FromString("100%")),
+	}
+
+	for _, batch := range batches {
+		for size := int32(1); size <= 64; size++ {
+			for rackCount := 1; rackCount <= 8; rackCount++ {
+				revisions := make([]string, rackCount)
+				for idx := range revisions {
+					revisions[idx] = "v1"
+				}
+
+				cluster := verticalScaleCluster(
+					size, revisions, batch, []interface{}{nsConfig("test", 2, true)},
+				)
+
+				topology := asdbv1.DistributeItems(size, utils.Len32(cluster.Spec.RackConfig.Racks))
+				want := clampedBatch(batch, topology[0])
+
+				if got := podsLeavingFirstRack(cluster); got != want {
+					t.Fatalf(
+						"batch %v, size %d over %d racks: got %d, want %d (topology %v)",
+						batch, size, rackCount, got, want, topology,
+					)
+				}
+			}
+		}
 	}
 }

--- a/test/cluster/rack_revision_test.go
+++ b/test/cluster/rack_revision_test.go
@@ -413,7 +413,9 @@ var _ = Describe(
 
 				BeforeEach(
 					func() {
-						aeroCluster := createDummyClusterWithRackRevision(clusterNamespacedName, versionV1, 2)
+						// Size 3 over 2 racks keeps 2 nodes up during the first revision
+						// bump, clearing the vertical scaling floor for SC RF 2.
+						aeroCluster := createDummyClusterWithRackRevision(clusterNamespacedName, versionV1, 3)
 						Expect(DeployCluster(k8sClient, ctx, aeroCluster)).ToNot(HaveOccurred())
 					},
 				)

--- a/test/envtests/cluster/cluster_webhook_utils.go
+++ b/test/envtests/cluster/cluster_webhook_utils.go
@@ -31,6 +31,33 @@ func uniqueNamespacedName(suffix string) types.NamespacedName {
 	return test.GetNamespacedName(name, testutil.DefaultNamespace)
 }
 
+// setNamespaceReplicationFactor sets replication-factor on cluster and rack configs.
+func setNamespaceReplicationFactor(cluster *asdbv1.AerospikeCluster, rf int) {
+	setRF := func(config map[string]interface{}) {
+		nsList, ok := config[asdbv1.ConfKeyNamespace].([]interface{})
+		if !ok {
+			return
+		}
+
+		for idx := range nsList {
+			ns, ok := nsList[idx].(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			ns[asdbv1.ConfKeyReplicationFactor] = rf
+		}
+	}
+
+	if cluster.Spec.AerospikeConfig != nil {
+		setRF(cluster.Spec.AerospikeConfig.Value)
+	}
+
+	for idx := range cluster.Spec.RackConfig.Racks {
+		setRF(cluster.Spec.RackConfig.Racks[idx].AerospikeConfig.Value)
+	}
+}
+
 // apNamespaceMemoryDataSizeOnly returns an AP namespace with pure in-memory storage (no devices/files).
 func apNamespaceMemoryDataSizeOnly(name string, rf int) map[string]interface{} {
 	return map[string]interface{}{

--- a/test/envtests/cluster/rack_revision_webhook_test.go
+++ b/test/envtests/cluster/rack_revision_webhook_test.go
@@ -25,6 +25,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	asdbv1 "github.com/aerospike/aerospike-kubernetes-operator/v4/api/v1"
 	"github.com/aerospike/aerospike-kubernetes-operator/v4/test"
@@ -364,7 +366,8 @@ var _ = Describe("Rack revision webhook validation", func() {
 				// 2) Status records baseline v1 storage; spec rolls back to v1 but keeps expanded
 				//    storage — must be rejected (it needs status row so validateRackUpdate can compare).
 				It("rejects rollback of rack revision after storage expansion (revision bump bypass)", func() {
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					// Dummy cluster is SC RF 2; size 3 so the bump clears the floor.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					rackSt := aeroCluster.Spec.Storage.DeepCopy()
 					aeroCluster.Spec.Storage = asdbv1.AerospikeStorageSpec{}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
@@ -431,7 +434,8 @@ var _ = Describe("Rack revision webhook validation", func() {
 					clusterName20 := strings.Repeat("a", 20)
 					cName = test.GetNamespacedName(clusterName20, clusterNamespacedName.Namespace)
 
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 2)
+					// Size 3 so the bump clears the vertical-scaling floor.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 3)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{"test"},
 						Racks:      []asdbv1.Rack{{ID: 1, Revision: "v1"}},
@@ -489,7 +493,8 @@ var _ = Describe("Rack revision webhook validation", func() {
 					clusterName20 := strings.Repeat("b", 20)
 					cName = test.GetNamespacedName(clusterName20, clusterNamespacedName.Namespace)
 
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 2)
+					// Size 3 so the bump clears the vertical-scaling floor.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 3)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{"test"},
 						Racks: []asdbv1.Rack{
@@ -515,12 +520,203 @@ var _ = Describe("Rack revision webhook validation", func() {
 							"reduce by 13",
 						).Validate(err)
 				})
+
+				// Vertical scaling: spec-only; batch is sized against the first rack.
+				It("rejects a revision bump on a single-node SC cluster", func() {
+					cName = uniqueNamespacedName("vscale-sc-single")
+					// SC size 1 requires RF 1; the size-1 rule fires first.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 1)
+					setNamespaceReplicationFactor(aeroCluster, 1)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks:      []asdbv1.Rack{{ID: 1, Revision: "v1"}},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							testutil.WebhookErrorPrefix,
+							"vertical scaling (rack revision change) is not allowed",
+							"spec.size is 1",
+						).Validate(err)
+				})
+
+				It("rejects a revision bump on a single-node AP cluster", func() {
+					cName = uniqueNamespacedName("vscale-ap-single")
+					aeroCluster := testCluster.CreateDummyAerospikeClusterWithRF(cName, 1, 2)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks:      []asdbv1.Rack{{ID: 1, Revision: "v1"}},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							testutil.WebhookErrorPrefix,
+							"vertical scaling (rack revision change) is not allowed",
+							"spec.size is 1",
+						).Validate(err)
+				})
+
+				It("rejects a revision bump when an SC namespace is at replication-factor 1", func() {
+					cName = uniqueNamespacedName("vscale-sc-rf1")
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 3)
+					setNamespaceReplicationFactor(aeroCluster, 1)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks:      []asdbv1.Rack{{ID: 1, Revision: "v1"}},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							testutil.WebhookErrorPrefix,
+							"vertical scaling (rack revision change) is not allowed",
+							`namespace "test" has replication-factor 1`,
+						).Validate(err)
+				})
+
+				It("rejects a revision bump when an AP namespace is at replication-factor 1", func() {
+					cName = uniqueNamespacedName("vscale-ap-rf1")
+					aeroCluster := testCluster.CreateDummyAerospikeClusterWithRF(cName, 3, 1)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces: []string{"test"},
+						Racks:      []asdbv1.Rack{{ID: 1, Revision: "v1"}},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							testutil.WebhookErrorPrefix,
+							"vertical scaling (rack revision change) is not allowed",
+							`namespace "test" has replication-factor 1`,
+						).Validate(err)
+				})
+
+				It("rejects a three-rack revision bump at full batch when survivors fall below RF", func() {
+					cName = uniqueNamespacedName("vscale-sc-floor")
+					// [2,2,2]; 100% batch leaves 4, below RF 5.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 6)
+					setNamespaceReplicationFactor(aeroCluster, 5)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces:             []string{"test"},
+						RollingUpdateBatchSize: ptr.To(intstr.FromString("100%")),
+						Racks: []asdbv1.Rack{
+							{ID: 1, Revision: "v1"},
+							{ID: 2, Revision: "v1"},
+							{ID: 3, Revision: "v1"},
+						},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							testutil.WebhookErrorPrefix,
+							"vertical scaling (rack revision change) is not allowed",
+							"2 of 6 nodes would go down",
+							"leaving 4",
+							`strong-consistency namespace "test"`,
+							"replication-factor 5",
+						).Validate(err)
+				})
+
+				It("rejects a two-rack revision bump at full batch when survivors are half the roster", func() {
+					cName = uniqueNamespacedName("vscale-sc-maj-2r")
+					// [2,2]; 100% batch leaves 2 of 4, which is not a majority.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 4)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces:             []string{"test"},
+						RollingUpdateBatchSize: ptr.To(intstr.FromString("100%")),
+						Racks: []asdbv1.Rack{
+							{ID: 1, Revision: "v1"},
+							{ID: 2, Revision: "v1"},
+						},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							testutil.WebhookErrorPrefix,
+							"vertical scaling (rack revision change) is not allowed",
+							"2 of 4 nodes would go down",
+							"leaving 2",
+							"majority",
+						).Validate(err)
+				})
+
+				It("rejects a three-rack revision bump at full batch when survivors are half the roster", func() {
+					cName = uniqueNamespacedName("vscale-sc-maj-3r")
+					// [2,1,1]; 100% batch leaves 2 of 4, which is not a majority.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 4)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces:             []string{"test"},
+						RollingUpdateBatchSize: ptr.To(intstr.FromString("100%")),
+						Racks: []asdbv1.Rack{
+							{ID: 1, Revision: "v1"},
+							{ID: 2, Revision: "v1"},
+							{ID: 3, Revision: "v1"},
+						},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					err = envtests.K8sClient.Update(ctx, current)
+					Expect(err).To(HaveOccurred())
+					envtests.NewStatusErrorMatcher().
+						WithMessageSubstrings(
+							testutil.WebhookErrorPrefix,
+							"vertical scaling (rack revision change) is not allowed",
+							"2 of 4 nodes would go down",
+							"leaving 2",
+							"majority",
+						).Validate(err)
+				})
 			})
 
 			Context("positive", func() {
 				It("allows update that changes rack InputStorage when rack Revision changes"+
 					"and status does not imply a conflict", func() {
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 2)
+					// Dummy cluster is SC RF 2; size 3 so the bump clears the floor.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(clusterNamespacedName, 3)
 					s1 := aeroCluster.Spec.Storage.DeepCopy()
 					aeroCluster.Spec.Storage = asdbv1.AerospikeStorageSpec{}
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
@@ -563,7 +759,8 @@ var _ = Describe("Rack revision webhook validation", func() {
 				It("allows UPDATE when revision grows but stays within the Pod label value model", func() {
 					// "abc" + short STS; label << 63.
 					cName = test.GetNamespacedName(threeCharClusterName, clusterNamespacedName.Namespace)
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 2)
+					// Size 3 so the bump clears the vertical-scaling floor.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 3)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{"test"},
 						Racks:      []asdbv1.Rack{{ID: 1, Revision: "v1"}},
@@ -583,14 +780,15 @@ var _ = Describe("Rack revision webhook validation", func() {
 				It("allows UPDATE when one rack has zero pods under DistributeItems"+
 					"(validateActualPodNames skips rackSize 0)", func() {
 					cName = uniqueNamespacedName("actpod-zero-rack")
-					// DistributeItems(2, 3) → [1,1,0]: only rack 1 and 2 gets a pod; rack 3 must be skipped.
-					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 2)
+					// [1,1,1,0]: skip rack 4. Size 3 also clears the SC RF 2 floor.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 3)
 					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
 						Namespaces: []string{"test"},
 						Racks: []asdbv1.Rack{
 							{ID: 1, Revision: "v1"},
 							{ID: 2, Revision: "v1"},
 							{ID: 3, Revision: "v1"},
+							{ID: 4, Revision: "v1"},
 						},
 					}
 
@@ -599,9 +797,101 @@ var _ = Describe("Rack revision webhook validation", func() {
 					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
 					Expect(err).ToNot(HaveOccurred())
 
-					// Only touch the rack that actually has pods; rack 3 remains unused by the distribution.
+					// Only touch racks that actually have pods; rack 4 remains unused by the distribution.
 					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
 					current.Spec.RackConfig.Racks[1].Revision = newRackRevision
+					Expect(envtests.K8sClient.Update(ctx, current)).To(Succeed())
+				})
+
+				It("allows a three-rack revision bump at full batch when survivors meet RF", func() {
+					cName = uniqueNamespacedName("vscale-sc-ok")
+					// Same topology as the reject case; RF 3 so 4 survivors suffice.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 6)
+					setNamespaceReplicationFactor(aeroCluster, 3)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces:             []string{"test"},
+						RollingUpdateBatchSize: ptr.To(intstr.FromString("100%")),
+						Racks: []asdbv1.Rack{
+							{ID: 1, Revision: "v1"},
+							{ID: 2, Revision: "v1"},
+							{ID: 3, Revision: "v1"},
+						},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					Expect(envtests.K8sClient.Update(ctx, current)).To(Succeed())
+				})
+
+				It("allows an AP revision bump even when survivors fall below RF", func() {
+					cName = uniqueNamespacedName("vscale-ap-floor")
+					// AP has no RF floor; 4 of 6 survivors at RF 5 is allowed.
+					aeroCluster := testCluster.CreateDummyAerospikeClusterWithRF(cName, 6, 5)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces:             []string{"test"},
+						RollingUpdateBatchSize: ptr.To(intstr.FromString("100%")),
+						Racks: []asdbv1.Rack{
+							{ID: 1, Revision: "v1"},
+							{ID: 2, Revision: "v1"},
+							{ID: 3, Revision: "v1"},
+						},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks[0].Revision = newRackRevision
+					Expect(envtests.K8sClient.Update(ctx, current)).To(Succeed())
+				})
+
+				It("allows a resize that changes no rack revision", func() {
+					cName = uniqueNamespacedName("vscale-resize-only")
+					// Resize-only is not vertical scaling.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 6)
+					setNamespaceReplicationFactor(aeroCluster, 5)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces:             []string{"test"},
+						RollingUpdateBatchSize: ptr.To(intstr.FromString("100%")),
+						Racks: []asdbv1.Rack{
+							{ID: 1, Revision: "v1"},
+							{ID: 2, Revision: "v1"},
+							{ID: 3, Revision: "v1"},
+						},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.Size = 9
+					Expect(envtests.K8sClient.Update(ctx, current)).To(Succeed())
+				})
+
+				It("allows adding a new rack that carries a revision", func() {
+					cName = uniqueNamespacedName("vscale-new-rack")
+					// New rack with a revision is not a migration.
+					aeroCluster := testCluster.CreateDummyAerospikeCluster(cName, 6)
+					setNamespaceReplicationFactor(aeroCluster, 5)
+					aeroCluster.Spec.RackConfig = asdbv1.RackConfig{
+						Namespaces:             []string{"test"},
+						RollingUpdateBatchSize: ptr.To(intstr.FromString("100%")),
+						Racks: []asdbv1.Rack{
+							{ID: 1, Revision: "v1"},
+							{ID: 2, Revision: "v1"},
+						},
+					}
+					Expect(envtests.K8sClient.Create(ctx, aeroCluster)).To(Succeed())
+
+					current, err := testCluster.GetCluster(envtests.K8sClient, ctx, cName)
+					Expect(err).ToNot(HaveOccurred())
+
+					current.Spec.RackConfig.Racks = append(
+						current.Spec.RackConfig.Racks, asdbv1.Rack{ID: 3, Revision: newRackRevision},
+					)
 					Expect(envtests.K8sClient.Update(ctx, current)).To(Succeed())
 				})
 			})


### PR DESCRIPTION

[vertical-scaling-test-results-approach-2.md](https://github.com/user-attachments/files/31836875/vertical-scaling-test-results-approach-2.md)
## Summary
- Block rack revision changes (vertical scaling) that would take the cluster down: size 1, replication-factor 1 (AP and SC), and SC clusters that would fall below RF or lose roster majority while a rack is replaced.
- Size the worst batch against the first rack (`DistributeItems` always gives it the most pods). 
- Known gap, not covered: scale-up/scale-down + revision bump in one apply can still be admitted and fail at runtime, roster related fields like forceBlockFromRoster, rosterNodeBlockList are also not covered

## Test plan
- [ ] Unit tests in `aerospikecluster_vertical_scaling_test.go`
- [ ] `make env-test-cluster` (rack-revision webhook specs, including majority cases)